### PR TITLE
[Fix] Add pendingOpen

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -629,13 +629,13 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         ) revert MarketInsufficientMarginError();
 
         if (
-            !PositionLib.maintained(
+            !PositionLib.margined(
                 context.latestPosition.local.magnitude().add(context.pendingOpen),
                 context.latestVersion,
                 context.riskParameter,
                 context.pendingCollateral
             )
-        ) revert MarketInsufficientMaintenanceError();
+        ) revert MarketInsufficientMarginError();
 
         if (
             (context.local.protection > context.latestPosition.local.timestamp) &&

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -32,10 +32,10 @@ interface IMarket is IInstance {
         Local local;
         PositionContext currentPosition;
         PositionContext latestPosition;
-        UFixed6 maxPendingMagnitude;
         UFixed6 previousPendingMagnitude;
         Fixed6 pendingCollateral;
-        UFixed6 closable;
+        UFixed6 pendingOpen;
+        UFixed6 pendingClose;
     }
 
     struct PositionContext {

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -59,8 +59,6 @@ interface IMarket is IInstance {
     error MarketInsufficientLiquidityError();
     // sig: 0x00e2b6a8
     error MarketInsufficientMarginError();
-    // sig: 0xa8e7d409
-    error MarketInsufficientMaintenanceError();
     // sig: 0x442145e5
     error MarketInsufficientCollateralError();
     // sig: 0xba555da7

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -118,7 +118,7 @@ describe('Liquidate', () => {
     const userBCollateral = (await market.locals(userB.address)).collateral
     await expect(
       market.connect(userB).update(userB.address, 0, 0, 0, userBCollateral.mul(-1).sub(1), false),
-    ).to.be.revertedWithCustomError(market, 'MarketInsufficientMaintenanceError') // underflow
+    ).to.be.revertedWithCustomError(market, 'MarketInsufficientMarginError') // underflow
 
     await market.connect(userB).update(user.address, 0, 0, 0, 0, true) // liquidate
 

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -12062,7 +12062,7 @@ describe('Market', () => {
           // can't close more than POSITION / 2
           await expect(
             market.connect(user).update(user.address, 0, POSITION.div(2).sub(1), 0, 0, false),
-          ).to.revertedWithPanic('0x11')
+          ).to.revertedWithCustomError(market, 'MarketOverCloseError')
 
           // close out as much as possible
           await expect(market.connect(user).update(user.address, 0, POSITION.div(2), 0, 0, false))
@@ -12076,7 +12076,7 @@ describe('Market', () => {
           // can't close any more
           await expect(
             market.connect(user).update(user.address, 0, POSITION.div(2).sub(1), 0, 0, false),
-          ).to.revertedWithPanic('0x11')
+          ).to.revertedWithCustomError(market, 'MarketOverCloseError')
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
           oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_5.timestamp])
@@ -12127,7 +12127,7 @@ describe('Market', () => {
           it('it reverts if not protected', async () => {
             await expect(market.connect(userB).update(userB.address, 0, 0, 0, 0, false)).to.be.revertedWithCustomError(
               market,
-              'MarketInsufficientMaintenanceError',
+              'MarketInsufficientMarginError',
             )
           })
 
@@ -12696,7 +12696,7 @@ describe('Market', () => {
 
           await expect(
             market.connect(liquidator).update(user.address, 0, 0, POSITION.div(4).sub(1), 0, true),
-          ).to.revertedWithPanic('0x11')
+          ).to.revertedWithCustomError(market, 'MarketOverCloseError')
 
           dsu.transfer.whenCalledWith(liquidator.address, EXPECTED_LIQUIDATION_FEE.add(1).mul(1e12)).returns(true)
           await expect(


### PR DESCRIPTION
Adds local awareness of the pending open amount, in addition to the existing pending close amount.

This partially resolves: https://github.com/sherlock-audit/2023-10-perennial-judging/issues/24, by providing better worst case position size for margin calculation.

Additionally this resolves: https://github.com/sherlock-audit/2023-10-perennial-judging/issues/23, by using margin for all pending position instead of maintenance. Maintenance is now *only* used to determine whether the latest position is liquidatable.