### PR TITLE
[Fix] Order.liquidityCheckApplicable() logic

### DIFF
--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -71,13 +71,19 @@ library OrderLib {
     /// @notice Returns whether the order increases any of the account's positions
     /// @return Whether the order increases any of the account's positions
     function increasesPosition(Order memory self) internal pure returns (bool) {
-        return self.maker.gt(Fixed6Lib.ZERO) || increasesTaker(self);
+        return increasesMaker(self) || increasesTaker(self);
     }
 
     /// @notice Returns whether the order increases the account's long or short positions
     /// @return Whether the order increases the account's long or short positions
     function increasesTaker(Order memory self) internal pure returns (bool) {
         return self.long.gt(Fixed6Lib.ZERO) || self.short.gt(Fixed6Lib.ZERO);
+    }
+
+    /// @notice Returns whether the order increases the account's maker position
+    /// @return Whether the order increases the account's maker positions
+    function increasesMaker(Order memory self) internal pure returns (bool) {
+        return self.maker.gt(Fixed6Lib.ZERO);
     }
 
     /// @notice Returns whether the order decreases the liquidity of the market
@@ -105,8 +111,8 @@ library OrderLib {
         MarketParameter memory marketParameter
     ) internal pure returns (bool) {
         return !marketParameter.closed &&
-            !marketParameter.makerCloseAlways &&
-            (!marketParameter.takerCloseAlways || increasesTaker(self));
+            ((self.maker.isZero()) || !marketParameter.makerCloseAlways || increasesMaker(self)) &&
+            ((self.long.isZero() && self.short.isZero()) || !marketParameter.takerCloseAlways || increasesTaker(self));
     }
 
     /// @notice Returns the liquidation fee of the position

--- a/packages/perennial/test/unit/types/Order.test.ts
+++ b/packages/perennial/test/unit/types/Order.test.ts
@@ -616,17 +616,20 @@ describe('Order', () => {
     })
 
     context('makerCloseAlways is true', () => {
-      it('returns false', async () => {
-        const result = await order.liquidityCheckApplicable(VALID_ORDER, {
-          ...VALID_MARKET_PARAMETER,
-          makerCloseAlways: true,
+      context('maker increase', () => {
+        it('returns true', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, maker: 10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
         })
-
-        expect(result).to.be.false
       })
-    })
 
-    context('takerCloseAlways is true', () => {
       context('long increase', () => {
         it('returns true', async () => {
           const result = await order.liquidityCheckApplicable(
@@ -662,7 +665,118 @@ describe('Order', () => {
             takerCloseAlways: true,
           })
 
+          expect(result).to.be.true
+        })
+      })
+
+      context('maker decrease', () => {
+        it('returns false', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, maker: -10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
+        })
+      })
+
+      context('long decrease', () => {
+        it('returns false', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, long: -10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
           expect(result).to.be.false
+        })
+      })
+
+      context('short decrease', () => {
+        it('returns false', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, short: -10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.false
+        })
+      })
+    })
+
+    context('takerCloseAlways is true', () => {
+      context('maker increase', () => {
+        it('returns true', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, maker: 10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
+        })
+      })
+
+      context('long increase', () => {
+        it('returns true', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, long: 10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
+        })
+      })
+
+      context('short increase', () => {
+        it('returns true', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, short: 10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
+        })
+      })
+
+      context('no increase', () => {
+        it('returns false', async () => {
+          const result = await order.liquidityCheckApplicable(VALID_ORDER, {
+            ...VALID_MARKET_PARAMETER,
+            takerCloseAlways: true,
+          })
+
+          expect(result).to.be.true
+        })
+      })
+
+      context('maker decrease', () => {
+        it('returns false', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, maker: -10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
         })
       })
 
@@ -696,6 +810,20 @@ describe('Order', () => {
     })
 
     context('closed, makerCloseAlways, and takerCloseAlways are false', () => {
+      context('maker increase', () => {
+        it('returns true', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, maker: 10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
+
+          expect(result).to.be.true
+        })
+      })
+
       context('long increase', () => {
         it('returns true', async () => {
           const result = await order.liquidityCheckApplicable({ ...VALID_ORDER, long: 10 }, VALID_MARKET_PARAMETER)
@@ -715,6 +843,20 @@ describe('Order', () => {
       context('no increase', () => {
         it('returns true', async () => {
           const result = await order.liquidityCheckApplicable(VALID_ORDER, VALID_MARKET_PARAMETER)
+
+          expect(result).to.be.true
+        })
+      })
+
+      context('maker decrease', () => {
+        it('returns false', async () => {
+          const result = await order.liquidityCheckApplicable(
+            { ...VALID_ORDER, maker: -10 },
+            {
+              ...VALID_MARKET_PARAMETER,
+              takerCloseAlways: true,
+            },
+          )
 
           expect(result).to.be.true
         })


### PR DESCRIPTION
Fixes: https://github.com/sherlock-audit/2023-09-perennial-judging/issues/62.