### PR TITLE
v2.1 codesize

### DIFF
--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -307,7 +307,6 @@ export async function createMarket(
   const market = Market__factory.connect(marketAddress, owner)
 
   await market.updateRiskParameter(riskParameter)
-  await market.updateReward(rewardToken.address)
   await market.updateParameter(beneficiaryB.address, constants.AddressZero, marketParameter)
 
   return market

--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -204,15 +204,6 @@ contract Vault is IVault, Instance {
         emit ParameterUpdated(newParameter);
     }
 
-    /// @notice Claims the accrued rewards for each registered market
-    /// @dev Callable by owner in case vault accrues rewards, since it is not able to disperse them itself
-    function claimReward() external onlyOwner {
-        for (uint256 marketId; marketId < totalMarkets; marketId++) {
-            _registrations[marketId].read().market.claimReward();
-            _registrations[marketId].read().market.reward().push(factory().owner());
-        }
-    }
-
     /// @notice Syncs `account`'s state up to current
     /// @dev Also rebalances the collateral and position of the vault without a deposit or withdraw
     /// @param account The account that should be synced

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -53,7 +53,7 @@ interface IMarket is IInstance {
     event RewardClaimed(address indexed account, UFixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);
-    event RewardUpdated(Token18 newReward);
+    // event RewardUpdated(Token18 newReward);
 
     // sig: 0x0fe90964
     error MarketInsufficientLiquidityError();
@@ -77,10 +77,6 @@ interface IMarket is IInstance {
     error MarketOverCloseError();
     // sig: 0x935bdc21
     error MarketExceedsPendingIdLimitError();
-    // sig: 0x473b50fd
-    error MarketRewardAlreadySetError();
-    // sig: 0x06fbf046
-    error MarketInvalidRewardError();
     // sig: 0x9bca0625
     error MarketNotCoordinatorError();
     // sig: 0xb602d086
@@ -111,7 +107,6 @@ interface IMarket is IInstance {
 
     function initialize(MarketDefinition calldata definition_) external;
     function token() external view returns (Token18);
-    function reward() external view returns (Token18);
     function oracle() external view returns (IOracleProvider);
     function payoff() external view returns (IPayoffProvider);
     function positions(address account) external view returns (Position memory);
@@ -122,11 +117,9 @@ interface IMarket is IInstance {
     function position() external view returns (Position memory);
     function global() external view returns (Global memory);
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;
-    function updateReward(Token18 newReward) external;
     function parameter() external view returns (MarketParameter memory);
     function riskParameter() external view returns (RiskParameter memory);
     function updateParameter(address newBeneficiary, address newCoordinator, MarketParameter memory newParameter) external;
     function updateRiskParameter(RiskParameter memory newRiskParameter) external;
     function claimFee() external;
-    function claimReward() external;
 }

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -53,7 +53,6 @@ interface IMarket is IInstance {
     event RewardClaimed(address indexed account, UFixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);
-    // event RewardUpdated(Token18 newReward);
 
     // sig: 0x0fe90964
     error MarketInsufficientLiquidityError();

--- a/packages/perennial/contracts/types/Version.sol
+++ b/packages/perennial/contracts/types/Version.sol
@@ -122,10 +122,6 @@ library VersionLib {
         (values.pnlMaker, values.pnlLong, values.pnlShort) =
             _accumulatePNL(self, fromPosition, fromOracleVersion, toOracleVersion);
 
-        // accumulate reward
-        (values.rewardMaker, values.rewardLong, values.rewardShort) =
-            _accumulateReward(self, fromPosition, fromOracleVersion, toOracleVersion, marketParameter);
-
         return (values, values.positionFeeFee.add(values.fundingFee).add(values.interestFee));
     }
 
@@ -292,38 +288,6 @@ library VersionLib {
         self.longValue.increment(pnlLong, position.long);
         self.shortValue.increment(pnlShort, position.short);
         self.makerValue.increment(pnlMaker, position.maker);
-    }
-
-    /// @notice Globally accumulates position's reward share since last oracle update
-    /// @param self The Version object to update
-    /// @param position The previous latest position
-    /// @param fromOracleVersion The previous latest oracle version
-    /// @param toOracleVersion The next latest oracle version
-    /// @param marketParameter The market parameter
-    /// @return rewardMaker The total reward accrued by makers
-    /// @return rewardLong The total reward accrued by longs
-    /// @return rewardShort The total reward accrued by shorts
-    function _accumulateReward(
-        Version memory self,
-        Position memory position,
-        OracleVersion memory fromOracleVersion,
-        OracleVersion memory toOracleVersion,
-        MarketParameter memory marketParameter
-    ) private pure returns (UFixed6 rewardMaker, UFixed6 rewardLong, UFixed6 rewardShort) {
-        UFixed6 elapsed = UFixed6Lib.from(toOracleVersion.timestamp - fromOracleVersion.timestamp);
-
-        if (!position.maker.isZero()) {
-            rewardMaker = elapsed.mul(marketParameter.makerRewardRate);
-            self.makerReward.increment(rewardMaker, position.maker);
-        }
-        if (!position.long.isZero()) {
-            rewardLong = elapsed.mul(marketParameter.longRewardRate);
-            self.longReward.increment(rewardLong, position.long);
-        }
-        if (!position.short.isZero()) {
-            rewardShort = elapsed.mul(marketParameter.shortRewardRate);
-            self.shortReward.increment(rewardShort, position.short);
-        }
     }
 }
 

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -968,7 +968,6 @@ describe('Happy Path', () => {
 
   it('delayed update w/ collateral (gas)', async () => {
     const positionFeesOn = true
-    const incentizesOn = true
 
     const POSITION = parse6decimal('0.0001')
     const COLLATERAL = parse6decimal('1000')
@@ -1012,9 +1011,9 @@ describe('Happy Path', () => {
       maxPendingGlobal: 8,
       maxPendingLocal: 8,
       positionFee: positionFeesOn ? parse6decimal('0.1') : 0,
-      makerRewardRate: incentizesOn ? parse6decimal('0.01') : 0,
-      longRewardRate: incentizesOn ? parse6decimal('0.001') : 0,
-      shortRewardRate: incentizesOn ? parse6decimal('0.001') : 0,
+      makerRewardRate: 0,
+      longRewardRate: 0,
+      shortRewardRate: 0,
       makerCloseAlways: false,
       takerCloseAlways: false,
       closed: false,
@@ -1050,7 +1049,7 @@ describe('Happy Path', () => {
       currentId: 3,
       latestId: 2,
       collateral: '986127025',
-      reward: incentizesOn ? '24669998' : 0,
+      reward: 0,
       protection: 0,
     })
     expectPositionEq(await market.pendingPositions(user.address, 3), {
@@ -1092,8 +1091,8 @@ describe('Happy Path', () => {
       makerValue: { _value: '-354909471518' },
       longValue: { _value: '362096873938' },
       shortValue: { _value: 0 },
-      makerReward: { _value: incentizesOn ? '606836363635' : 0 },
-      longReward: { _value: incentizesOn ? '60683636363' : 0 },
+      makerReward: { _value: 0 },
+      longReward: { _value: 0 },
       shortReward: { _value: 0 },
     })
   })
@@ -1101,7 +1100,6 @@ describe('Happy Path', () => {
   // uncheck skip to see gas results
   it.skip('multi-delayed update w/ collateral (gas)', async () => {
     const positionFeesOn = true
-    const incentizesOn = true
     const delay = 5
     const sync = true
 
@@ -1154,9 +1152,9 @@ describe('Happy Path', () => {
       maxPendingGlobal: 8,
       maxPendingLocal: 8,
       positionFee: positionFeesOn ? parse6decimal('0.1') : 0,
-      makerRewardRate: incentizesOn ? parse6decimal('0.01') : 0,
-      longRewardRate: incentizesOn ? parse6decimal('0.001') : 0,
-      shortRewardRate: incentizesOn ? parse6decimal('0.001') : 0,
+      makerRewardRate: 0,
+      longRewardRate: 0,
+      shortRewardRate: 0,
       makerCloseAlways: false,
       takerCloseAlways: false,
       closed: false,

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -257,7 +257,6 @@ export async function createMarket(
 
   const market = Market__factory.connect(marketAddress, owner)
   await market.updateRiskParameter(riskParameter)
-  await market.updateReward(rewardToken.address)
   await market.updateParameter(beneficiaryB.address, constants.AddressZero, marketParameter)
 
   return market

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -442,9 +442,9 @@ describe('Market', () => {
       maxPendingGlobal: 5,
       maxPendingLocal: 3,
       settlementFee: 0,
-      makerRewardRate: parse6decimal('0.3'),
-      longRewardRate: parse6decimal('0.2'),
-      shortRewardRate: parse6decimal('0.1'),
+      makerRewardRate: parse6decimal('0.0'),
+      longRewardRate: parse6decimal('0.0'),
+      shortRewardRate: parse6decimal('0.0'),
       makerCloseAlways: false,
       takerCloseAlways: false,
       closed: false,
@@ -535,17 +535,15 @@ describe('Market', () => {
         maxPendingGlobal: 5,
         maxPendingLocal: 3,
         settlementFee: parse6decimal('0.09'),
-        makerRewardRate: parse6decimal('0.06'),
-        longRewardRate: parse6decimal('0.07'),
-        shortRewardRate: parse6decimal('0.08'),
+        makerRewardRate: parse6decimal('0.00'),
+        longRewardRate: parse6decimal('0.00'),
+        shortRewardRate: parse6decimal('0.00'),
         makerCloseAlways: true,
         takerCloseAlways: true,
         closed: true,
       }
 
       it('updates the parameters', async () => {
-        await market.connect(owner).updateReward(reward.address)
-
         await expect(
           market.connect(owner).updateParameter(beneficiary.address, coordinator.address, defaultMarketParameter),
         )
@@ -565,9 +563,9 @@ describe('Market', () => {
         expect(marketParameter.maxPendingGlobal).to.equal(defaultMarketParameter.maxPendingGlobal)
         expect(marketParameter.maxPendingLocal).to.equal(defaultMarketParameter.maxPendingLocal)
         expect(marketParameter.settlementFee).to.equal(defaultMarketParameter.settlementFee)
-        expect(marketParameter.makerRewardRate).to.equal(defaultMarketParameter.makerRewardRate)
-        expect(marketParameter.longRewardRate).to.equal(defaultMarketParameter.longRewardRate)
-        expect(marketParameter.shortRewardRate).to.equal(defaultMarketParameter.shortRewardRate)
+        expect(marketParameter.makerRewardRate).to.equal(0)
+        expect(marketParameter.longRewardRate).to.equal(0)
+        expect(marketParameter.shortRewardRate).to.equal(0)
         expect(marketParameter.closed).to.equal(defaultMarketParameter.closed)
       })
 
@@ -694,7 +692,6 @@ describe('Market', () => {
 
     describe('#update', async () => {
       beforeEach(async () => {
-        await market.connect(owner).updateReward(reward.address)
         await market.connect(owner).updateParameter(beneficiary.address, coordinator.address, marketParameter)
 
         oracle.at.whenCalledWith(ORACLE_VERSION_0.timestamp).returns(ORACLE_VERSION_0)
@@ -1315,7 +1312,7 @@ describe('Market', () => {
               currentId: 3,
               latestId: 2,
               collateral: COLLATERAL,
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -1353,7 +1350,7 @@ describe('Market', () => {
               makerValue: { _value: 0 },
               longValue: { _value: 0 },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
@@ -1376,7 +1373,7 @@ describe('Market', () => {
               currentId: 2,
               latestId: 1,
               collateral: COLLATERAL,
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -1411,7 +1408,7 @@ describe('Market', () => {
               makerValue: { _value: 0 },
               longValue: { _value: 0 },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
@@ -1446,7 +1443,7 @@ describe('Market', () => {
               currentId: 2,
               latestId: 1,
               collateral: COLLATERAL.sub(MAKER_FEE).sub(SETTLEMENT_FEE),
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -1481,7 +1478,7 @@ describe('Market', () => {
               makerValue: { _value: 0 },
               longValue: { _value: 0 },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
@@ -1684,7 +1681,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL,
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -1715,7 +1712,7 @@ describe('Market', () => {
                 makerValue: { _value: 0 },
                 longValue: { _value: 0 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
@@ -1789,7 +1786,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL,
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -1820,7 +1817,7 @@ describe('Market', () => {
                 makerValue: { _value: 0 },
                 longValue: { _value: 0 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
@@ -1842,7 +1839,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL,
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -1875,7 +1872,7 @@ describe('Market', () => {
                 makerValue: { _value: 0 },
                 longValue: { _value: 0 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
@@ -1903,7 +1900,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: COLLATERAL,
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -1934,7 +1931,7 @@ describe('Market', () => {
                 makerValue: { _value: 0 },
                 longValue: { _value: 0 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).add(EXPECTED_REWARD.mul(3).div(5)) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
@@ -1958,7 +1955,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL,
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -1989,7 +1986,7 @@ describe('Market', () => {
                 makerValue: { _value: 0 },
                 longValue: { _value: 0 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
@@ -2027,7 +2024,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL.sub(MAKER_FEE).add(MAKER_FEE_WITHOUT_FEE).sub(SETTLEMENT_FEE),
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -2058,7 +2055,7 @@ describe('Market', () => {
                 makerValue: { _value: MAKER_FEE_WITHOUT_FEE.div(10) },
                 longValue: { _value: 0 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
@@ -2391,7 +2388,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -2411,7 +2408,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -2451,8 +2448,8 @@ describe('Market', () => {
                 },
                 longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -2485,7 +2482,7 @@ describe('Market', () => {
                 currentId: 2,
                 latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -2505,7 +2502,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -2545,8 +2542,8 @@ describe('Market', () => {
                 },
                 longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -2595,7 +2592,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(TAKER_FEE)
                   .sub(SETTLEMENT_FEE),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -2615,7 +2612,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -2655,8 +2652,8 @@ describe('Market', () => {
                 },
                 longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -2713,7 +2710,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(TAKER_FEE)
                   .sub(SETTLEMENT_FEE),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -2736,7 +2733,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -2778,8 +2775,8 @@ describe('Market', () => {
                 },
                 longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -2995,7 +2992,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -3013,7 +3010,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -3053,8 +3050,8 @@ describe('Market', () => {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
               })
@@ -3131,7 +3128,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -3149,7 +3146,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -3189,8 +3186,8 @@ describe('Market', () => {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
               })
@@ -3214,7 +3211,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -3233,7 +3230,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -3274,8 +3271,8 @@ describe('Market', () => {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
               })
@@ -3307,7 +3304,7 @@ describe('Market', () => {
                     .sub(EXPECTED_FUNDING_WITH_FEE_2_25_123)
                     .sub(EXPECTED_INTEREST_5_123)
                     .sub(EXPECTED_INTEREST_25_123),
-                  reward: EXPECTED_REWARD.mul(2).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -3327,7 +3324,7 @@ describe('Market', () => {
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_25_123)
                     .sub(13), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -3369,8 +3366,8 @@ describe('Market', () => {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
@@ -3388,8 +3385,8 @@ describe('Market', () => {
                       .mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5).add(EXPECTED_REWARD.mul(2).mul(2).div(5)) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
               })
@@ -3413,7 +3410,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -3431,7 +3428,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -3471,8 +3468,8 @@ describe('Market', () => {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
               })
@@ -3514,7 +3511,7 @@ describe('Market', () => {
                     .sub(EXPECTED_INTEREST_5_123)
                     .sub(TAKER_FEE)
                     .sub(SETTLEMENT_FEE),
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -3533,7 +3530,7 @@ describe('Market', () => {
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .add(TAKER_FEE_WITHOUT_FEE)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -3575,8 +3572,8 @@ describe('Market', () => {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
                   shortValue: { _value: 0 },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
                   shortReward: { _value: 0 },
                 })
               })
@@ -3736,7 +3733,7 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                 .sub(EXPECTED_INTEREST_5_123),
-              reward: EXPECTED_REWARD.mul(2),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -3757,7 +3754,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(8), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -3801,8 +3798,8 @@ describe('Market', () => {
                 _value: EXPECTED_PNL.add(EXPECTED_FUNDING_WITH_FEE_1_5_123).add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
               },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-              longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+              makerReward: { _value: 0 },
+              longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
           })
@@ -3863,7 +3860,7 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                 .sub(EXPECTED_INTEREST_5_123),
-              reward: EXPECTED_REWARD.mul(2),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -3884,7 +3881,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(8), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -3929,8 +3926,8 @@ describe('Market', () => {
                 _value: EXPECTED_PNL.add(EXPECTED_FUNDING_WITH_FEE_1_5_123).add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
               },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-              longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+              makerReward: { _value: 0 },
+              longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
           })
@@ -4008,7 +4005,7 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_2_5_150)
                   .sub(EXPECTED_INTEREST_5_150)
                   .sub(5), // loss of precision
-                reward: EXPECTED_REWARD.mul(2).mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -4032,7 +4029,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_150)
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(22), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -4081,8 +4078,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
@@ -4102,8 +4099,8 @@ describe('Market', () => {
                     .sub(1), // loss of precision
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
@@ -4123,8 +4120,8 @@ describe('Market', () => {
                     .sub(1), // loss of precision
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(3) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -4209,7 +4206,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_3)
                   .add(EXPECTED_PNL)
                   .sub(5), // loss of precision
-                reward: EXPECTED_REWARD.mul(2).mul(3),
+                reward: 0,
               })
               expectLocalEq(await market.locals(liquidator.address), {
                 ...DEFAULT_LOCAL,
@@ -4238,7 +4235,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_150.add(EXPECTED_INTEREST_WITHOUT_FEE_2).mul(4).div(5))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(16), // loss of precision
-                reward: EXPECTED_REWARD.mul(4).div(5).mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -4263,7 +4260,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_3_25_123.add(EXPECTED_INTEREST_WITHOUT_FEE_3))
                   .sub(EXPECTED_PNL)
                   .sub(12), // loss of precision
-                reward: EXPECTED_REWARD.div(5).mul(3).mul(2).add(EXPECTED_REWARD.mul(3)),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userC.address), {
                 ...DEFAULT_POSITION,
@@ -4314,8 +4311,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(25) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
@@ -4334,8 +4331,8 @@ describe('Market', () => {
                     .sub(1), // loss of precision
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(25).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
@@ -4358,10 +4355,8 @@ describe('Market', () => {
                     .sub(1), // loss of precision
                 },
                 shortValue: { _value: 0 },
-                makerReward: {
-                  _value: EXPECTED_REWARD.mul(3).mul(2).div(25).mul(2).add(EXPECTED_REWARD.mul(3).mul(2).div(5)),
-                },
-                longReward: { _value: EXPECTED_REWARD.mul(2).mul(3).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -4401,7 +4396,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
                   .add(EXPECTED_PNL),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -4423,7 +4418,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(EXPECTED_PNL)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -4472,8 +4467,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
 
@@ -4523,7 +4518,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -4603,7 +4598,7 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
                   .sub(EXPECTED_FUNDING_WITH_FEE_2_5_96.add(EXPECTED_INTEREST_5_96))
                   .sub(EXPECTED_LIQUIDATION_FEE),
-                reward: EXPECTED_REWARD.mul(2).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -4633,7 +4628,7 @@ describe('Market', () => {
                 )
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_5_96))
                   .sub(20), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -4680,8 +4675,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
@@ -4698,8 +4693,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
@@ -4716,8 +4711,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(3) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
             })
@@ -4761,7 +4756,7 @@ describe('Market', () => {
                 collateral: parse6decimal('216')
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
                   .sub(EXPECTED_PNL),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -4785,7 +4780,7 @@ describe('Market', () => {
                 )
                   .add(EXPECTED_PNL)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -4831,8 +4826,8 @@ describe('Market', () => {
                     .mul(-1),
                 },
                 shortValue: { _value: 0 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
                 shortReward: { _value: 0 },
               })
 
@@ -4872,7 +4867,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                reward: EXPECTED_REWARD.mul(2).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -5341,7 +5336,7 @@ describe('Market', () => {
                 currentId: 3,
                 latestId: 2,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                reward: EXPECTED_REWARD,
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -5361,7 +5356,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -5401,9 +5396,9 @@ describe('Market', () => {
                 },
                 longValue: { _value: 0 },
                 shortValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -5439,7 +5434,7 @@ describe('Market', () => {
                 currentId: 2,
                 latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                reward: EXPECTED_REWARD,
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -5459,7 +5454,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -5499,9 +5494,9 @@ describe('Market', () => {
                 },
                 longValue: { _value: 0 },
                 shortValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -5554,7 +5549,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(TAKER_FEE)
                   .sub(SETTLEMENT_FEE),
-                reward: EXPECTED_REWARD,
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -5574,7 +5569,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -5614,9 +5609,9 @@ describe('Market', () => {
                 },
                 longValue: { _value: 0 },
                 shortValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -5675,7 +5670,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(TAKER_FEE)
                   .sub(SETTLEMENT_FEE),
-                reward: EXPECTED_REWARD,
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -5697,7 +5692,7 @@ describe('Market', () => {
                     EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123),
                   ),
                 ).sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -5739,9 +5734,9 @@ describe('Market', () => {
                 },
                 longValue: { _value: 0 },
                 shortValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
             })
           })
@@ -5956,7 +5951,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD,
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -5974,7 +5969,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -6014,9 +6009,9 @@ describe('Market', () => {
                   shortValue: {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5) },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -6092,7 +6087,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD,
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -6110,7 +6105,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -6150,9 +6145,9 @@ describe('Market', () => {
                   shortValue: {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5) },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -6174,7 +6169,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD,
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -6193,7 +6188,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -6234,9 +6229,9 @@ describe('Market', () => {
                   shortValue: {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5) },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -6267,7 +6262,7 @@ describe('Market', () => {
                     .sub(EXPECTED_FUNDING_WITH_FEE_2_25_123)
                     .sub(EXPECTED_INTEREST_5_123)
                     .sub(EXPECTED_INTEREST_25_123),
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -6287,7 +6282,7 @@ describe('Market', () => {
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_25_123)
                     .sub(13), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -6329,9 +6324,9 @@ describe('Market', () => {
                   shortValue: {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5) },
+                  shortReward: { _value: 0 },
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                   makerValue: {
@@ -6348,9 +6343,9 @@ describe('Market', () => {
                       .add(EXPECTED_FUNDING_WITH_FEE_2_25_123.add(EXPECTED_INTEREST_25_123).mul(2).div(5))
                       .mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5).add(EXPECTED_REWARD.mul(2).div(5)) },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -6373,7 +6368,7 @@ describe('Market', () => {
                   currentId: 3,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-                  reward: EXPECTED_REWARD,
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -6391,7 +6386,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -6431,9 +6426,9 @@ describe('Market', () => {
                   shortValue: {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5) },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -6475,7 +6470,7 @@ describe('Market', () => {
                     .sub(EXPECTED_INTEREST_5_123)
                     .sub(TAKER_FEE)
                     .sub(SETTLEMENT_FEE),
-                  reward: EXPECTED_REWARD,
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -6494,7 +6489,7 @@ describe('Market', () => {
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                     .add(TAKER_FEE_WITHOUT_FEE)
                     .sub(8), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -6536,9 +6531,9 @@ describe('Market', () => {
                   shortValue: {
                     _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+                  makerReward: { _value: 0 },
                   longReward: { _value: 0 },
-                  shortReward: { _value: EXPECTED_REWARD.div(5) },
+                  shortReward: { _value: 0 },
                 })
               })
             })
@@ -6697,7 +6692,7 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                 .sub(EXPECTED_INTEREST_5_123),
-              reward: EXPECTED_REWARD,
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -6718,7 +6713,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(8), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -6763,9 +6758,9 @@ describe('Market', () => {
               shortValue: {
                 _value: EXPECTED_PNL.add(EXPECTED_FUNDING_WITH_FEE_1_5_123).add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
               },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
-              shortReward: { _value: EXPECTED_REWARD.div(5) },
+              shortReward: { _value: 0 },
             })
           })
 
@@ -6825,7 +6820,7 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                 .sub(EXPECTED_INTEREST_5_123),
-              reward: EXPECTED_REWARD,
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -6846,7 +6841,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(8), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -6890,9 +6885,9 @@ describe('Market', () => {
               shortValue: {
                 _value: EXPECTED_PNL.add(EXPECTED_FUNDING_WITH_FEE_1_5_123).add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
               },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
-              shortReward: { _value: EXPECTED_REWARD.div(5) },
+              shortReward: { _value: 0 },
             })
           })
         })
@@ -6971,7 +6966,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123)).sub(
                   EXPECTED_FUNDING_WITH_FEE_2_5_96.add(EXPECTED_INTEREST_5_96),
                 ),
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -6993,7 +6988,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_5_96))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(20), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -7042,9 +7037,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 makerValue: {
@@ -7060,9 +7055,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5).mul(2) },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
                 makerValue: {
@@ -7078,9 +7073,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5).mul(3) },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -7170,7 +7165,7 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_3_25_123)
                   .sub(EXPECTED_INTEREST_3)
                   .add(EXPECTED_PNL),
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -7192,7 +7187,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_2).mul(4).div(5))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(17), // loss of precision
-                reward: EXPECTED_REWARD.mul(4).div(5).mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -7217,7 +7212,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_3_25_123.add(EXPECTED_INTEREST_WITHOUT_FEE_3))
                   .sub(EXPECTED_PNL)
                   .sub(12), // loss of precision
-                reward: EXPECTED_REWARD.div(5).mul(3).mul(2).add(EXPECTED_REWARD.mul(3)),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userC.address), {
                 ...DEFAULT_POSITION,
@@ -7268,9 +7263,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(25) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 makerValue: {
@@ -7287,9 +7282,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(25).mul(2) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
                 makerValue: {
@@ -7310,11 +7305,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: {
-                  _value: EXPECTED_REWARD.mul(3).mul(2).div(25).mul(2).add(EXPECTED_REWARD.mul(3).mul(2).div(5)),
-                },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.mul(3).div(5) },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -7353,7 +7346,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123)).add(
                   EXPECTED_PNL,
                 ),
-                reward: EXPECTED_REWARD,
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -7374,7 +7367,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
                   .sub(EXPECTED_PNL)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -7418,9 +7411,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
 
               const oracleVersionHigherPrice2 = {
@@ -7467,7 +7460,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -7556,7 +7549,7 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_2_5_150)
                   .sub(EXPECTED_INTEREST_5_150)
                   .sub(EXPECTED_LIQUIDATION_FEE),
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -7579,7 +7572,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_150)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_150)
                   .sub(22), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -7626,9 +7619,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 makerValue: {
@@ -7646,9 +7639,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5).mul(2) },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
                 makerValue: {
@@ -7666,9 +7659,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(3) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5).mul(2) },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -7712,7 +7705,7 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(EXPECTED_PNL),
-                reward: EXPECTED_REWARD,
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -7735,7 +7728,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .add(EXPECTED_PNL)
                   .sub(8), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -7781,9 +7774,9 @@ describe('Market', () => {
                     .div(5)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+                makerReward: { _value: 0 },
                 longReward: { _value: 0 },
-                shortReward: { _value: EXPECTED_REWARD.div(5) },
+                shortReward: { _value: 0 },
               })
 
               const oracleVersionHigherPrice2 = {
@@ -7831,7 +7824,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -8483,7 +8476,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -8503,7 +8496,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -8558,9 +8551,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -8594,7 +8587,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -8614,7 +8607,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -8669,9 +8662,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -8720,7 +8713,7 @@ describe('Market', () => {
                   .sub(TAKER_FEE)
                   .sub(SETTLEMENT_FEE)
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -8740,7 +8733,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -8795,9 +8788,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -8831,7 +8824,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -8851,7 +8844,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -8906,9 +8899,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -8943,7 +8936,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -8964,7 +8957,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -9019,9 +9012,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -9055,7 +9048,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -9075,7 +9068,7 @@ describe('Market', () => {
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -9130,9 +9123,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -9167,7 +9160,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -9188,7 +9181,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -9243,9 +9236,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
           })
@@ -9442,7 +9435,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                     .sub(2), // loss of precision
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -9460,7 +9453,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                     .sub(13), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -9513,9 +9506,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(1), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                  shortReward: { _value: EXPECTED_REWARD.div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -9595,7 +9588,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                     .sub(2), // loss of precision
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -9613,7 +9606,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                     .sub(13), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -9666,9 +9659,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(1), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                  shortReward: { _value: EXPECTED_REWARD.div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -9693,7 +9686,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                     .sub(2), // loss of precision
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -9712,7 +9705,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                     .sub(13), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -9766,9 +9759,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(1), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                  shortReward: { _value: EXPECTED_REWARD.div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -9799,7 +9792,7 @@ describe('Market', () => {
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                     .sub(EXPECTED_INTEREST_10_80_123_ALL.div(5))
                     .sub(3), // loss of precision
-                  reward: EXPECTED_REWARD.mul(2).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -9819,7 +9812,7 @@ describe('Market', () => {
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_80_123_ALL)
                     .sub(38), // loss of precision
-                  reward: EXPECTED_REWARD.mul(3).mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(userB.address), {
                   ...DEFAULT_POSITION,
@@ -9874,9 +9867,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(1), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                  shortReward: { _value: EXPECTED_REWARD.div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                   makerValue: {
@@ -9910,9 +9903,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(2), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5).add(EXPECTED_REWARD.mul(2).mul(2).div(5)) },
-                  shortReward: { _value: EXPECTED_REWARD.mul(2).div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -9937,7 +9930,7 @@ describe('Market', () => {
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                     .sub(2), // loss of precision
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -9979,9 +9972,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(1), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                  shortReward: { _value: EXPECTED_REWARD.div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
               })
 
@@ -10023,7 +10016,7 @@ describe('Market', () => {
                     .sub(TAKER_FEE)
                     .sub(SETTLEMENT_FEE)
                     .sub(2), // loss of precision
-                  reward: EXPECTED_REWARD.mul(2),
+                  reward: 0,
                 })
                 expectPositionEq(await market.positions(user.address), {
                   ...DEFAULT_POSITION,
@@ -10066,9 +10059,9 @@ describe('Market', () => {
                       .mul(-1)
                       .sub(1), // loss of precision
                   },
-                  makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                  longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                  shortReward: { _value: EXPECTED_REWARD.div(10) },
+                  makerReward: { _value: 0 },
+                  longReward: { _value: 0 },
+                  shortReward: { _value: 0 },
                 })
               })
             })
@@ -10237,7 +10230,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                 .sub(2), // loss of precision
-              reward: EXPECTED_REWARD.mul(2),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -10258,7 +10251,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                 .sub(13), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -10316,9 +10309,9 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.mul(2).div(3))
                   .div(10),
               },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-              longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-              shortReward: { _value: EXPECTED_REWARD.div(10) },
+              makerReward: { _value: 0 },
+              longReward: { _value: 0 },
+              shortReward: { _value: 0 },
             })
           })
 
@@ -10384,7 +10377,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                 .sub(2), // loss of precision
-              reward: EXPECTED_REWARD.mul(2),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -10405,7 +10398,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                 .sub(13), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -10463,9 +10456,9 @@ describe('Market', () => {
                   .div(10)
                   .sub(1), // loss of precision
               },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-              longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-              shortReward: { _value: EXPECTED_REWARD.div(10) },
+              makerReward: { _value: 0 },
+              longReward: { _value: 0 },
+              shortReward: { _value: 0 },
             })
           })
         })
@@ -10547,7 +10540,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_45_ALL.div(3))
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_3_10_123_ALL)
                   .sub(9), // loss of precision
-                reward: EXPECTED_REWARD.mul(2).mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -10571,7 +10564,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_45_ALL)
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(25), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -10630,9 +10623,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 makerValue: {
@@ -10658,9 +10651,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
-                shortReward: { _value: EXPECTED_REWARD.div(10).mul(2) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
                 makerValue: {
@@ -10690,9 +10683,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(3) },
-                shortReward: { _value: EXPECTED_REWARD.div(10).mul(3) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -10793,7 +10786,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_3.div(3))
                   .sub(EXPECTED_PNL)
                   .sub(6), // loss of precision
-                reward: EXPECTED_REWARD.mul(2).mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -10817,7 +10810,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_2.mul(10).div(12))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(19), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(2).mul(10).div(12),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -10879,9 +10872,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(12) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 makerValue: {
@@ -10908,9 +10901,9 @@ describe('Market', () => {
                     .mul(-1)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(12).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
-                shortReward: { _value: EXPECTED_REWARD.div(10).mul(2) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
                 makerValue: {
@@ -10949,9 +10942,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(12).mul(2).add(EXPECTED_REWARD.mul(3).div(2)) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(3) },
-                shortReward: { _value: EXPECTED_REWARD.div(10).mul(3) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -10991,7 +10984,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(EXPECTED_PNL)
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -11013,7 +11006,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(EXPECTED_PNL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -11071,9 +11064,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
 
               const oracleVersionHigherPrice2 = {
@@ -11122,7 +11115,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                reward: EXPECTED_REWARD.mul(3).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -11229,7 +11222,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_96_ALL.div(3))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(9), // loss of precision
-                reward: EXPECTED_REWARD.mul(2).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -11255,7 +11248,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_3)
                   .sub(EXPECTED_PNL.mul(2))
                   .sub(45), // loss of precision
-                reward: EXPECTED_REWARD.mul(3).mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -11314,9 +11307,9 @@ describe('Market', () => {
                     .mul(-1)
                     .div(10),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 makerValue: {
@@ -11343,9 +11336,9 @@ describe('Market', () => {
                     .div(10)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
-                shortReward: { _value: EXPECTED_REWARD.div(10).mul(2) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
                 makerValue: {
@@ -11378,9 +11371,9 @@ describe('Market', () => {
                     .div(10)
                     .sub(1), // loss of precision
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(3) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5).mul(2) },
-                shortReward: { _value: EXPECTED_REWARD.div(10).mul(3) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
             })
 
@@ -11439,7 +11432,7 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(EXPECTED_PNL)
                   .sub(2), // loss of precision
-                reward: EXPECTED_REWARD.mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -11462,7 +11455,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(EXPECTED_PNL)
                   .sub(13), // loss of precision
-                reward: EXPECTED_REWARD.mul(3),
+                reward: 0,
               })
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
@@ -11518,9 +11511,9 @@ describe('Market', () => {
                     .div(10)
                     .mul(-1),
                 },
-                makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-                longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-                shortReward: { _value: EXPECTED_REWARD.div(10) },
+                makerReward: { _value: 0 },
+                longReward: { _value: 0 },
+                shortReward: { _value: 0 },
               })
 
               const oracleVersionLowerPrice2 = {
@@ -11569,7 +11562,7 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                reward: EXPECTED_REWARD.mul(2).mul(2),
+                reward: 0,
                 protection: ORACLE_VERSION_4.timestamp,
                 protectionAmount: EXPECTED_LIQUIDATION_FEE,
                 protectionInitiator: liquidator.address,
@@ -12366,7 +12359,7 @@ describe('Market', () => {
             collateral: parse6decimal('216')
               .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
               .sub(EXPECTED_PNL),
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
             protection: ORACLE_VERSION_4.timestamp,
             protectionAmount: EXPECTED_LIQUIDATION_FEE,
             protectionInitiator: liquidator.address,
@@ -12388,7 +12381,7 @@ describe('Market', () => {
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
               .add(EXPECTED_PNL)
               .sub(8), // loss of precision
-            reward: EXPECTED_REWARD.mul(3),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -12431,8 +12424,8 @@ describe('Market', () => {
               _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).add(EXPECTED_PNL).div(5).mul(-1),
             },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-            longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+            makerReward: { _value: 0 },
+            longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
         })
@@ -12514,7 +12507,7 @@ describe('Market', () => {
               .sub(EXPECTED_FUNDING_WITH_FEE_2_5_150)
               .sub(EXPECTED_INTEREST_5_150)
               .sub(EXPECTED_LIQUIDATION_FEE),
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
             protection: ORACLE_VERSION_4.timestamp,
             protectionAmount: EXPECTED_LIQUIDATION_FEE,
             protectionInitiator: liquidator.address,
@@ -12537,7 +12530,7 @@ describe('Market', () => {
               .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_150)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_150)
               .sub(22), // loss of precision
-            reward: EXPECTED_REWARD.mul(3).mul(3),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -12581,9 +12574,9 @@ describe('Market', () => {
             shortValue: {
               _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).add(EXPECTED_PNL).div(5).mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
-            shortReward: { _value: EXPECTED_REWARD.div(5) },
+            shortReward: { _value: 0 },
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
             makerValue: {
@@ -12601,9 +12594,9 @@ describe('Market', () => {
                 .div(5)
                 .mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
-            shortReward: { _value: EXPECTED_REWARD.div(5).mul(2) },
+            shortReward: { _value: 0 },
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
             makerValue: {
@@ -12621,9 +12614,9 @@ describe('Market', () => {
                 .div(5)
                 .mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(3) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
-            shortReward: { _value: EXPECTED_REWARD.div(5).mul(2) },
+            shortReward: { _value: 0 },
           })
         })
       })
@@ -12796,7 +12789,7 @@ describe('Market', () => {
               .sub(EXPECTED_INTEREST_5_150)
               .sub(EXPECTED_ROUND_3_ACC)
               .sub(EXPECTED_LIQUIDATION_FEE), // does not double charge
-            reward: EXPECTED_REWARD.mul(3),
+            reward: 0,
             protection: ORACLE_VERSION_5.timestamp,
             protectionAmount: EXPECTED_LIQUIDATION_FEE,
             protectionInitiator: liquidator.address,
@@ -12820,7 +12813,7 @@ describe('Market', () => {
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_150)
               .add(EXPECTED_ROUND_3_ACC_WITHOUT_FEE)
               .sub(32), // loss of precision
-            reward: EXPECTED_REWARD.mul(3).mul(4),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -12865,9 +12858,9 @@ describe('Market', () => {
             shortValue: {
               _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).add(EXPECTED_PNL).div(5).mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
-            shortReward: { _value: EXPECTED_REWARD.div(5) },
+            shortReward: { _value: 0 },
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
             makerValue: {
@@ -12887,9 +12880,9 @@ describe('Market', () => {
                 .div(5)
                 .mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(2) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
-            shortReward: { _value: EXPECTED_REWARD.div(5).mul(2) },
+            shortReward: { _value: 0 },
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_5.timestamp), {
             makerValue: {
@@ -12909,9 +12902,9 @@ describe('Market', () => {
                 .div(5)
                 .mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10).mul(3) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
-            shortReward: { _value: EXPECTED_REWARD.div(5).mul(3) },
+            shortReward: { _value: 0 },
           })
         })
       })
@@ -12984,7 +12977,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL,
-            reward: EXPECTED_REWARD.mul(3),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13042,7 +13035,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13127,7 +13120,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL.add(TAKER_FEE_WITHOUT_FEE),
-            reward: EXPECTED_REWARD.mul(3).mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13192,7 +13185,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13200,7 +13193,7 @@ describe('Market', () => {
             makerValue: { _value: TAKER_FEE_WITHOUT_FEE.div(10) },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13285,7 +13278,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL,
-            reward: EXPECTED_REWARD.mul(3).mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13350,7 +13343,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13358,7 +13351,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13443,7 +13436,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL,
-            reward: EXPECTED_REWARD.mul(3).mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13508,7 +13501,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13516,7 +13509,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13617,7 +13610,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL.add(TAKER_FEE_WITHOUT_FEE),
-            reward: EXPECTED_REWARD.mul(3).mul(3),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13689,7 +13682,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13697,7 +13690,7 @@ describe('Market', () => {
             makerValue: { _value: 0 },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13705,7 +13698,7 @@ describe('Market', () => {
             makerValue: { _value: TAKER_FEE_WITHOUT_FEE.div(10) },
             longValue: { _value: 0 },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(3).div(10) },
+            makerReward: { _value: 0 },
             longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
@@ -13730,7 +13723,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
@@ -13750,7 +13743,7 @@ describe('Market', () => {
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
               .sub(8), // loss of precision
-            reward: EXPECTED_REWARD.mul(3),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13790,8 +13783,8 @@ describe('Market', () => {
             },
             longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
             shortValue: { _value: 0 },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-            longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+            makerReward: { _value: 0 },
+            longReward: { _value: 0 },
             shortReward: { _value: 0 },
           })
         })
@@ -13829,7 +13822,7 @@ describe('Market', () => {
             currentId: 3,
             latestId: 2,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
@@ -13849,7 +13842,7 @@ describe('Market', () => {
               .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
               .sub(16), // loss of precision
-            reward: EXPECTED_REWARD.mul(3).mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13867,7 +13860,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-            reward: EXPECTED_REWARD,
+            reward: 0,
           })
           expectPositionEq(await market.positions(userC.address), {
             ...DEFAULT_POSITION,
@@ -13917,9 +13910,9 @@ describe('Market', () => {
             shortValue: {
               _value: EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.sub(EXPECTED_INTEREST_5_123).div(5),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-            longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-            shortReward: { _value: EXPECTED_REWARD.div(5) },
+            makerReward: { _value: 0 },
+            longReward: { _value: 0 },
+            shortReward: { _value: 0 },
           })
         })
 
@@ -13951,7 +13944,7 @@ describe('Market', () => {
             currentId: 3,
             latestId: 2,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
@@ -13971,7 +13964,7 @@ describe('Market', () => {
               .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
               .sub(16), // loss of precision
-            reward: EXPECTED_REWARD.mul(3).mul(2),
+            reward: 0,
           })
           expectPositionEq(await market.positions(userB.address), {
             ...DEFAULT_POSITION,
@@ -13989,7 +13982,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-            reward: EXPECTED_REWARD,
+            reward: 0,
           })
           expectPositionEq(await market.positions(userC.address), {
             ...DEFAULT_POSITION,
@@ -14039,9 +14032,9 @@ describe('Market', () => {
             shortValue: {
               _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
             },
-            makerReward: { _value: EXPECTED_REWARD.mul(3).mul(2).div(10) },
-            longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
-            shortReward: { _value: EXPECTED_REWARD.div(5) },
+            makerReward: { _value: 0 },
+            longReward: { _value: 0 },
+            shortReward: { _value: 0 },
           })
         })
       })
@@ -14139,7 +14132,7 @@ describe('Market', () => {
             currentId: 3,
             latestId: 2,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
@@ -14148,7 +14141,7 @@ describe('Market', () => {
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
               .sub(8), // loss of precision
-            reward: EXPECTED_REWARD.mul(3),
+            reward: 0,
           })
 
           dsu.transfer
@@ -14174,14 +14167,14 @@ describe('Market', () => {
             currentId: 3,
             latestId: 2,
             collateral: 0,
-            reward: EXPECTED_REWARD.mul(2),
+            reward: 0,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
             currentId: 3,
             latestId: 2,
             collateral: 0,
-            reward: EXPECTED_REWARD.mul(3),
+            reward: 0,
           })
         })
 
@@ -14765,7 +14758,6 @@ describe('Market', () => {
           marketDefinition.payoff = payoff.address
           await marketPayoff.connect(factorySigner).initialize(marketDefinition)
           await marketPayoff.connect(owner).updateRiskParameter(riskParameter)
-          await marketPayoff.connect(owner).updateReward(reward.address)
           await marketPayoff.connect(owner).updateParameter(beneficiary.address, coordinator.address, marketParameter)
 
           dsu.transferFrom.whenCalledWith(user.address, marketPayoff.address, COLLATERAL.mul(1e12)).returns(true)
@@ -14807,7 +14799,7 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123_P2)
                 .sub(EXPECTED_INTEREST_5_123_P2),
-              reward: EXPECTED_REWARD.mul(2),
+              reward: 0,
             })
             expectPositionEq(await marketPayoff.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -14828,7 +14820,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123_P2)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123_P2)
                 .sub(19), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await marketPayoff.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -14876,8 +14868,8 @@ describe('Market', () => {
                   .mul(-1),
               },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-              longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+              makerReward: { _value: 0 },
+              longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
           })
@@ -14919,7 +14911,7 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123_P2)
                 .sub(EXPECTED_INTEREST_5_123_P2),
-              reward: EXPECTED_REWARD,
+              reward: 0,
             })
             expectPositionEq(await marketPayoff.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -14940,7 +14932,7 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123_P2)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123_P2)
                 .sub(19), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await marketPayoff.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -14988,9 +14980,9 @@ describe('Market', () => {
                   .div(5)
                   .mul(-1),
               },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
-              shortReward: { _value: EXPECTED_REWARD.div(5) },
+              shortReward: { _value: 0 },
             })
           })
         })
@@ -15041,7 +15033,7 @@ describe('Market', () => {
               currentId: 3,
               latestId: 2,
               collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123_V).sub(EXPECTED_INTEREST_5_123),
-              reward: EXPECTED_REWARD.mul(2),
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -15061,7 +15053,7 @@ describe('Market', () => {
               collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123_V)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(13), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -15103,8 +15095,8 @@ describe('Market', () => {
                 _value: EXPECTED_FUNDING_WITH_FEE_1_5_123_V.add(EXPECTED_INTEREST_5_123).div(5).mul(-1),
               },
               shortValue: { _value: 0 },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
-              longReward: { _value: EXPECTED_REWARD.mul(2).div(5) },
+              makerReward: { _value: 0 },
+              longReward: { _value: 0 },
               shortReward: { _value: 0 },
             })
           })
@@ -15151,7 +15143,7 @@ describe('Market', () => {
               currentId: 3,
               latestId: 2,
               collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123_V).sub(EXPECTED_INTEREST_5_123).add(5), // excess fundingFee taken from long
-              reward: EXPECTED_REWARD,
+              reward: 0,
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -15171,7 +15163,7 @@ describe('Market', () => {
               collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123_V)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(13), // loss of precision
-              reward: EXPECTED_REWARD.mul(3),
+              reward: 0,
             })
             expectPositionEq(await market.positions(userB.address), {
               ...DEFAULT_POSITION,
@@ -15213,9 +15205,9 @@ describe('Market', () => {
               shortValue: {
                 _value: EXPECTED_FUNDING_WITH_FEE_1_5_123_V.add(EXPECTED_INTEREST_5_123).div(5).mul(-1).add(1), // loss of precision (fundingFee)
               },
-              makerReward: { _value: EXPECTED_REWARD.mul(3).div(10) },
+              makerReward: { _value: 0 },
               longReward: { _value: 0 },
-              shortReward: { _value: EXPECTED_REWARD.div(5) },
+              shortReward: { _value: 0 },
             })
           })
 
@@ -15443,7 +15435,6 @@ describe('Market', () => {
       const DONATION = MARKET_FEE.sub(ORACLE_FEE).sub(RISK_FEE)
 
       beforeEach(async () => {
-        await market.connect(owner).updateReward(reward.address)
         await market.updateParameter(beneficiary.address, coordinator.address, {
           ...marketParameter,
           riskFee: parse6decimal('0.2'),

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -3704,8 +3704,8 @@ describe('Market', () => {
                 interestFee: EXPECTED_INTEREST_FEE_5_123,
                 pnlMaker: EXPECTED_PNL,
                 pnlLong: EXPECTED_PNL.mul(-1),
-                rewardMaker: EXPECTED_REWARD.mul(3),
-                rewardLong: EXPECTED_REWARD.mul(2),
+                rewardMaker: 0,
+                rewardLong: 0,
               })
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(user.address, ORACLE_VERSION_2.timestamp, oracleVersionLowerPrice.timestamp, 1, 2, {
@@ -3713,7 +3713,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.mul(-1)
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123),
-                rewardAmount: EXPECTED_REWARD.mul(2),
+                rewardAmount: 0,
               })
 
             await expect(settle(market, userB))
@@ -3723,7 +3723,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8),
-                rewardAmount: EXPECTED_REWARD.mul(3),
+                rewardAmount: 0,
               })
 
             expectLocalEq(await market.locals(user.address), {
@@ -3831,8 +3831,8 @@ describe('Market', () => {
                 interestFee: EXPECTED_INTEREST_FEE_5_123,
                 pnlMaker: EXPECTED_PNL,
                 pnlLong: EXPECTED_PNL.mul(-1),
-                rewardMaker: EXPECTED_REWARD.mul(3),
-                rewardLong: EXPECTED_REWARD.mul(2),
+                rewardMaker: 0,
+                rewardLong: 0,
               })
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(user.address, ORACLE_VERSION_2.timestamp, oracleVersionHigherPrice.timestamp, 1, 2, {
@@ -3840,7 +3840,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.mul(-1)
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123),
-                rewardAmount: EXPECTED_REWARD.mul(2),
+                rewardAmount: 0,
               })
 
             await expect(settle(market, userB))
@@ -3850,7 +3850,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8),
-                rewardAmount: EXPECTED_REWARD.mul(3),
+                rewardAmount: 0,
               })
 
             expectLocalEq(await market.locals(user.address), {
@@ -6663,8 +6663,8 @@ describe('Market', () => {
                 interestFee: EXPECTED_INTEREST_FEE_5_123,
                 pnlMaker: EXPECTED_PNL,
                 pnlShort: EXPECTED_PNL.mul(-1),
-                rewardMaker: EXPECTED_REWARD.mul(3),
-                rewardShort: EXPECTED_REWARD,
+                rewardMaker: 0,
+                rewardShort: 0,
               })
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(user.address, ORACLE_VERSION_2.timestamp, oracleVersionLowerPrice.timestamp, 1, 2, {
@@ -6672,7 +6672,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.mul(-1)
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123),
-                rewardAmount: EXPECTED_REWARD,
+                rewardAmount: 0,
               })
 
             await expect(settle(market, userB))
@@ -6682,7 +6682,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8),
-                rewardAmount: EXPECTED_REWARD.mul(3),
+                rewardAmount: 0,
               })
 
             expectLocalEq(await market.locals(user.address), {
@@ -6791,8 +6791,8 @@ describe('Market', () => {
                 interestFee: EXPECTED_INTEREST_FEE_5_123,
                 pnlMaker: EXPECTED_PNL,
                 pnlShort: EXPECTED_PNL.mul(-1),
-                rewardMaker: EXPECTED_REWARD.mul(3),
-                rewardShort: EXPECTED_REWARD,
+                rewardMaker: 0,
+                rewardShort: 0,
               })
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(user.address, ORACLE_VERSION_2.timestamp, oracleVersionHigherPrice.timestamp, 1, 2, {
@@ -6800,7 +6800,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.mul(-1)
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123),
-                rewardAmount: EXPECTED_REWARD,
+                rewardAmount: 0,
               })
 
             await expect(settle(market, userB))
@@ -6810,7 +6810,7 @@ describe('Market', () => {
                 collateralAmount: EXPECTED_PNL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(8),
-                rewardAmount: EXPECTED_REWARD.mul(3),
+                rewardAmount: 0,
               })
 
             expectLocalEq(await market.locals(user.address), {
@@ -10195,9 +10195,9 @@ describe('Market', () => {
                 pnlMaker: EXPECTED_PNL.div(2).mul(-1),
                 pnlLong: EXPECTED_PNL.div(2).mul(-1),
                 pnlShort: EXPECTED_PNL,
-                rewardMaker: EXPECTED_REWARD.mul(3),
-                rewardLong: EXPECTED_REWARD.mul(2),
-                rewardShort: EXPECTED_REWARD,
+                rewardMaker: 0,
+                rewardLong: 0,
+                rewardShort: 0,
               })
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(user.address, ORACLE_VERSION_2.timestamp, oracleVersionLowerPrice.timestamp, 1, 2, {
@@ -10207,7 +10207,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(2), // loss of precision
-                rewardAmount: EXPECTED_REWARD.mul(2),
+                rewardAmount: 0,
               })
 
             await expect(settle(market, userB))
@@ -10219,7 +10219,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                rewardAmount: EXPECTED_REWARD.mul(3),
+                rewardAmount: 0,
               })
 
             expectLocalEq(await market.locals(user.address), {
@@ -10342,9 +10342,9 @@ describe('Market', () => {
                 pnlMaker: EXPECTED_PNL.div(2).mul(-1),
                 pnlLong: EXPECTED_PNL.div(2).mul(-1),
                 pnlShort: EXPECTED_PNL,
-                rewardMaker: EXPECTED_REWARD.mul(3),
-                rewardLong: EXPECTED_REWARD.mul(2),
-                rewardShort: EXPECTED_REWARD,
+                rewardMaker: 0,
+                rewardLong: 0,
+                rewardShort: 0,
               })
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(user.address, ORACLE_VERSION_2.timestamp, oracleVersionHigherPrice.timestamp, 1, 2, {
@@ -10354,7 +10354,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(2), // loss of precision
-                rewardAmount: EXPECTED_REWARD.mul(2),
+                rewardAmount: 0,
               })
 
             await expect(settle(market, userB))
@@ -10366,7 +10366,7 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(13), // loss of precision
-                rewardAmount: EXPECTED_REWARD.mul(3),
+                rewardAmount: 0,
               })
 
             expectLocalEq(await market.locals(user.address), {

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -1301,40 +1301,6 @@ describe('Version', () => {
           expect(value.shortReward._value).to.equal(0)
         })
       })
-
-      context('positions', () => {
-        it('accumulates rewards', async () => {
-          await version.store(EMPTY_VERSION)
-
-          const { ret, value } = await accumulateWithReturn(
-            GLOBAL,
-            {
-              ...FROM_POSITION,
-              maker: parse6decimal('10'),
-              long: parse6decimal('12'),
-              short: parse6decimal('2'),
-            },
-            { ...TO_POSITION, fee: 0 },
-            ORACLE_VERSION_1,
-            ORACLE_VERSION_2,
-            {
-              ...VALID_MARKET_PARAMETER,
-              makerRewardRate: parse6decimal('0.001'),
-              longRewardRate: parse6decimal('0.002'),
-              shortRewardRate: parse6decimal('0.003'),
-            },
-            VALID_RISK_PARAMETER,
-          )
-
-          expect(ret[0].rewardMaker).to.equal(parse6decimal('3.6'))
-          expect(ret[0].rewardLong).to.equal(parse6decimal('7.2'))
-          expect(ret[0].rewardShort).to.equal(parse6decimal('10.8'))
-
-          expect(value.makerReward._value).to.equal(parse6decimal('0.36'))
-          expect(value.longReward._value).to.equal(parse6decimal('0.6'))
-          expect(value.shortReward._value).to.equal(parse6decimal('5.4'))
-        })
-      })
     })
   })
 })


### PR DESCRIPTION
### Code Size Changeset for v2.1

#### Background
The reward system has not yet been turned on since launch, so there are no reward balances within the system that need to be kept track of for backwards compatibility. This system takes up considerably code complexity within the protocol, and is a good candidate for removal, since we've determined more efficient ways to achieve the same incentivization goals.

For this first pass, we will only remove the minimum changeset required to statifies our codesize requirements, optimizing for least criticial codepaths first.

- Removes the `reward()` token getter and setter so that the reward token cannot be set.
- Removes the `claimReward()` function since there are no reward, and can no longer be any rewards, in the system.
- Removes the `_accumulateReward()` function within `Version` since there cannot be a non-zero reward rate without a non-zero reward token.