### PR TITLE
Add additional getters for PythOracle

### DIFF
--- a/packages/perennial-oracle/contracts/interfaces/IPythOracle.sol
+++ b/packages/perennial-oracle/contracts/interfaces/IPythOracle.sol
@@ -21,7 +21,13 @@ interface IPythOracle is IOracleProvider, IInstance, IKept {
     function commitRequested(uint256 versionIndex, bytes calldata updateData) external payable;
     function commit(uint256 versionIndex, uint256 oracleVersion, bytes calldata updateData) external payable;
 
+    function MIN_VALID_TIME_AFTER_VERSION() external view returns (uint256);
+    function MAX_VALID_TIME_AFTER_VERSION() external view returns (uint256);
+    function GRACE_PERIOD() external view returns (uint256);
+    function KEEPER_REWARD_PREMIUM() external view returns (UFixed18);
+    function KEEPER_BUFFER() external view returns (uint256);
     function versionList(uint256 versionIndex) external view returns (uint256);
+    function versionListLength() external view returns (uint256);
     function nextVersionIndexToCommit() external view returns (uint256);
     function nextVersionToCommit() external view returns (uint256);
 }

--- a/packages/perennial-oracle/contracts/pyth/PythOracle.sol
+++ b/packages/perennial-oracle/contracts/pyth/PythOracle.sol
@@ -14,19 +14,19 @@ import "../interfaces/IPythFactory.sol";
 ///      This implementation only supports non-negative prices.
 contract PythOracle is IPythOracle, Instance, Kept {
     /// @dev A Pyth update must come at least this long after a version to be valid
-    uint256 constant private MIN_VALID_TIME_AFTER_VERSION = 12 seconds;
+    uint256 constant public MIN_VALID_TIME_AFTER_VERSION = 12 seconds;
 
     /// @dev A Pyth update must come at most this long after a version to be valid
-    uint256 constant private MAX_VALID_TIME_AFTER_VERSION = 15 seconds;
+    uint256 constant public MAX_VALID_TIME_AFTER_VERSION = 15 seconds;
 
     /// @dev After this amount of time has passed for a version without being committed, the version can be invalidated.
-    uint256 constant private GRACE_PERIOD = 1 minutes;
+    uint256 constant public GRACE_PERIOD = 1 minutes;
 
     /// @dev The multiplier for the keeper reward on top of cost
-    UFixed18 constant private KEEPER_REWARD_PREMIUM = UFixed18.wrap(1.5e18);
+    UFixed18 constant public KEEPER_REWARD_PREMIUM = UFixed18.wrap(1.5e18);
 
     /// @dev The fixed gas buffer that is added to the keeper reward
-    uint256 constant private KEEPER_BUFFER = 80_000;
+    uint256 constant public KEEPER_BUFFER = 80_000;
 
     /// @dev Pyth contract
     AbstractPyth public immutable pyth;
@@ -70,6 +70,10 @@ contract PythOracle is IPythOracle, Instance, Kept {
         if (!pyth.priceFeedExists(id_)) revert PythOracleInvalidPriceIdError(id_);
 
         id = id_;
+    }
+
+    function versionListLength() external view returns (uint256) {
+        return versionList.length;
     }
 
     /// @notice Records a request for a new oracle version

--- a/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
@@ -104,6 +104,28 @@ describe('PythOracle', () => {
     })
   })
 
+  describe('constants', async () => {
+    it('#MIN_VALID_TIME_AFTER_VERSION', async () => {
+      expect(await pythOracle.MIN_VALID_TIME_AFTER_VERSION()).to.equal(12)
+    })
+
+    it('#MAX_VALID_TIME_AFTER_VERSION', async () => {
+      expect(await pythOracle.MAX_VALID_TIME_AFTER_VERSION()).to.equal(15)
+    })
+
+    it('#GRACE_PERIOD', async () => {
+      expect(await pythOracle.GRACE_PERIOD()).to.equal(60)
+    })
+
+    it('#KEEPER_REWARD_PREMIUM', async () => {
+      expect(await pythOracle.KEEPER_REWARD_PREMIUM()).to.equal(utils.parseEther('1.5'))
+    })
+
+    it('#KEEPER_BUFFER', async () => {
+      expect(await pythOracle.KEEPER_BUFFER()).to.equal(80000)
+    })
+  })
+
   describe('#commitRequested', async () => {
     it('commits successfully and incentivizes the keeper', async () => {
       const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
@@ -420,24 +442,24 @@ describe('PythOracle', () => {
   describe('#request', async () => {
     it('can request a version', async () => {
       // No requested versions
-      await expect(pythOracle.callStatic.versionList(0)).to.be.reverted
+      expect(await pythOracle.versionListLength()).to.equal(0)
       await pythOracle.connect(oracleSigner).request(user.address)
       // Now there is exactly one requested version
-      expect(await pythOracle.callStatic.versionList(0)).to.equal(STARTING_TIME)
-      await expect(pythOracle.callStatic.versionList(1)).to.be.reverted
+      expect(await pythOracle.versionList(0)).to.equal(STARTING_TIME)
+      expect(await pythOracle.versionListLength()).to.equal(1)
     })
 
     it('can request a version w/ granularity', async () => {
       await pythOracleFactory.updateGranularity(10)
 
       // No requested versions
-      await expect(pythOracle.callStatic.versionList(0)).to.be.reverted
+      expect(await pythOracle.versionListLength()).to.equal(0)
       await pythOracle.connect(oracleSigner).request(user.address)
       const currentTimestamp = await pythOracleFactory.current()
 
       // Now there is exactly one requested version
-      expect(await pythOracle.callStatic.versionList(0)).to.equal(currentTimestamp)
-      await expect(pythOracle.callStatic.versionList(1)).to.be.reverted
+      expect(await pythOracle.versionList(0)).to.equal(currentTimestamp)
+      expect(await pythOracle.versionListLength()).to.equal(1)
     })
 
     it('does not allow unauthorized users to request', async () => {


### PR DESCRIPTION
- Adds `versionListLength()`
- Makes all constants public