### PR TITLE
De-duplicate context loading in Vault

### DIFF
--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -271,6 +271,9 @@ contract Vault is IVault, Instance {
         UFixed6 redeemShares,
         UFixed6 claimAssets
     ) private {
+        // load strategy
+        context.strategy = StrategyLib.load(context.registrations);
+
         // magic values
         if (claimAssets.eq(UFixed6Lib.MAX)) claimAssets = context.local.assets;
         if (redeemShares.eq(UFixed6Lib.MAX)) redeemShares = context.local.shares;
@@ -288,7 +291,6 @@ contract Vault is IVault, Instance {
             revert VaultInsufficientMinimumError();
         if (!redeemShares.isZero() && context.latestCheckpoint.toAssets(redeemShares, context.settlementFee).isZero())
             revert VaultInsufficientMinimumError();
-
         if (context.local.current != context.local.latest) revert VaultExistingOrderError();
 
         // asses socialization and settlement fee
@@ -388,16 +390,16 @@ contract Vault is IVault, Instance {
 
         if (!rebalance || collateral.lt(Fixed6Lib.ZERO)) return;
 
-        StrategyLib.MarketTarget[] memory targets = StrategyLib.allocate(
+        StrategyLib.MarketTarget[] memory targets = context.strategy.allocate(
             context.registrations,
             UFixed6Lib.from(collateral.max(Fixed6Lib.ZERO)),
             assets
         );
 
-        for (uint256 marketId; marketId < context.markets.length; marketId++)
+        for (uint256 marketId; marketId < context.registrations.length; marketId++)
             if (targets[marketId].collateral.lt(Fixed6Lib.ZERO))
                 _retarget(context.registrations[marketId], targets[marketId]);
-        for (uint256 marketId; marketId < context.markets.length; marketId++)
+        for (uint256 marketId; marketId < context.registrations.length; marketId++)
             if (targets[marketId].collateral.gte(Fixed6Lib.ZERO))
                 _retarget(context.registrations[marketId], targets[marketId]);
     }
@@ -440,39 +442,22 @@ contract Vault is IVault, Instance {
         context.currentIds.initialize(totalMarkets);
         context.latestIds.initialize(totalMarkets);
         context.registrations = new Registration[](totalMarkets);
-        context.markets = new MarketContext[](totalMarkets);
+        context.collaterals = new Fixed6[](totalMarkets);
 
         for (uint256 marketId; marketId < totalMarkets; marketId++) {
             // parameter
             Registration memory registration = _registrations[marketId].read();
             MarketParameter memory marketParameter = registration.market.parameter();
+
             context.registrations[marketId] = registration;
-            context.settlementFee = context.settlementFee.add(marketParameter.settlementFee);
-
-            // global
-            Global memory global = registration.market.global();
-            Position memory latestPosition = registration.market.position();
-            Position memory currentPosition = registration.market.pendingPosition(global.currentId);
-            currentPosition.adjust(latestPosition);
-
-            context.markets[marketId].latestPrice = global.latestPrice.abs();
-            context.markets[marketId].currentPosition = currentPosition.maker;
-            context.markets[marketId].currentNet = currentPosition.net();
             context.totalWeight += registration.weight;
+            context.settlementFee = context.settlementFee.add(marketParameter.settlementFee);
 
             // local
             Local memory local = registration.market.locals(address(this));
-            Position memory latestAccountPosition = registration.market.positions(address(this));
-            Position memory currentAccountPosition = registration.market.pendingPositions(address(this), local.currentId);
-            currentAccountPosition.adjust(latestAccountPosition);
-
-            context.markets[marketId].collateral = local.collateral;
-            context.markets[marketId].latestAccountPosition = latestAccountPosition.maker;
-            context.markets[marketId].currentAccountPosition = currentAccountPosition.maker;
-
-            // ids
             context.latestIds.update(marketId, local.latestId);
             context.currentIds.update(marketId, local.currentId);
+            context.collaterals[marketId] = local.collateral;
         }
 
         if (account != address(0)) context.local = _accounts[account].read();
@@ -501,80 +486,22 @@ contract Vault is IVault, Instance {
     /// @notice The maximum available redemption amount for `account`
     /// @param context Context to use
     /// @return redemptionAmount Maximum available redemption amount
-    function _maxRedeem(Context memory context) private view returns (UFixed6 redemptionAmount) {
+    function _maxRedeem(Context memory context) private pure returns (UFixed6) {
         if (context.latestCheckpoint.unhealthy()) return UFixed6Lib.ZERO;
+        UFixed6 maxRedeemAssets = context.strategy.maxRedeem(context.registrations, context.totalWeight);
+        UFixed6 maxRedeemShares = maxRedeemAssets.eq(UFixed6Lib.MAX) ?
+            UFixed6Lib.MAX :
+            context.latestCheckpoint.toShares(maxRedeemAssets, UFixed6Lib.ZERO);
 
-        redemptionAmount = UFixed6Lib.MAX;
-        for (uint256 marketId; marketId < context.markets.length; marketId++) {
-            MarketContext memory marketContext = context.markets[marketId];
-            Registration memory registration = context.registrations[marketId];
-            // If market has 0 weight, leverage, or position, skip
-            if (
-                registration.weight == 0 ||
-                registration.leverage.isZero() ||
-                (marketContext.latestAccountPosition.isZero() && marketContext.currentAccountPosition.isZero())
-            ) continue;
-
-            UFixed6 collateral = marketContext.currentPosition
-                .sub(marketContext.currentNet.min(marketContext.currentPosition))           // available maker
-                .min(_closablePosition(context, marketId).mul(StrategyLib.LEVERAGE_BUFFER)) // available closable
-                .muldiv(marketContext.latestPrice, registration.leverage)                   // available collateral
-                .muldiv(context.totalWeight, registration.weight);                          // collateral in market
-
-            redemptionAmount = redemptionAmount.min(context.latestCheckpoint.toShares(collateral, UFixed6Lib.ZERO));
-        }
-    }
-
-    /// @notice Returns the closable position amount for `marketId`
-    /// @param context Context to use
-    /// @param marketId Market to use
-    /// @return closable The closable amount
-    function _closablePosition(Context memory context, uint256 marketId) private view returns (UFixed6 closable) {
-        // latest position
-        Position memory latestPosition = context.registrations[marketId].market.positions(address(this));
-        UFixed6 previousMaker;
-        (previousMaker, closable) = _loadPosition(
-            latestPosition,
-            latestPosition,
-            previousMaker,
-            latestPosition.maker
-        );
-
-        // pending positions
-        for (uint256 id = context.latestIds.get(marketId) + 1; id <= context.currentIds.get(marketId); id++) {
-            (previousMaker, closable) = _loadPosition(
-                latestPosition,
-                context.registrations[marketId].market.pendingPositions(address(this), id),
-                previousMaker,
-                closable
-            );
-        }
-    }
-
-    /// @notice Loads one position for the closable position calculation
-    /// @param latestPosition The latest position
-    /// @param position The position to load
-    /// @param previousMaker The previous maker amount
-    /// @param previousClosable The previous closable amount
-    /// @return nextMaker The next maker amount
-    /// @return nextClosable The next closable amount
-    function _loadPosition(
-        Position memory latestPosition,
-        Position memory position,
-        UFixed6 previousMaker,
-        UFixed6 previousClosable
-    ) private pure returns (UFixed6 nextMaker, UFixed6 nextClosable) {
-        position.adjust(latestPosition);
-        nextClosable = previousClosable.sub(previousMaker.sub(position.maker.min(previousMaker)));
-        nextMaker = position.maker;
+        return maxRedeemShares.min(context.local.shares);
     }
 
     /// @notice Returns the real amount of collateral in the vault
     /// @return value The real amount of collateral in the vault
     function _collateral(Context memory context) public view returns (Fixed6 value) {
         value = Fixed6Lib.from(UFixed6Lib.from(asset.balanceOf()));
-        for (uint256 marketId; marketId < context.markets.length; marketId++)
-            value = value.add(context.markets[marketId].collateral);
+        for (uint256 marketId; marketId < context.registrations.length; marketId++)
+            value = value.add(context.collaterals[marketId]);
     }
 
     /// @notice Returns the collateral and fee information for the vault at position

--- a/packages/perennial-vault/contracts/interfaces/IVault.sol
+++ b/packages/perennial-vault/contracts/interfaces/IVault.sol
@@ -9,9 +9,13 @@ import "../types/Checkpoint.sol";
 import "../types/Mapping.sol";
 import "../types/VaultParameter.sol";
 import "../types/Registration.sol";
+import "../lib/StrategyLib.sol";
 
 interface IVault is IInstance {
     struct Context {
+        // strategy
+        Strategy strategy;
+
         // parameters
         UFixed6 settlementFee;
         uint256 totalWeight;
@@ -19,7 +23,7 @@ interface IVault is IInstance {
         // markets
         uint256 currentId;
         Registration[] registrations;
-        MarketContext[] markets;
+        Fixed6[] collaterals;
         Mapping currentIds;
         Mapping latestIds;
 
@@ -29,20 +33,6 @@ interface IVault is IInstance {
         Checkpoint latestCheckpoint;
         Account global;
         Account local;
-    }
-
-    struct MarketContext {
-        // latest global
-        UFixed6 latestPrice;
-
-        // current global
-        UFixed6 currentPosition;
-        UFixed6 currentNet;
-
-        // current local
-        Fixed6 collateral;
-        UFixed6 latestAccountPosition;
-        UFixed6 currentAccountPosition;
     }
 
     struct Target {

--- a/packages/perennial-vault/contracts/lib/StrategyLib.sol
+++ b/packages/perennial-vault/contracts/lib/StrategyLib.sol
@@ -3,6 +3,41 @@ pragma solidity ^0.8.13;
 
 import "../types/Registration.sol";
 
+/// @dev The context of an underlying market
+struct MarketStrategyContext {
+    /// @dev The market parameter set
+    MarketParameter marketParameter;
+
+    /// @dev The risk parameter set
+    RiskParameter riskParameter;
+
+    /// @dev The local state of the vault
+    Local local;
+
+    /// @dev The vault's current account position
+    Position currentAccountPosition;
+
+    /// @dev The vault's latest account position
+    Position latestAccountPosition;
+
+    /// @dev The current global position
+    Position currentPosition;
+
+    /// @dev The latest valid price
+    Fixed6 latestPrice;
+
+    /// @dev The margin requirement of the vault
+    UFixed6 margin;
+
+    /// @dev The current closable amount of the vault
+    UFixed6 closable;
+}
+
+struct Strategy {
+    MarketStrategyContext[] marketContexts;
+}
+using StrategyLib for Strategy global;
+
 /// @title Strategy
 /// @notice Logic for vault capital allocation
 /// @dev - Deploys collateral first to satisfy the margin of each market, then deploys the rest by weight.
@@ -10,36 +45,6 @@ import "../types/Registration.sol";
 library StrategyLib {
     /// @dev The maximum multiplier that is allowed for leverage
     UFixed6 public constant LEVERAGE_BUFFER = UFixed6.wrap(1.2e6);
-
-    /// @dev The context of an underlying market
-    struct MarketContext {
-        /// @dev The market parameter set
-        MarketParameter marketParameter;
-
-        /// @dev The risk parameter set
-        RiskParameter riskParameter;
-
-        /// @dev The local state of the vault
-        Local local;
-
-        /// @dev The vault's current account position
-        Position currentAccountPosition;
-
-        /// @dev The vault's latest account position
-        Position latestAccountPosition;
-
-        /// @dev The current global position
-        Position currentPosition;
-
-        /// @dev The latest valid price
-        Fixed6 latestPrice;
-
-        /// @dev The margin requirement of the vault
-        UFixed6 margin;
-
-        /// @dev The current closable amount of the vault
-        UFixed6 closable;
-    }
 
     /// @dev The target allocation for a market
     struct MarketTarget {
@@ -56,44 +61,81 @@ library StrategyLib {
         UFixed6 marketAssets;
         UFixed6 minPosition;
         UFixed6 maxPosition;
+        UFixed6 minAssets;
+        uint256 totalWeight;
+        UFixed6 totalMargin;
+    }
+
+    function load(Registration[] memory registrations) internal view returns (Strategy memory strategy) {
+        strategy.marketContexts = new MarketStrategyContext[](registrations.length);
+        for (uint256 marketId; marketId < registrations.length; marketId++)
+            strategy.marketContexts[marketId] = _loadContext(registrations[marketId]);
+    }
+
+    function maxRedeem(
+        Strategy memory strategy,
+        Registration[] memory registrations,
+        uint256 totalWeight
+    ) internal pure returns (UFixed6 redemptionAssets) {
+        redemptionAssets = UFixed6Lib.MAX;
+        for (uint256 marketId; marketId < strategy.marketContexts.length; marketId++) {
+            MarketStrategyContext memory marketContext = strategy.marketContexts[marketId];
+            Registration memory registration = registrations[marketId];
+
+            // If market has 0 weight, leverage, or position, skip
+            if (
+                registration.weight == 0 ||
+                registration.leverage.isZero() || (
+                    marketContext.latestAccountPosition.maker.isZero() &&
+                    marketContext.currentAccountPosition.maker.isZero()
+                )
+            ) continue;
+
+            UFixed6 collateral = marketContext.currentPosition.maker
+                .sub(marketContext.currentPosition.net().min(marketContext.currentPosition.maker))  // available maker
+                .min(marketContext.closable.mul(StrategyLib.LEVERAGE_BUFFER))                       // available closable
+                .muldiv(marketContext.latestPrice.abs(), registration.leverage)                     // available collateral
+                .muldiv(totalWeight, registration.weight);                                          // collateral in market
+
+            redemptionAssets = redemptionAssets.min(collateral);
+        }
     }
 
     /// @notice Compute the target allocation for each market
+    /// @param strategy The strategy of the vault
     /// @param registrations The registrations of the markets
     /// @param collateral The amount of collateral to allocate
     /// @param assets The amount of collateral that is eligible for positions
     function allocate(
+        Strategy memory strategy,
         Registration[] memory registrations,
         UFixed6 collateral,
         UFixed6 assets
-    ) internal view returns (MarketTarget[] memory targets) {
-        MarketContext[] memory contexts = new MarketContext[](registrations.length);
-        for (uint256 marketId; marketId < registrations.length; marketId++)
-            contexts[marketId] = _loadContext(registrations[marketId]);
-
-        (uint256 totalWeight, UFixed6 totalMargin) = _aggregate(registrations, contexts);
+    ) internal pure returns (MarketTarget[] memory targets) {
+        _AllocateLocals memory _locals;
+        (_locals.totalWeight, _locals.totalMargin) = _aggregate(registrations, strategy.marketContexts);
 
         targets = new MarketTarget[](registrations.length);
         for (uint256 marketId; marketId < registrations.length; marketId++) {
-            _AllocateLocals memory _locals;
-            _locals.marketCollateral = contexts[marketId].margin
-                .add(collateral.sub(totalMargin).muldiv(registrations[marketId].weight, totalWeight));
+
+            _locals.marketCollateral = strategy.marketContexts[marketId].margin
+                .add(collateral.sub(_locals.totalMargin).muldiv(registrations[marketId].weight, _locals.totalWeight));
 
             _locals.marketAssets = assets
-                .muldiv(registrations[marketId].weight, totalWeight)
+                .muldiv(registrations[marketId].weight, _locals.totalWeight)
                 .min(_locals.marketCollateral.mul(LEVERAGE_BUFFER));
 
-            UFixed6 minAssets = contexts[marketId].riskParameter.minMargin
-                .unsafeDiv(registrations[marketId].leverage.mul(contexts[marketId].riskParameter.maintenance));
-            if (contexts[marketId].marketParameter.closed || _locals.marketAssets.lt(minAssets))
+            _locals.minAssets = strategy.marketContexts[marketId].riskParameter.minMargin
+                .unsafeDiv(registrations[marketId].leverage.mul(strategy.marketContexts[marketId].riskParameter.maintenance));
+            if (strategy.marketContexts[marketId].marketParameter.closed || _locals.marketAssets.lt(_locals.minAssets))
                 _locals.marketAssets = UFixed6Lib.ZERO;
 
-            (_locals.minPosition, _locals.maxPosition) = _positionLimit(contexts[marketId]);
+            (_locals.minPosition, _locals.maxPosition) = _positionLimit(strategy.marketContexts[marketId]);
 
             (targets[marketId].collateral, targets[marketId].position) = (
-                Fixed6Lib.from(_locals.marketCollateral).sub(contexts[marketId].local.collateral),
+                Fixed6Lib.from(_locals.marketCollateral).sub(strategy.marketContexts[marketId].local.collateral),
                 _locals.marketAssets
-                    .muldiv(registrations[marketId].leverage, contexts[marketId].latestPrice.abs())
+                    .muldiv(registrations[marketId].leverage, strategy.marketContexts[marketId].latestPrice.abs())
                     .min(_locals.maxPosition)
                     .max(_locals.minPosition)
             );
@@ -102,88 +144,88 @@ library StrategyLib {
 
     /// @notice Load the context of a market
     /// @param registration The registration of the market
-    /// @return context The context of the market
-    function _loadContext(Registration memory registration) private view returns (MarketContext memory context) {
-        context.marketParameter = registration.market.parameter();
-        context.riskParameter = registration.market.riskParameter();
-        context.local = registration.market.locals(address(this));
+    /// @return marketContext The context of the market
+    function _loadContext(Registration memory registration) private view returns (MarketStrategyContext memory marketContext) {
+        marketContext.marketParameter = registration.market.parameter();
+        marketContext.riskParameter = registration.market.riskParameter();
+        marketContext.local = registration.market.locals(address(this));
         Global memory global = registration.market.global();
-        context.latestPrice = global.latestPrice;
+        marketContext.latestPrice = global.latestPrice;
 
         // latest position
         UFixed6 previousClosable;
         previousClosable = _loadPosition(
-            context,
-            context.latestAccountPosition = registration.market.positions(address(this)),
+            marketContext,
+            marketContext.latestAccountPosition = registration.market.positions(address(this)),
             previousClosable
         );
-        context.closable = context.latestAccountPosition.maker;
+        marketContext.closable = marketContext.latestAccountPosition.maker;
 
         // pending positions
-        for (uint256 id = context.local.latestId + 1; id <= context.local.currentId; id++)
+        for (uint256 id = marketContext.local.latestId + 1; id <= marketContext.local.currentId; id++)
             previousClosable = _loadPosition(
-                context,
-                context.currentAccountPosition = registration.market.pendingPositions(address(this), id),
+                marketContext,
+                marketContext.currentAccountPosition = registration.market.pendingPositions(address(this), id),
                 previousClosable
             );
 
         // current position
         Position memory latestPosition = registration.market.position();
-        context.currentPosition = registration.market.pendingPosition(global.currentId);
-        context.currentPosition.adjust(latestPosition);
+        marketContext.currentPosition = registration.market.pendingPosition(global.currentId);
+        marketContext.currentPosition.adjust(latestPosition);
     }
 
     /// @notice Loads one position for the context calculation
-    /// @param context The context of the market
+    /// @param marketContext The context of the market
     /// @param position The position to load
     /// @param previousMaker The previous maker position
     /// @return nextMaker The next maker position
     function _loadPosition(
-        MarketContext memory context,
+        MarketStrategyContext memory marketContext,
         Position memory position,
         UFixed6 previousMaker
     ) private pure returns (UFixed6 nextMaker) {
-        position.adjust(context.latestAccountPosition);
+        position.adjust(marketContext.latestAccountPosition);
 
-        context.margin = position
-            .margin(OracleVersion(0, context.latestPrice, true), context.riskParameter)
-            .max(context.margin);
-        context.closable = context.closable.sub(previousMaker.sub(position.maker.min(previousMaker)));
+        marketContext.margin = position
+            .margin(OracleVersion(0, marketContext.latestPrice, true), marketContext.riskParameter)
+            .max(marketContext.margin);
+        marketContext.closable = marketContext.closable.sub(previousMaker.sub(position.maker.min(previousMaker)));
         nextMaker = position.maker;
     }
 
     /// @notice Aggregate the context of all markets
     /// @param registrations The registrations of the markets
-    /// @param contexts The contexts of the markets
+    /// @param marketContexts The contexts of the markets
     /// @return totalWeight The total weight of all markets
     /// @return totalMargin The total margin of all markets
     function _aggregate(
         Registration[] memory registrations,
-        MarketContext[] memory contexts
+        MarketStrategyContext[] memory marketContexts
     ) private pure returns (uint256 totalWeight, UFixed6 totalMargin) {
         for (uint256 marketId; marketId < registrations.length; marketId++) {
             totalWeight += registrations[marketId].weight;
-            totalMargin = totalMargin.add(contexts[marketId].margin);
+            totalMargin = totalMargin.add(marketContexts[marketId].margin);
         }
     }
 
     /// @notice Compute the position limit of a market
-    /// @param context The context of the market
+    /// @param marketContext The context of the market
     /// @return The minimum position size before crossing the net position
     /// @return The maximum position size before crossing the maker limit
-    function _positionLimit(MarketContext memory context) private pure returns (UFixed6, UFixed6) {
+    function _positionLimit(MarketStrategyContext memory marketContext) private pure returns (UFixed6, UFixed6) {
         return (
             // minimum position size before crossing the net position
-            context.currentAccountPosition.maker.sub(
-                context.currentPosition.maker
-                    .sub(context.currentPosition.net().min(context.currentPosition.maker))
-                    .min(context.currentAccountPosition.maker)
-                    .min(context.closable)
+            marketContext.currentAccountPosition.maker.sub(
+            marketContext.currentPosition.maker
+                    .sub(marketContext.currentPosition.net().min(marketContext.currentPosition.maker))
+                    .min(marketContext.currentAccountPosition.maker)
+                    .min(marketContext.closable)
             ),
             // maximum position size before crossing the maker limit
-            context.currentAccountPosition.maker.add(
-                context.riskParameter.makerLimit
-                    .sub(context.currentPosition.maker.min(context.riskParameter.makerLimit))
+            marketContext.currentAccountPosition.maker.add(
+            marketContext.riskParameter.makerLimit
+                    .sub(marketContext.currentPosition.maker.min(marketContext.riskParameter.makerLimit))
             )
         );
     }

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -548,7 +548,10 @@ describe('Vault', () => {
       )
 
       // User 2 should not be able to redeem; they haven't deposited anything.
-      await expect(vault.connect(user2).update(user2.address, 0, 1, 0)).to.be.revertedWithPanic('0x11')
+      await expect(vault.connect(user2).update(user2.address, 0, 1, 0)).to.be.revertedWithCustomError(
+        vault,
+        'VaultRedemptionLimitExceededError',
+      )
       expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('10010'))
       await vault.connect(user).update(user.address, 0, (await vault.accounts(user.address)).shares, 0)
       await updateOracle()
@@ -573,6 +576,7 @@ describe('Vault', () => {
       )
 
       await vault.connect(user).update(user.address, 0, 0, ethers.constants.MaxUint256)
+
       expect(await totalCollateralInVault()).to.equal(0)
       expect(await asset.balanceOf(user.address)).to.equal(parse6decimal('100000').add(fundingAmount).mul(1e12))
       expect((await vault.accounts(user.address)).assets).to.equal(0)
@@ -761,7 +765,7 @@ describe('Vault', () => {
       // We shouldn't be able to redeem more than balance.
       await expect(
         vault.connect(user).update(user.address, 0, (await vault.accounts(user.address)).shares.add(1), 0),
-      ).to.be.revertedWithPanic('0x11')
+      ).to.be.revertedWithCustomError(vault, 'VaultRedemptionLimitExceededError')
 
       // But we should be able to redeem exactly balance.
 


### PR DESCRIPTION
Consolidates and de-duplicates context loading between the core vault flow and the strategy flow.

- Saves `~105k` gas on update.
- Removes `41` LoC from Vault.
- Removes `525 bytes` code size from Vault.