### PR TITLE
[Fix] Use allocate for max redeem calculation

### DIFF
--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -486,9 +486,13 @@ contract Vault is IVault, Instance {
     /// @notice The maximum available redemption amount for `account`
     /// @param context Context to use
     /// @return redemptionAmount Maximum available redemption amount
-    function _maxRedeem(Context memory context) private pure returns (UFixed6) {
+    function _maxRedeem(Context memory context) private view returns (UFixed6) {
         if (context.latestCheckpoint.unhealthy()) return UFixed6Lib.ZERO;
-        UFixed6 maxRedeemAssets = context.strategy.maxRedeem(context.registrations, context.totalWeight);
+        UFixed6 maxRedeemAssets = context.strategy.maxRedeem(
+            context.registrations,
+            context.totalWeight,
+            UFixed6Lib.from(_collateral(context).max(Fixed6Lib.ZERO))
+        );
         UFixed6 maxRedeemShares = maxRedeemAssets.eq(UFixed6Lib.MAX) ?
             UFixed6Lib.MAX :
             context.latestCheckpoint.toShares(maxRedeemAssets, UFixed6Lib.ZERO);

--- a/packages/perennial-vault/contracts/interfaces/IVault.sol
+++ b/packages/perennial-vault/contracts/interfaces/IVault.sol
@@ -61,6 +61,7 @@ interface IVault is IInstance {
     error MappingStorageInvalidError();
     error RegistrationStorageInvalidError();
     error VaultParameterStorageInvalidError();
+    error StrategyLibInsufficientMarginError();
 
     function initialize(Token18 asset, IMarket initialMaker, UFixed6 cap, string calldata name_) external;
     function name() external view returns (string memory);

--- a/packages/perennial-vault/contracts/lib/StrategyLib.sol
+++ b/packages/perennial-vault/contracts/lib/StrategyLib.sol
@@ -43,6 +43,8 @@ using StrategyLib for Strategy global;
 /// @dev - Deploys collateral first to satisfy the margin of each market, then deploys the rest by weight.
 ///      - Positions are then targeted based on the amount of collateral that ends up deployed to each market.
 library StrategyLib {
+    error StrategyLibInsufficientMarginError();
+
     /// @dev The maximum multiplier that is allowed for leverage
     UFixed6 public constant LEVERAGE_BUFFER = UFixed6.wrap(1.2e6);
 
@@ -133,6 +135,8 @@ library StrategyLib {
     ) internal pure returns (MarketTarget[] memory targets) {
         _AllocateLocals memory _locals;
         (_locals.totalWeight, _locals.totalMargin) = _aggregate(registrations, strategy.marketContexts);
+
+        if (collateral.lt(_locals.totalMargin)) revert StrategyLibInsufficientMarginError();
 
         targets = new MarketTarget[](registrations.length);
         for (uint256 marketId; marketId < registrations.length; marketId++) {

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1737,14 +1737,10 @@ describe('Vault', () => {
         expect((await vault.accounts(user.address)).assets).to.equal(finalUnclaimed)
         expect((await vault.accounts(ethers.constants.AddressZero)).assets).to.equal(finalUnclaimed)
 
-        // 6. Claim should be pro-rated
-        const initialBalanceOf = await asset.balanceOf(user.address)
-        await vault.connect(user).update(user.address, 0, 0, ethers.constants.MaxUint256)
-        expect(await collateralInVault()).to.equal(finalCollateral)
-        expect(await btcCollateralInVault()).to.equal(btcFinalCollateral)
-        expect((await vault.accounts(user.address)).assets).to.equal(0)
-        expect((await vault.accounts(ethers.constants.AddressZero)).assets).to.equal(0)
-        expect(await asset.balanceOf(user.address)).to.equal(initialBalanceOf)
+        // 6. Claim should not be possible since we cannot rebalance
+        await expect(
+          vault.connect(user).update(user.address, 0, 0, ethers.constants.MaxUint256),
+        ).to.revertedWithCustomError(vault, 'StrategyLibInsufficientMarginError')
       })
     })
 

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -817,15 +817,14 @@ describe('Vault', () => {
       await vault.settle(user.address)
 
       // The vault can close 1 ETH of maker positions in the ETH market, which means the user can redeem 5/4 this amount
-      const makerAvailable = BigNumber.from(1000000)
-      const redeemAvailable = await vault.convertToShares(
-        originalOraclePrice.mul(makerAvailable).mul(5).div(4).div(leverage),
-      )
+      const makerAvailable = BigNumber.from(1000268)
+      const redeemAvailable = (
+        await vault.convertToShares(originalOraclePrice.mul(makerAvailable).mul(5).div(4).div(leverage))
+      ).sub(1)
 
       await expect(
         vault.connect(user).update(user.address, 0, redeemAvailable.add(1), 0),
       ).to.be.revertedWithCustomError(vault, 'VaultRedemptionLimitExceededError')
-
       await expect(vault.connect(user).update(user.address, 0, redeemAvailable, 0)).to.not.be.reverted
     })
 
@@ -857,7 +856,7 @@ describe('Vault', () => {
       await vault.settle(user.address)
 
       // The vault can close 1 BTC of maker positions in the BTC market, which means the user can redeem 5/1 this amount
-      const makerAvailable = BigNumber.from(100000)
+      const makerAvailable = BigNumber.from(100005)
       const redeemAvailable = (
         await vault.convertToShares(btcOriginalOraclePrice.mul(makerAvailable).mul(5).div(1).div(leverage))
       ).sub(1)
@@ -865,7 +864,6 @@ describe('Vault', () => {
       await expect(
         vault.connect(user).update(user.address, 0, redeemAvailable.add(1), 0),
       ).to.be.revertedWithCustomError(vault, 'VaultRedemptionLimitExceededError')
-
       await expect(vault.connect(user).update(user.address, 0, redeemAvailable, 0)).to.not.be.reverted
     })
 


### PR DESCRIPTION
Resolves: https://github.com/sherlock-audit/2023-10-perennial-judging/issues/29.