### PR TITLE
[Fix] Always set version validity

### DIFF
--- a/packages/perennial/contracts/types/Version.sol
+++ b/packages/perennial/contracts/types/Version.sol
@@ -95,6 +95,9 @@ library VersionLib {
         MarketParameter memory marketParameter,
         RiskParameter memory riskParameter
     ) internal pure returns (VersionAccumulationResult memory values, UFixed6 totalFee) {
+        // record validity
+        self.valid = toOracleVersion.valid;
+
         if (marketParameter.closed) return (values, UFixed6Lib.ZERO);
 
         // accumulate position fee
@@ -130,9 +133,6 @@ library VersionLib {
         // accumulate reward
         (values.rewardMaker, values.rewardLong, values.rewardShort) =
             _accumulateReward(self, fromPosition, fromOracleVersion, toOracleVersion, marketParameter);
-
-        // record validity
-        self.valid = toOracleVersion.valid;
 
         return (values, values.positionFeeFee.add(values.fundingFee).add(values.interestFee));
     }

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -405,6 +405,24 @@ describe('Version', () => {
           expect(value.valid).to.be.true
         })
       })
+
+      context('market closed, currently invalid, toOracleVersion.valid = true', () => {
+        it('marks the version as valid', async () => {
+          await version.store({ ...VALID_VERSION, valid: false })
+          await version.accumulate(
+            GLOBAL,
+            FROM_POSITION,
+            TO_POSITION,
+            ORACLE_VERSION_1,
+            ORACLE_VERSION_2,
+            { ...VALID_MARKET_PARAMETER, closed: true },
+            VALID_RISK_PARAMETER,
+          )
+
+          const value = await version.read()
+          expect(value.valid).to.be.true
+        })
+      })
     })
 
     describe('position fee accumulation', () => {


### PR DESCRIPTION
If the market was closed, the current `valid` flag would never be changed