### PR TITLE
MultiInvokerKeeper

### DIFF
--- a/packages/perennial-extensions/contracts/MultiInvokerKeeper.sol
+++ b/packages/perennial-extensions/contracts/MultiInvokerKeeper.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "@equilibria/root/attribute/Ownable.sol";
+import "./MultiInvoker.sol";
+
+/// @title MultiInvokerKeeper
+/// @notice A contract that forwards invocations to a MultiInvoker, keeping any accrued DSU in this contract
+contract MultiInvokerKeeper is Ownable {
+    /// @dev The MultiInvoker to forward invocations to
+    MultiInvoker public immutable multiInvoker;
+
+    constructor(address multiinvoker_) {
+        multiInvoker = MultiInvoker(multiinvoker_);
+    }
+
+    function initialize() external initializer(1) {
+        __UOwnable__initialize();
+    }
+
+    /// @notice Forwards invocations to `multiinvoker`, keeping any accrued DSU in this contract
+    /// @param invocations List of actions to execute in order
+    function invoke(IMultiInvoker.Invocation[] calldata invocations) external payable {
+        multiInvoker.invoke{value: msg.value}(invocations);
+    }
+
+    /// @notice Sweeps any accrued DSU to the specified recipient
+    function sweepDSU(address recipient) external onlyOwner {
+        multiInvoker.DSU().push(recipient, multiInvoker.DSU().balanceOf());
+    }
+}

--- a/packages/perennial-extensions/test/unit/MultiInvokerKeeper/MultiInvokerKeeper.test.ts
+++ b/packages/perennial-extensions/test/unit/MultiInvokerKeeper/MultiInvokerKeeper.test.ts
@@ -1,0 +1,70 @@
+import { FakeContract, smock } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect, use } from 'chai'
+import HRE from 'hardhat'
+
+import { MultiInvoker, IERC20, MultiInvokerKeeper, MultiInvokerKeeper__factory } from '../../../types/generated'
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+
+const ethers = { HRE }
+use(smock.matchers)
+
+describe.only('MultiInvokerKeeper', () => {
+  let owner: SignerWithAddress
+  let user: SignerWithAddress
+  let dsu: FakeContract<IERC20>
+  let multiInvoker: FakeContract<MultiInvoker>
+  let multiInvokerKeeper: MultiInvokerKeeper
+
+  const fixture = async () => {
+    ;[owner, user] = await ethers.HRE.ethers.getSigners()
+  }
+
+  beforeEach(async () => {
+    await loadFixture(fixture)
+
+    dsu = await smock.fake<IERC20>('IERC20')
+    multiInvoker = await smock.fake<MultiInvoker>('MultiInvoker')
+    multiInvoker.DSU.returns(dsu.address)
+    multiInvokerKeeper = await new MultiInvokerKeeper__factory(owner).deploy(multiInvoker.address)
+    await multiInvokerKeeper.initialize()
+  })
+
+  describe('#invoke', () => {
+    it('calls invoke on the MultiInvoker', async () => {
+      const invocations = [
+        {
+          action: 0,
+          args: '0x',
+        },
+      ]
+      await multiInvokerKeeper.connect(user).invoke(invocations)
+      expect(multiInvoker.invoke).to.have.been.calledWith(invocations)
+    })
+  })
+
+  describe('#sweepDSU', () => {
+    const BALANCE = 1
+
+    const fixture = async () => {
+      dsu.balanceOf.returns(BALANCE)
+      dsu.transfer.returns(true)
+    }
+
+    beforeEach(async () => {
+      await loadFixture(fixture)
+    })
+
+    it('only allows the owner to call', async () => {
+      await expect(multiInvokerKeeper.connect(user).sweepDSU(user.address)).to.be.revertedWithCustomError(
+        multiInvokerKeeper,
+        'UOwnableNotOwnerError',
+      )
+    })
+
+    it('sweeps all the DSU from the MultiInvoker', async () => {
+      await multiInvokerKeeper.sweepDSU(user.address)
+      expect(dsu.transfer).to.have.been.calledWith(user.address, BALANCE)
+    })
+  })
+})


### PR DESCRIPTION
We don't want the Gelato keeper to call MultiInvoker because they'll get doubly-paid (once by our mechanism, then again by Gelato's fee system). So they can call this contract instead, which won't forward the former to them.

I'm not really satisfied by the name of this contract so I'm happy to take opinions on better names.

Also don't have a clear idea on how flexible the admin functionality should be. For now I've added the bare minimum (sweep DSU) but I'm also happy to take suggestions here.