### PR TITLE
[Fix] Update getters for Vault and PythOracle

### DIFF
--- a/packages/perennial-oracle/contracts/interfaces/IPythOracle.sol
+++ b/packages/perennial-oracle/contracts/interfaces/IPythOracle.sol
@@ -30,4 +30,6 @@ interface IPythOracle is IOracleProvider, IInstance, IKept {
     function versionListLength() external view returns (uint256);
     function nextVersionIndexToCommit() external view returns (uint256);
     function nextVersionToCommit() external view returns (uint256);
+    function publishTimes(uint256 version) external view returns (uint256);
+    function lastCommittedPublishTime() external view returns (uint256);
 }

--- a/packages/perennial-oracle/contracts/pyth/PythOracle.sol
+++ b/packages/perennial-oracle/contracts/pyth/PythOracle.sol
@@ -44,10 +44,10 @@ contract PythOracle is IPythOracle, Instance, Kept {
     mapping(uint256 => Fixed6) private _prices;
 
     /// @dev Mapping from oracle version to when its VAA was published to Pyth
-    mapping(uint256 => uint256) private _publishTimes;
+    mapping(uint256 => uint256) public publishTimes;
 
     /// @dev The time when the last committed update was published to Pyth
-    uint256 private _lastCommittedPublishTime;
+    uint256 public lastCommittedPublishTime;
 
     /// @dev The oracle version that was most recently committed
     /// @dev We assume that we cannot commit an oracle version of 0, so `_latestVersion` being 0 means that no version has been committed yet
@@ -141,8 +141,8 @@ contract PythOracle is IPythOracle, Instance, Kept {
         uint256 versionToCommit = versionList[versionIndex];
         PythStructs.Price memory pythPrice = _validateAndGetPrice(versionToCommit, updateData);
 
-        if (pythPrice.publishTime <= _lastCommittedPublishTime) revert PythOracleNonIncreasingPublishTimes();
-        _lastCommittedPublishTime = pythPrice.publishTime;
+        if (pythPrice.publishTime <= lastCommittedPublishTime) revert PythOracleNonIncreasingPublishTimes();
+        lastCommittedPublishTime = pythPrice.publishTime;
 
         // Ensure that the keeper is committing the earliest possible version
         if (versionIndex > nextVersionIndexToCommit) {
@@ -223,7 +223,7 @@ contract PythOracle is IPythOracle, Instance, Kept {
         _prices[oracleVersion] = (expo6Decimal < 0) ?
             Fixed6.wrap(price.price).div(Fixed6Lib.from(UFixed6Lib.from(10 ** uint256(-expo6Decimal)))) :
             Fixed6.wrap(price.price).mul(Fixed6Lib.from(UFixed6Lib.from(10 ** uint256(expo6Decimal))));
-        _publishTimes[oracleVersion] = price.publishTime;
+        publishTimes[oracleVersion] = price.publishTime;
     }
 
     /// @notice Pulls funds from the factory to reward the keeper

--- a/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracle.test.ts
@@ -727,4 +727,26 @@ describe('PythOracle', () => {
       })
     })
   })
+
+  describe('#publishTimes', async () => {
+    it('returns the publish time for a version', async () => {
+      await pythOracle.connect(oracleSigner).request(user.address)
+      await pythOracle.connect(user).commitRequested(0, VAA, {
+        value: 1,
+      })
+      const publishTime = await pythOracle.publishTimes('1686198981')
+      expect(publishTime).to.equal('1686198987')
+    })
+  })
+
+  describe('#lastCommittedPublishTime', async () => {
+    it('returns the last commit publish time', async () => {
+      await pythOracle.connect(oracleSigner).request(user.address)
+      await pythOracle.connect(user).commitRequested(0, VAA, {
+        value: 1,
+      })
+      const publishTime = await pythOracle.lastCommittedPublishTime()
+      expect(publishTime).to.equal('1686198987')
+    })
+  })
 })

--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -83,6 +83,20 @@ contract Vault is IVault, Instance {
         return _accounts[account].read();
     }
 
+    /// @notice Returns the checkpoint for a given id
+    /// @param id The id to query
+    /// @return The checkpoint for the given id
+    function checkpoints(uint256 id) external view returns (Checkpoint memory) {
+        return _checkpoints[id].read();
+    }
+
+    /// @notice Returns the mapping for a given id
+    /// @param id The id to query
+    /// @return The mapping for the given id
+    function mappings(uint256 id) external view returns (Mapping memory) {
+        return _mappings[id].read();
+    }
+
     /// @notice Returns the name of the vault
     /// @return The name of the vault
     function name() external view returns (string memory) {

--- a/packages/perennial-vault/contracts/interfaces/IVault.sol
+++ b/packages/perennial-vault/contracts/interfaces/IVault.sol
@@ -83,6 +83,8 @@ interface IVault is IInstance {
     function parameter() external view returns (VaultParameter memory);
     function registrations(uint256 marketId) external view returns (Registration memory);
     function accounts(address account) external view returns (Account memory);
+    function checkpoints(uint256 id) external view returns (Checkpoint memory);
+    function mappings(uint256 id) external view returns (Mapping memory);
     function register(IMarket market) external;
     function updateMarket(uint256 marketId, uint256 newWeight, UFixed6 newLeverage) external;
     function updateParameter(VaultParameter memory newParameter) external;

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -490,6 +490,13 @@ describe('Vault', () => {
       await updateOracle()
       await vault.settle(user.address)
 
+      const checkpoint1 = await vault.checkpoints(1)
+      expect(checkpoint1.deposit).to.equal(smallDeposit)
+      expect(checkpoint1.count).to.equal(1)
+      const mapping1 = await vault.mappings(1)
+      expect(mapping1._ids[0]).to.equal(1)
+      expect(mapping1._ids[1]).to.equal(1)
+
       // We're underneath the collateral minimum, so we shouldn't have opened any positions.
       expect(await position()).to.equal(0)
       expect(await btcPosition()).to.equal(0)
@@ -504,6 +511,14 @@ describe('Vault', () => {
       expect(await vault.convertToShares(parse6decimal('10'))).to.equal(parse6decimal('10'))
       await updateOracle()
       await vault.settle(user.address)
+      const checkpoint2 = await vault.checkpoints(2)
+      expect(checkpoint2.deposit).to.equal(largeDeposit)
+      expect(checkpoint2.assets).to.equal(smallDeposit)
+      expect(checkpoint2.shares).to.equal(smallDeposit)
+      expect(checkpoint2.count).to.equal(1)
+      const mapping2 = await vault.mappings(2)
+      expect(mapping2._ids[0]).to.equal(2)
+      expect(mapping2._ids[1]).to.equal(2)
 
       expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('10010'))
       expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(parse6decimal('10010'))


### PR DESCRIPTION
* Adds getters for `publishTimes` and `lastCommittedPublishTime` so that keepers can figure out where in the window to publish versions
* Adds getters for `checkpoints` and `mappings` in the Vault so make it easier for frontends to fetch data