### PR TITLE
[Fix] Check latest on oracle switchover

### DIFF
--- a/packages/perennial-oracle/contracts/Oracle.sol
+++ b/packages/perennial-oracle/contracts/Oracle.sol
@@ -28,7 +28,6 @@ contract Oracle is IOracle, Instance {
     /// @param newProvider The new oracle provider
     function update(IOracleProvider newProvider) external {
         if (msg.sender != address(factory())) revert OracleNotFactoryError();
-        // TODO: just check the latest here
         _updateCurrent(newProvider);
         _updateLatest(newProvider.latest());
     }
@@ -89,7 +88,7 @@ contract Oracle is IOracle, Instance {
             if (latestVersion.timestamp > oracles[global.current].timestamp)
                 oracles[global.current].timestamp = uint96(latestVersion.timestamp);
         }
-        
+
         // add the new oracle registration
         oracles[++global.current] = Epoch(newProvider, uint96(newProvider.current()));
         emit OracleUpdated(newProvider);


### PR DESCRIPTION
Non-requested versions allow the `.latest()` of an oracle to sometimes be greater than the last requested's `.current()`.

This could create a situation in `Oracle` where the `.latest()` went backwards if switched over in this case.

This changes adds an extra check to `Oracle.update()` to take into account the `.latest()` of the sub-oracle during the switchover to avoid this.