### PR TITLE
Add verify-proxies, commit-price hardhat tasks

### DIFF
--- a/packages/common/tsconfig.default.json
+++ b/packages/common/tsconfig.default.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/packages/perennial-deploy/hardhat.config.ts
+++ b/packages/perennial-deploy/hardhat.config.ts
@@ -1,6 +1,7 @@
 import defaultConfig from '../common/hardhat.default.config'
 import { solidityOverrides as coreOverrides } from '@equilibria/perennial-v2/hardhat.config'
 import { solidityOverrides as vaultOverrides } from '@equilibria/perennial-v2-vault/hardhat.config'
+import './tasks'
 
 const config = defaultConfig({
   dependencyPaths: [

--- a/packages/perennial-deploy/package.json
+++ b/packages/perennial-deploy/package.json
@@ -34,6 +34,8 @@
   "author": "",
   "license": "APACHE-2.0",
   "dependencies": {
-    "@equilibria/perennial-v2": "1.0.0"
+    "@equilibria/perennial-v2": "1.0.0",
+    "@types/isomorphic-fetch": "^0.0.37",
+    "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/packages/perennial-deploy/package.json
+++ b/packages/perennial-deploy/package.json
@@ -35,6 +35,7 @@
   "license": "APACHE-2.0",
   "dependencies": {
     "@equilibria/perennial-v2": "1.0.0",
+    "@pythnetwork/pyth-evm-js": "^1.29.0",
     "@types/isomorphic-fetch": "^0.0.37",
     "isomorphic-fetch": "^3.0.0"
   }

--- a/packages/perennial-deploy/tasks/commitPrice.ts
+++ b/packages/perennial-deploy/tasks/commitPrice.ts
@@ -1,0 +1,67 @@
+import '@nomiclabs/hardhat-ethers'
+import { task, types } from 'hardhat/config'
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
+import { EvmPriceServiceConnection } from '@pythnetwork/pyth-evm-js'
+
+const PYTH_ENDPOINT = 'https://hermes.pyth.network'
+
+export default task('commit-price', 'Commits a price for the given price id')
+  .addParam('priceid', 'The price id to commit', '', types.string)
+  .setAction(async ({ priceid: priceId }: TaskArguments, HRE: HardhatRuntimeEnvironment) => {
+    if (!priceId) throw new Error('No Price ID provided')
+    const {
+      ethers,
+      deployments: { get },
+    } = HRE
+
+    const oracleFactory = await ethers.getContractAt('IOracleFactory', (await get('OracleFactory')).address)
+    const oracle = await ethers.getContractAt('Oracle', await oracleFactory.oracles(priceId))
+    const oracleGlobal = await oracle.callStatic.global()
+    const pythProvider = await ethers.getContractAt(
+      'IPythOracle',
+      (
+        await oracle.callStatic.oracles(oracleGlobal.current)
+      ).provider,
+    )
+
+    const pyth = new EvmPriceServiceConnection(PYTH_ENDPOINT, { priceFeedRequestConfig: { binary: true } })
+    const [minValidTime, nextVersionIndexToCommit] = await Promise.all([
+      pythProvider.callStatic.MIN_VALID_TIME_AFTER_VERSION(),
+      pythProvider.callStatic.nextVersionIndexToCommit(),
+    ])
+
+    const vaa = await getRecentVaa({
+      pyth,
+      feedIds: [{ providerId: priceId, minValidTime: minValidTime.toBigInt() }],
+    })
+
+    console.log('Committing VAA')
+    const hash = await pythProvider.commit(nextVersionIndexToCommit, vaa[0].version, vaa[0].vaa, { value: 1n })
+    console.log('VAA committed. Hash:', hash)
+  })
+
+const getRecentVaa = async ({
+  pyth,
+  feedIds,
+}: {
+  pyth: EvmPriceServiceConnection
+  feedIds: { providerId: string; minValidTime: bigint }[]
+}) => {
+  const priceFeeds = await pyth.getLatestPriceFeeds(feedIds.map(({ providerId }) => providerId))
+  if (!priceFeeds) throw new Error('No price feeds found')
+
+  return priceFeeds.map(priceFeed => {
+    const vaa = priceFeed.getVAA()
+    if (!vaa) throw new Error('No VAA found')
+
+    const publishTime = priceFeed.getPriceUnchecked().publishTime
+    const minValidTime = feedIds.find(({ providerId }) => `0x${providerId}` === priceFeed.id)?.minValidTime
+
+    return {
+      feedId: priceFeed.id,
+      vaa: `0x${Buffer.from(vaa, 'base64').toString('hex')}`,
+      publishTime,
+      version: BigInt(publishTime) - (minValidTime ?? 4n),
+    }
+  })
+}

--- a/packages/perennial-deploy/tasks/commitPrice.ts
+++ b/packages/perennial-deploy/tasks/commitPrice.ts
@@ -25,9 +25,9 @@ export default task('commit-price', 'Commits a price for the given price id')
     )
 
     const pyth = new EvmPriceServiceConnection(PYTH_ENDPOINT, { priceFeedRequestConfig: { binary: true } })
-    const [minValidTime, nextVersionIndexToCommit] = await Promise.all([
+    const [minValidTime, versionListLength] = await Promise.all([
       pythProvider.callStatic.MIN_VALID_TIME_AFTER_VERSION(),
-      pythProvider.callStatic.nextVersionIndexToCommit(),
+      pythProvider.callStatic.versionListLength(),
     ])
 
     const vaa = await getRecentVaa({
@@ -36,7 +36,7 @@ export default task('commit-price', 'Commits a price for the given price id')
     })
 
     console.log('Committing VAA')
-    const hash = await pythProvider.commit(nextVersionIndexToCommit, vaa[0].version, vaa[0].vaa, { value: 1n })
+    const { hash } = await pythProvider.commit(versionListLength, vaa[0].version, vaa[0].vaa, { value: 1n })
     console.log('VAA committed. Hash:', hash)
   })
 

--- a/packages/perennial-deploy/tasks/index.ts
+++ b/packages/perennial-deploy/tasks/index.ts
@@ -1,0 +1,1 @@
+export * from './verifyProxies'

--- a/packages/perennial-deploy/tasks/index.ts
+++ b/packages/perennial-deploy/tasks/index.ts
@@ -1,1 +1,2 @@
 export * from './verifyProxies'
+export * from './commitPrice'

--- a/packages/perennial-deploy/tasks/verifyProxies.ts
+++ b/packages/perennial-deploy/tasks/verifyProxies.ts
@@ -1,0 +1,74 @@
+import fetch from 'isomorphic-fetch'
+import '@nomiclabs/hardhat-ethers'
+import { task } from 'hardhat/config'
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
+import { Factory__factory, ProxyAdmin__factory } from '../types/generated'
+
+export default task('verify-proxies', 'Verifies proxies on Etherscan for the given network').setAction(
+  async (args: TaskArguments, HRE: HardhatRuntimeEnvironment) => {
+    const {
+      ethers,
+      deployments: { get, all, getNetworkName },
+      config: { etherscan },
+    } = HRE
+    const res = await HRE.run('verify:get-etherscan-endpoint')
+    const apiKey = (etherscan?.apiKey as Record<string, string>)[getNetworkName()]
+    const proxyVerifyUrl = `${res.urls.apiURL}?module=contract&action=verifyproxycontract&apikey=${apiKey}`
+    const proxyVerifyStatusUrl = `${res.urls.apiURL}?module=contract&action=checkproxyverification&apikey=${apiKey}"`
+
+    const proxyAdmin = ProxyAdmin__factory.connect((await get('ProxyAdmin')).address, ethers.provider)
+    const allDeployments = await all()
+    const proxies = await Promise.all(
+      Object.entries(allDeployments)
+        .filter(([, deployment]) => deployment.abi.filter(({ name }) => name === 'upgradeTo').length > 0)
+        .filter(([name]) => name !== 'Pyth')
+        .map(async ([name, deployment]) => {
+          const impl = await proxyAdmin.callStatic.getProxyImplementation(deployment.address)
+          return { address: deployment.address, name, expected: impl, deployment }
+        }),
+    )
+    const factories = proxies.filter(({ name }) => name.endsWith('Factory') && name !== 'PayoffFactory')
+    const instances = await Promise.all(
+      factories.map(async ({ name, deployment }) => {
+        const contract = Factory__factory.connect(deployment.address, ethers.provider)
+        const impl = await contract.callStatic.implementation()
+        const res = await contract.queryFilter(contract.filters.InstanceRegistered())
+        return res.map(({ args }) => ({
+          address: args.instance,
+          expected: impl,
+          name: name.replace('Factory', 'Impl'),
+        }))
+      }),
+    )
+
+    const allAddresses = [
+      ...instances.flat(),
+      ...proxies.map(({ name, address, expected }) => ({ address, expected, name })),
+    ]
+
+    for (const addressData of allAddresses) {
+      const { address, expected, name } = addressData
+      console.log(`Linking proxy ${name} - Address: ${address}, Expected: ${expected}`)
+      const res = await fetch(proxyVerifyUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
+        body: `address=${address}&expectedimplementation=${expected}`,
+      })
+      const json = await res.json()
+      const proxyguid = json.result
+      let msg = 'Pending in queue'
+      let proxyResultJson = {} as Record<string, unknown>
+      while (msg === 'Pending in queue') {
+        const proxyResult = await fetch(`${proxyVerifyStatusUrl}&guid=${proxyguid}`)
+        proxyResultJson = await proxyResult.json()
+        msg = proxyResultJson.result as string
+        await new Promise(resolve => setTimeout(resolve, 500))
+      }
+      console.log(`> Result: ${proxyResultJson.message} (${proxyResultJson.status}) - ${proxyResultJson.result}`)
+
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+  },
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.15.4":
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
+  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@chainlink/contracts@0.3.1":
   version "0.3.1"
   resolved "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.3.1.tgz"
@@ -1978,6 +1985,32 @@
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz"
   integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
 
+"@pythnetwork/price-service-client@*":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@pythnetwork/price-service-client/-/price-service-client-1.8.0.tgz#d8e99e8b19326a75ab07145eb2af0ce04d4861b0"
+  integrity sha512-wJGs9J0N1VsI5H5djNjRPRxGZz7gJjRKxaWHSTBHbt8zCwvrKAC9DXn0Zhy4H/xQq3EPW3lpDtkd76bOTQ5qew==
+  dependencies:
+    "@pythnetwork/price-service-sdk" "*"
+    "@types/ws" "^8.5.3"
+    axios "=1.1.0"
+    axios-retry "~3.3.0"
+    isomorphic-ws "^4.0.1"
+    ts-log "^2.2.4"
+    ws "^8.6.0"
+
+"@pythnetwork/price-service-sdk@*":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@pythnetwork/price-service-sdk/-/price-service-sdk-1.4.0.tgz#57413dc0fe79999077bc234fadd3e64268d1e6b0"
+  integrity sha512-KZU9byZhm57Lx6eEhXk1pxDxCRbUxCIyKrJsiuqh8ZOVBxzbtVz4/iQTmgXWgWydMKuvOD37v1OwvtHCQf0k8w==
+
+"@pythnetwork/pyth-evm-js@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@pythnetwork/pyth-evm-js/-/pyth-evm-js-1.29.0.tgz#22eecea549da404fa15442a16bccb2e8ce005ac4"
+  integrity sha512-xvPfwMTTLwk35xu4tIe0deyZDMrhotbF0vQlKnZdpFumC+P6kBkui09RfIKQn0jK4x+LTIJ4yXgHsdbgTZfdrQ==
+  dependencies:
+    "@pythnetwork/price-service-client" "*"
+    buffer "^6.0.3"
+
 "@pythnetwork/pyth-sdk-solidity@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.1.tgz#604e71840b68d688281a64369e377dfc7109173e"
@@ -2110,7 +2143,14 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.16.0", "@solidity-parser/parser@^0.16.1":
+"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
+  integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
+"@solidity-parser/parser@^0.16.0":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.16.1.tgz#f7c8a686974e1536da0105466c4db6727311253c"
   integrity sha512-PdhRFNhbTtu3x8Axm0uYpqOy/lODYQK+MlYSgqIsq2L8SFYEHJPHNUiOTAJbDGzNjjr1/n9AcIayxafR/fWmYw==
@@ -2208,6 +2248,11 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/isomorphic-fetch@^0.0.37":
+  version "0.0.37"
+  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.37.tgz#d3efed60248923ae14f797ad20b82b4ae4b0ca83"
+  integrity sha512-+27HulrbyFpcalE4Agl+KHfGi4Qkcdmxv/ISi+DmUs5NECAFxRHeuZaLJj6DBfDRle6yxCOqLHJrfyVy9y5x9w==
 
 "@types/json-schema@^7.0.7":
   version "7.0.11"
@@ -2341,6 +2386,13 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.1.tgz#1254750a4fec4aff2ebec088ccd0bb02e91fedb4"
   integrity sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==
+
+"@types/ws@^8.5.3":
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.6.tgz#e9ad51f0ab79b9110c50916c9fcbddc36d373065"
+  integrity sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^4.26.1":
   version "4.33.0"
@@ -2818,6 +2870,23 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axios-retry@~3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.3.1.tgz#47624646138aedefbad2ac32f226f4ee94b6dcab"
+  integrity sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
+
+axios@=1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.0.tgz#94d25e6524743c7fc33954dd536687bbb957793a"
+  integrity sha512-hsJgcqz4JY7f+HZ4cWTrPZ6tZNCNFPTRx1MjRqu/hbpgpHdSCUpLVuplc+jE/h7dOvyANtw/ERA3HC2Rz/QoMg==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -4692,6 +4761,11 @@ follow-redirects@^1.12.1, follow-redirects@^1.14.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
@@ -5807,6 +5881,11 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
+
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz"
@@ -5900,6 +5979,19 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -7822,6 +7914,11 @@ protocols@^2.0.1:
   resolved "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz"
   integrity sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -8107,6 +8204,11 @@ reduce-flatten@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz"
   integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
@@ -9272,6 +9374,11 @@ ts-generator@^0.1.1:
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
+ts-log@^2.2.4:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.5.tgz#aef3252f1143d11047e2cb6f7cfaac7408d96623"
+  integrity sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==
+
 ts-node@^8.0.2:
   version "8.10.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz"
@@ -9641,6 +9748,11 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+whatwg-fetch@^3.4.1:
+  version "3.6.19"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz#caefd92ae630b91c07345537e67f8354db470973"
+  integrity sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==
+
 whatwg-url@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
@@ -9818,6 +9930,11 @@ ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.6.0:
+  version "8.14.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
+  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
 xmlhttprequest@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
Etherscan has an API to link proxies to impls rather than doing it manually - since we use proxies fairly heavily this task just pulls all contracts that are proxies are requests Etherscan to link them to our expected impl

Also adds a task to commit a price for a given feed ID