### PR TITLE
[Fix] Add uniqueness check on Pyth oracle id

### DIFF
--- a/packages/perennial-oracle/contracts/interfaces/IPythFactory.sol
+++ b/packages/perennial-oracle/contracts/interfaces/IPythFactory.sol
@@ -18,6 +18,7 @@ interface IPythFactory is IOracleProviderFactory, IFactory {
 
     error PythFactoryNotInstanceError();
     error PythFactoryInvalidGranularityError();
+    error PythFactoryAlreadyCreatedError();
 
     function initialize(IOracleFactory oracleFactory) external;
     function create(bytes32 id) external returns (IPythOracle oracle);

--- a/packages/perennial-oracle/contracts/pyth/PythFactory.sol
+++ b/packages/perennial-oracle/contracts/pyth/PythFactory.sol
@@ -58,6 +58,8 @@ contract PythFactory is IPythFactory, Factory {
     /// @param id The id of the oracle to create
     /// @return newOracle The newly created oracle instance
     function create(bytes32 id) external onlyOwner returns (IPythOracle newOracle) {
+        if (oracles[id] != IOracleProvider(address(0))) revert PythFactoryAlreadyCreatedError();
+
         newOracle = IPythOracle(address(
             _create(abi.encodeCall(IPythOracle.initialize, (id, ethTokenChainlinkFeed, keeperToken)))));
         oracles[id] = newOracle;

--- a/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
@@ -94,6 +94,15 @@ describe('PythOracle', () => {
     // block.timestamp of the next call will be STARTING_TIME (1686198973)
   })
 
+  describe('Factory', async () => {
+    it('cant recreate price id', async () => {
+      await expect(pythOracleFactory.create(PYTH_ETH_USD_PRICE_FEED)).to.be.revertedWithCustomError(
+        pythOracleFactory,
+        'PythFactoryAlreadyCreatedError',
+      )
+    })
+  })
+
   describe('#initialize', async () => {
     it('only initializes with a valid priceId', async () => {
       const invalidPriceId = '0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0acd'


### PR DESCRIPTION
Adds a uniqueness check to the Pyth Factory to ensure two oracle on the same price feed are not deployed which could lead to bad state since only one can be registered in `oracles`