### PR TITLE
Relax invariant

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -496,8 +496,11 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             collateral.lt(Fixed6Lib.from(-1, _liquidationFee(context, newOrder)))
         )) revert MarketInvalidProtectionError();
 
-        if (context.currentTimestamp - context.latestVersion.timestamp >= context.riskParameter.staleAfter)
-            revert MarketStalePriceError();
+        if (
+            !(context.currentPosition.local.magnitude().isZero() && context.latestPosition.local.magnitude().isZero()) &&
+            (newOrder.isEmpty() && collateral.gte(Fixed6Lib.ZERO)) &&
+            (context.currentTimestamp - context.latestVersion.timestamp >= context.riskParameter.staleAfter)
+        ) revert MarketStalePriceError();
 
         if (context.marketParameter.closed && newOrder.increasesPosition())
             revert MarketClosedError();

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -498,7 +498,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         if (
             !(context.currentPosition.local.magnitude().isZero() && context.latestPosition.local.magnitude().isZero()) &&
-            (newOrder.isEmpty() && collateral.gte(Fixed6Lib.ZERO)) &&
+            !(newOrder.isEmpty() && collateral.gte(Fixed6Lib.ZERO)) &&
             (context.currentTimestamp - context.latestVersion.timestamp >= context.riskParameter.staleAfter)
         ) revert MarketStalePriceError();
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -514,9 +514,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         if (protected) return; // The following invariants do not apply to protected position updates (liquidations)
 
         if (
-            msg.sender != account &&                                                                   // sender is operating on own account
-            !IMarketFactory(address(factory())).operators(account, msg.sender) &&                      // sender is operating on own account
-            !(newOrder.isEmpty() && collateralAfterFees.isZero() && collateral.gt(Fixed6Lib.ZERO))     // sender is repaying shortfall for this account
+            msg.sender != account &&                                                        // sender is operating on own account
+            !IMarketFactory(address(factory())).operators(account, msg.sender) &&           // sender is operator approved for account
+            !(newOrder.isEmpty() && collateral.gte(Fixed6Lib.ZERO))                         // sender is depositing zero or more into account, without position change
         ) revert MarketOperatorNotAllowedError();
 
         if (

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -497,9 +497,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         )) revert MarketInvalidProtectionError();
 
         if (
-            !(context.currentPosition.local.magnitude().isZero() && context.latestPosition.local.magnitude().isZero()) &&
-            !(newOrder.isEmpty() && collateral.gte(Fixed6Lib.ZERO)) &&
-            (context.currentTimestamp - context.latestVersion.timestamp >= context.riskParameter.staleAfter)
+            !(context.currentPosition.local.magnitude().isZero() && context.latestPosition.local.magnitude().isZero()) &&   // sender has no position
+            !(newOrder.isEmpty() && collateral.gte(Fixed6Lib.ZERO)) &&                                                      // sender is depositing zero or more into account, without position change
+            (context.currentTimestamp - context.latestVersion.timestamp >= context.riskParameter.staleAfter)                // price is not stale
         ) revert MarketStalePriceError();
 
         if (context.marketParameter.closed && newOrder.increasesPosition())


### PR DESCRIPTION
Relaxes the `MarketStalePriceError` invariant to allow two new cases:
- Don't check for stale price when the account has no position (both latest & current are empty).
- Don't check for stale price when the position is unchanged, and the collateral is either also unchanged or depositing.

Relaxes the `MarketOperatorNotAllowedError` invariant to allow one new case:
- Allow anyone to deposit zero-or-more into any account with no position change.
  - Zero amount constitutes a settlement, while non-zero can be used for resolving shortfall.
  - Note: Previously this did not allow depositing on-behalf outside of shortfall resolution.