### PR TITLE
[Fix] Cap funding skew at 100%

### DIFF
--- a/packages/perennial/contracts/types/Version.sol
+++ b/packages/perennial/contracts/types/Version.sol
@@ -183,7 +183,7 @@ library VersionLib {
         // Compute long-short funding rate
         Fixed6 funding = global.pAccumulator.accumulate(
             riskParameter.pController,
-            toPosition.staticSkew(riskParameter),
+            toPosition.staticSkew(riskParameter).min(Fixed6Lib.ONE).max(Fixed6Lib.NEG_ONE),
             fromOracleVersion.timestamp,
             toOracleVersion.timestamp,
             fromPosition.takerSocialized().mul(fromOracleVersion.price.abs())

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14823,6 +14823,20 @@ describe('Market', () => {
               shortReward: { _value: 0 },
             })
           })
+
+          it('correctly stores large skew', async () => {
+            const riskParameter = { ...(await market.riskParameter()) }
+            riskParameter.skewScale = parse6decimal('1')
+            await market.connect(owner).updateRiskParameter(riskParameter)
+
+            await market.connect(user).update(user.address, 0, POSITION, 0, 0, false)
+
+            oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
+            oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
+            oracle.request.whenCalledWith(user.address).returns()
+
+            await expect(market.connect(user).update(user.address, 0, POSITION, 0, 0, false)).to.not.reverted
+          })
         })
 
         context('short', async () => {
@@ -14918,6 +14932,20 @@ describe('Market', () => {
               longReward: { _value: 0 },
               shortReward: { _value: EXPECTED_REWARD.div(5) },
             })
+          })
+
+          it('correctly stores large skew', async () => {
+            const riskParameter = { ...(await market.riskParameter()) }
+            riskParameter.skewScale = parse6decimal('1')
+            await market.connect(owner).updateRiskParameter(riskParameter)
+
+            await market.connect(user).update(user.address, 0, 0, POSITION, 0, false)
+
+            oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
+            oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
+            oracle.request.whenCalledWith(user.address).returns()
+
+            await expect(market.connect(user).update(user.address, 0, 0, POSITION, 0, false)).to.not.reverted
           })
         })
       })


### PR DESCRIPTION
Resolves: https://github.com/sherlock-audit/2023-10-perennial-judging/issues/57.