### PR TITLE
[FIX] interfaceFee stored incorrectly

### DIFF
--- a/packages/perennial-extensions/contracts/types/TriggerOrder.sol
+++ b/packages/perennial-extensions/contracts/types/TriggerOrder.sol
@@ -104,7 +104,7 @@ library TriggerOrderStorageLib {
             uint64(UFixed6.unwrap(newValue.fee)),
             int64(Fixed6.unwrap(newValue.price)),
             int64(Fixed6.unwrap(newValue.delta)),
-            uint40(UFixed6.unwrap(newValue.interfaceFee.amount)),
+            uint48(UFixed6.unwrap(newValue.interfaceFee.amount)),
             newValue.interfaceFee.receiver,
             newValue.interfaceFee.unwrap,
             bytes11(0)

--- a/packages/perennial-extensions/test/helpers/invoke.ts
+++ b/packages/perennial-extensions/test/helpers/invoke.ts
@@ -2,10 +2,15 @@ import { BigNumberish, utils } from 'ethers'
 import { IMultiInvoker } from '../../types/generated'
 import { InterfaceFeeStruct, TriggerOrderStruct } from '../../types/generated/contracts/MultiInvoker'
 import { ethers } from 'hardhat'
+import { BigNumber } from 'ethers'
 
 export const MAX_INT = ethers.constants.MaxInt256
 export const MIN_INT = ethers.constants.MinInt256
 export const MAX_UINT = ethers.constants.MaxUint256
+export const MAX_UINT48 = BigNumber.from('281474976710655')
+export const MAX_UINT64 = BigNumber.from('18446744073709551615')
+export const MAX_INT64 = BigNumber.from('9223372036854775807')
+export const MIN_INT64 = BigNumber.from('-9223372036854775808')
 
 export type OrderStruct = {
   side?: number
@@ -196,6 +201,10 @@ export const buildExecOrder = ({
 module.exports = {
   MAX_INT,
   MAX_UINT,
+  MAX_UINT48,
+  MAX_UINT64,
+  MAX_INT64,
+  MIN_INT64,
   buildCancelOrder,
   buildExecOrder,
   buildPlaceOrder,

--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -8,16 +8,19 @@ import { expect } from 'chai'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { IMultiInvoker, Market, MultiInvoker } from '../../../types/generated'
 import { Compare, Dir, openTriggerOrder } from '../../helpers/types'
-import { buildCancelOrder, buildExecOrder, buildPlaceOrder } from '../../helpers/invoke'
+import {
+  MAX_INT64,
+  MAX_UINT48,
+  MAX_UINT64,
+  MIN_INT64,
+  buildCancelOrder,
+  buildExecOrder,
+  buildPlaceOrder,
+} from '../../helpers/invoke'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { InterfaceFeeStruct, TriggerOrderStruct } from '../../../types/generated/contracts/MultiInvoker'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { ethers } from 'hardhat'
-
-const MAX_UINT48 = BigNumber.from('281474976710655')
-const MAX_UINT64 = BigNumber.from('18446744073709551615')
-const MAX_INT64 = BigNumber.from('9223372036854775807')
-const MIN_INT64 = BigNumber.from('-9223372036854775808')
 
 describe('Orders', () => {
   let instanceVars: InstanceVars


### PR DESCRIPTION
address [audit finding ](https://github.com/sherlock-audit/2023-10-perennial-judging/issues/43) that interfaceFee is declared as a uint48 but is cast to uint40 when stored, as well as adding min/max storage value coverage for `TriggerOrder`s 
