### PR TITLE
[Fix] Use current in request

### DIFF
--- a/packages/perennial-oracle/contracts/pyth/PythOracle.sol
+++ b/packages/perennial-oracle/contracts/pyth/PythOracle.sol
@@ -75,9 +75,9 @@ contract PythOracle is IPythOracle, Instance, Kept {
     /// @notice Records a request for a new oracle version
     /// @dev Original sender to optionally use for callbacks
     function request(address) external onlyAuthorized {
-        if (versionList.length == 0 || versionList[versionList.length - 1] != block.timestamp) {
-            versionList.push(block.timestamp);
-        }
+        uint256 currentTimestamp = current();
+        if (versionList.length == 0 || versionList[versionList.length - 1] != currentTimestamp)
+            versionList.push(currentTimestamp);
     }
 
     /// @notice Returns the latest synced oracle version and the current oracle version

--- a/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
@@ -369,6 +369,19 @@ describe('PythOracle', () => {
       await expect(pythOracle.callStatic.versionList(1)).to.be.reverted
     })
 
+    it('can request a version w/ granularity', async () => {
+      await pythOracleFactory.updateGranularity(10)
+
+      // No requested versions
+      await expect(pythOracle.callStatic.versionList(0)).to.be.reverted
+      await pythOracle.connect(oracleSigner).request(user.address)
+      const currentTimestamp = await pythOracleFactory.current()
+
+      // Now there is exactly one requested version
+      expect(await pythOracle.callStatic.versionList(0)).to.equal(currentTimestamp)
+      await expect(pythOracle.callStatic.versionList(1)).to.be.reverted
+    })
+
     it('does not allow unauthorized users to request', async () => {
       await expect(pythOracle.connect(user).request(user.address)).to.be.reverted
     })


### PR DESCRIPTION
Fixes a bug in the Pyth oracle `request()` function to use the correct `current()` value when recording the requested version.