### PR TITLE
[Fix] Make fees nonnegative

### DIFF
--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -59,7 +59,8 @@ library OrderLib {
             .max(Fixed6Lib.ZERO);
         Fixed6 takerFee = Fixed6Lib.from(riskParameter.takerFee)
             .add(Fixed6Lib.from(riskParameter.takerSkewFee.mul(self.skew)))
-            .add(Fixed6Lib.from(riskParameter.takerImpactFee).mul(self.impact));
+            .add(Fixed6Lib.from(riskParameter.takerImpactFee).mul(self.impact))
+            .max(Fixed6Lib.ZERO);
         Fixed6 fee = Fixed6Lib.from(self.maker.abs().mul(latestVersion.price.abs())).mul(makerFee)
             .add(Fixed6Lib.from(self.long.abs().add(self.short.abs()).mul(latestVersion.price.abs())).mul(takerFee));
 

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1033,7 +1033,7 @@ describe('Fees', () => {
           e => e.event === 'PositionProcessed',
         )?.args as unknown as PositionProcessedEventObject
 
-        const expectedShortSkewFee = BigNumber.from('-1138829') // The impact fee refunds more than the taker fee charged
+        const expectedShortSkewFee = BigNumber.from('0') // The impact fee refunds more than the taker fee charged, but is capped at zero
         expect(accountProcessEventShort.accumulationResult.positionFee).to.equal(expectedShortSkewFee)
         expect(
           positionProcessEventShort.accumulationResult.positionFeeMaker.add(


### PR DESCRIPTION
Temporarily resolves: https://github.com/sherlock-audit/2023-10-perennial-judging/issues/58, while we design a more holistic algorithm.