### PR TITLE
[Fix] singled sided invariant

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -504,7 +504,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         if (context.currentPosition.global.maker.gt(context.riskParameter.makerLimit))
             revert MarketMakerOverLimitError();
 
-        if (!newOrder.singleSided(context.currentPosition.local))
+        if (!newOrder.singleSided(context.currentPosition.local) || !newOrder.singleSided(context.latestPosition.local))
             revert MarketNotSingleSidedError();
 
         if (protected) return; // The following invariants do not apply to protected position updates (liquidations)


### PR DESCRIPTION
Follow on from https://github.com/equilibria-xyz/perennial-v2/pull/82.

Fixes issue where position of side A could be closed to zero then reopened as side B all while pending. This restricts all pending positions of an account to be the same single side as originally intended.