### PR TITLE
[Fix] Properly adjust positions in Vault calculations

### DIFF
--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -450,7 +450,9 @@ contract Vault is IVault, Instance {
 
             // global
             Global memory global = registration.market.global();
+            Position memory latestPosition = registration.market.position();
             Position memory currentPosition = registration.market.pendingPosition(global.currentId);
+            currentPosition.adjust(latestPosition);
 
             context.markets[marketId].latestPrice = global.latestPrice.abs();
             context.markets[marketId].currentPosition = currentPosition.maker;
@@ -461,6 +463,8 @@ contract Vault is IVault, Instance {
             Local memory local = registration.market.locals(address(this));
             Position memory latestAccountPosition = registration.market.positions(address(this));
             Position memory currentAccountPosition = registration.market.pendingPositions(address(this), local.currentId);
+            currentAccountPosition.adjust(latestAccountPosition);
+
             context.markets[marketId].collateral = local.collateral;
             context.markets[marketId].latestAccountPosition = latestAccountPosition.maker;
             context.markets[marketId].currentAccountPosition = currentAccountPosition.maker;

--- a/packages/perennial-vault/contracts/lib/StrategyLib.sol
+++ b/packages/perennial-vault/contracts/lib/StrategyLib.sol
@@ -128,7 +128,9 @@ library StrategyLib {
             );
 
         // current position
+        Position memory latestPosition = registration.market.position();
         context.currentPosition = registration.market.pendingPosition(global.currentId);
+        context.currentPosition.adjust(latestPosition);
     }
 
     /// @notice Loads one position for the context calculation


### PR DESCRIPTION
Adds `.adjust()` to each instance of a pending position being read in the vault to properly read the position value.

Fixes: https://github.com/sherlock-audit/2023-09-perennial-judging/issues/55.