### PR TITLE
Add additional price commit flags

### DIFF
--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -368,7 +368,6 @@ describe('Orders', () => {
     it('exceeds max trigger fee on execution', async () => {
       const { user, chainlink } = instanceVars
 
-      console.log(userPosition)
       const trigger = openTriggerOrder({
         size: userPosition,
         price: payoff(marketPrice.add(10)),


### PR DESCRIPTION
Adds additional parameters to MultiInvoker's `COMMIT_PRICE` action:
- `revertOnFailure` to optionally silently fail commits that revert within a batched call
- `value` to specify the amount of ether to pass through with the sub-call