### PR TITLE
Vault weight sum to one

### DIFF
--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -30,7 +30,7 @@ function payoff(number: BigNumber): BigNumber {
   return number.mul(number).div(utils.parseEther('1'))
 }
 
-describe.only('Orders', () => {
+describe('Orders', () => {
   let instanceVars: InstanceVars
   let dsuCollateral: BigNumber
   let collateral: BigNumber

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -388,7 +388,7 @@ export async function createVault(
   await vault.register(btcMarket.address)
   await vault.updateLeverage(0, leverage ?? parse6decimal('4.0'))
   await vault.updateLeverage(1, leverage ?? parse6decimal('4.0'))
-  await vault.updateWeights([0.8, 0.2])
+  await vault.updateWeights([parse6decimal('0.8'), parse6decimal('0.2')])
 
   await vault.updateParameter({
     cap: maxCollateral ?? parse6decimal('500000'),

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -386,8 +386,10 @@ export async function createVault(
   await vaultFactory.create(instanceVars.dsu.address, ethMarket.address, 'Blue Chip')
 
   await vault.register(btcMarket.address)
-  await vault.updateMarket(0, 4, leverage ?? parse6decimal('4.0'))
-  await vault.updateMarket(1, 1, leverage ?? parse6decimal('4.0'))
+  await vault.updateLeverage(0, leverage ?? parse6decimal('4.0'))
+  await vault.updateLeverage(1, leverage ?? parse6decimal('4.0'))
+  await vault.updateWeights([0.8, 0.2])
+
   await vault.updateParameter({
     cap: maxCollateral ?? parse6decimal('500000'),
   })

--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -161,17 +161,23 @@ contract Vault is IVault, Instance {
 
         asset.approve(address(market));
 
-        uint256 newMarketId = totalMarkets++;
-        _registerMarket(newMarketId, market);
+        uint256 newMarketId = _registerMarket(market);
         _updateMarket(newMarketId, newMarketId == 0 ? UFixed6Lib.ONE : UFixed6Lib.ZERO, UFixed6Lib.ZERO);
     }
 
-    // TODO
-    function _registerMarket(uint256 marketId, IMarket market) private {
-        _registrations[marketId].store(Registration(market, UFixed6Lib.ZERO, UFixed6Lib.ZERO));
-        emit MarketRegistered(marketId, market);
+    /// @notice Processes the state changes for a market registration
+    /// @param market The market to register
+    /// @return newMarketId The new market id
+    function _registerMarket(IMarket market) private returns (uint256 newMarketId) {
+        newMarketId = totalMarkets++;
+        _registrations[newMarketId].store(Registration(market, UFixed6Lib.ZERO, UFixed6Lib.ZERO));
+        emit MarketRegistered(newMarketId, market);
     }
 
+    /// @notice Processes the state changes for a market update
+    /// @param marketId The market id
+    /// @param newWeight The new weight for the market
+    /// @param newLeverage The new leverage for the market
     function _updateMarket(uint256 marketId, UFixed6 newWeight, UFixed6 newLeverage) private {
         Registration memory registration = _registrations[marketId].read();
         registration.weight = newWeight.eq(UFixed6Lib.MAX) ? registration.weight : newWeight;

--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -162,9 +162,14 @@ contract Vault is IVault, Instance {
         asset.approve(address(market));
 
         uint256 newMarketId = totalMarkets++;
-        _updateMarket(newMarketId, newMarketId == 0 ? UFixed6Lib.ONE : UFixed6Lib.ZERO, UFixed6Lib.MAX);
+        _registerMarket(newMarketId, market);
+        _updateMarket(newMarketId, newMarketId == 0 ? UFixed6Lib.ONE : UFixed6Lib.ZERO, UFixed6Lib.ZERO);
+    }
 
-        emit MarketRegistered(newMarketId, market);
+    // TODO
+    function _registerMarket(uint256 marketId, IMarket market) private {
+        _registrations[marketId].store(Registration(market, UFixed6Lib.ZERO, UFixed6Lib.ZERO));
+        emit MarketRegistered(marketId, market);
     }
 
     function _updateMarket(uint256 marketId, UFixed6 newWeight, UFixed6 newLeverage) private {

--- a/packages/perennial-vault/contracts/interfaces/IVault.sol
+++ b/packages/perennial-vault/contracts/interfaces/IVault.sol
@@ -15,7 +15,6 @@ interface IVault is IInstance {
     struct Context {
         // parameters
         UFixed6 settlementFee;
-        uint256 totalWeight;
 
         // markets
         uint256 currentId;
@@ -39,7 +38,7 @@ interface IVault is IInstance {
     }
 
     event MarketRegistered(uint256 indexed marketId, IMarket market);
-    event MarketUpdated(uint256 indexed marketId, uint256 newWeight, UFixed6 newLeverage);
+    event MarketUpdated(uint256 indexed marketId, UFixed6 newWeight, UFixed6 newLeverage);
     event ParameterUpdated(VaultParameter newParameter);
     event Updated(address indexed sender, address indexed account, uint256 version, UFixed6 depositAssets, UFixed6 redeemShares, UFixed6 claimAssets);
 
@@ -63,6 +62,8 @@ interface IVault is IInstance {
     error VaultNotSingleSidedError();
     // sig: 0xa65ac9fb
     error VaultInsufficientMinimumError();
+    // sig: 0xdbdb7620
+    error VaultAggregateWeightError();
 
     // sig: 0xb8a09499
     error AccountStorageInvalidError();
@@ -95,6 +96,7 @@ interface IVault is IInstance {
     function checkpoints(uint256 id) external view returns (Checkpoint memory);
     function mappings(uint256 id) external view returns (Mapping memory);
     function register(IMarket market) external;
-    function updateMarket(uint256 marketId, uint256 newWeight, UFixed6 newLeverage) external;
+    function updateLeverage(uint256 marketId, UFixed6 newLeverage) external;
+    function updateWeights(UFixed6[] calldata newWeights) external;
     function updateParameter(VaultParameter memory newParameter) external;
 }

--- a/packages/perennial-vault/contracts/lib/StrategyLib.sol
+++ b/packages/perennial-vault/contracts/lib/StrategyLib.sol
@@ -46,8 +46,6 @@ struct MarketStrategyContext {
 }
 
 struct Strategy {
-    uint256 totalWeight;
-
     UFixed6 totalMargin;
 
     Fixed6 totalCollateral;
@@ -85,19 +83,14 @@ library StrategyLib {
         strategy.marketContexts = new MarketStrategyContext[](registrations.length);
         for (uint256 marketId; marketId < registrations.length; marketId++) {
             strategy.marketContexts[marketId] = _loadContext(registrations[marketId]);
-            strategy.totalWeight += registrations[marketId].weight;
             strategy.totalMargin = strategy.totalMargin.add(strategy.marketContexts[marketId].margin);
             strategy.totalCollateral = strategy.totalCollateral.add(strategy.marketContexts[marketId].local.collateral);
-        }
-
-        // second pass to compute minAssets (TODO remove w/ totalWeight to one change)
-        for (uint256 marketId; marketId < registrations.length; marketId++) {
             strategy.minAssets = strategy.minAssets.max(
-                (registrations[marketId].leverage.isZero() || registrations[marketId].weight == 0) ?
+                (registrations[marketId].leverage.isZero() || registrations[marketId].weight.isZero()) ?
                     UFixed6Lib.ZERO : // skip if no leverage or weight
                     strategy.marketContexts[marketId].minPosition
                         .muldiv(strategy.marketContexts[marketId].latestPrice.abs(), registrations[marketId].leverage)
-                        .muldiv(strategy.totalWeight, registrations[marketId].weight)
+                        .div(registrations[marketId].weight)
             );
         }
     }
@@ -113,8 +106,6 @@ library StrategyLib {
         UFixed6 withdrawal,
         UFixed6 ineligable
     ) internal pure returns (MarketTarget[] memory targets) {
-        UFixed6 totalDeployed;
-
         UFixed6 collateral = UFixed6Lib.unsafeFrom(strategy.totalCollateral).add(deposit).unsafeSub(withdrawal);
         UFixed6 assets = collateral.unsafeSub(ineligable);
 
@@ -122,65 +113,52 @@ library StrategyLib {
         if (assets.lt(strategy.minAssets)) revert StrategyLibInsufficientAssetsError();
 
         targets = new MarketTarget[](strategy.marketContexts.length);
-        for (uint256 marketId; marketId < strategy.marketContexts.length; marketId++)
-            (targets[marketId], totalDeployed) = _allocateMarket(
+        UFixed6 totalMarketCollateral;
+        for (uint256 marketId; marketId < strategy.marketContexts.length; marketId++) {
+            UFixed6 marketCollateral;
+            (targets[marketId], marketCollateral) = _allocateMarket(
                 strategy.marketContexts[marketId],
-                totalDeployed,
-                strategy.totalWeight,
                 strategy.totalMargin,
                 collateral,
                 assets
             );
+            totalMarketCollateral = totalMarketCollateral.add(marketCollateral);
+        }
 
         if (strategy.marketContexts.length != 0)
-            targets[0].collateral = targets[0].collateral.add(Fixed6Lib.from(collateral.sub(totalDeployed)));
+            targets[0].collateral = targets[0].collateral.add(Fixed6Lib.from(collateral.sub(totalMarketCollateral)));
     }
 
     /// @notice Compute the target allocation for a market
     /// @param marketContext The context of the market
-    /// @param totalDeployed The total amount of deployed collateral accumulator
-    /// @param totalWeight The total weight of the vault
     /// @param totalMargin The total margin requirement of the vault
     /// @param collateral The total amount of collateral of the vault
     /// @param assets The total amount of collateral available for allocation
     function _allocateMarket(
         MarketStrategyContext memory marketContext,
-        UFixed6 totalDeployed,
-        uint256 totalWeight,
         UFixed6 totalMargin,
         UFixed6 collateral,
         UFixed6 assets
-    ) private pure returns (MarketTarget memory target, UFixed6 newTotalDeployed) {
-        UFixed6 marketCollateral = marketContext.margin
-            .add(collateral.sub(totalMargin).muldiv(marketContext.registration.weight, totalWeight));
+    ) private pure returns (MarketTarget memory target, UFixed6 marketCollateral) {
+        marketCollateral = marketContext.margin
+            .add(collateral.sub(totalMargin).mul(marketContext.registration.weight));
 
         UFixed6 marketAssets = assets
             .unsafeSub(marketContext.pendingFee)
-            .muldiv(marketContext.registration.weight, totalWeight)
+            .mul(marketContext.registration.weight)
             .min(marketCollateral.mul(LEVERAGE_BUFFER));
+
+        target.collateral = Fixed6Lib.from(marketCollateral).sub(marketContext.local.collateral);
 
         UFixed6 minAssets = marketContext.riskParameter.minMargin
             .unsafeDiv(marketContext.registration.leverage.mul(marketContext.riskParameter.maintenance));
 
         if (marketContext.marketParameter.closed || marketAssets.lt(minAssets)) marketAssets = UFixed6Lib.ZERO;
 
-        (target.collateral, target.position, newTotalDeployed) = (
-            Fixed6Lib.from(marketCollateral).sub(marketContext.local.collateral),
-            _limitPosition(
-                marketAssets.muldiv(marketContext.registration.leverage, marketContext.latestPrice.abs()),
-                marketContext
-            ),
-            totalDeployed.add(marketCollateral)
-        );
-    }
-
-    // TODO: remove w/ totalWeight to one change
-    /// @dev required for stack too deep
-    function _limitPosition(
-        UFixed6 position,
-        MarketStrategyContext memory marketContext
-    ) private pure returns (UFixed6) {
-        return position.max(marketContext.minPosition).min(marketContext.maxPosition);
+        target.position = marketAssets
+            .muldiv(marketContext.registration.leverage, marketContext.latestPrice.abs())
+            .max(marketContext.minPosition)
+            .min(marketContext.maxPosition);
     }
 
     /// @notice Load the context of a market

--- a/packages/perennial-vault/contracts/types/Registration.sol
+++ b/packages/perennial-vault/contracts/types/Registration.sol
@@ -10,7 +10,7 @@ struct Registration {
     IMarket market;
 
     /// @dev The weight of the market
-    uint256 weight;
+    UFixed6 weight;
 
     /// @dev The leverage of the market
     UFixed6 leverage;
@@ -33,18 +33,18 @@ library RegistrationStorageLib {
         StoredRegistration memory storedValue = self.value;
         return Registration(
             IMarket(storedValue.market),
-            uint256(storedValue.weight),
+            UFixed6.wrap(uint256(storedValue.weight)),
             UFixed6.wrap(uint256(storedValue.leverage))
         );
     }
 
     function store(RegistrationStorage storage self, Registration memory newValue) internal {
-        if (newValue.weight > uint256(type(uint32).max)) revert RegistrationStorageInvalidError();
+        if (newValue.weight.gt(UFixed6.wrap(type(uint32).max))) revert RegistrationStorageInvalidError();
         if (newValue.leverage.gt(UFixed6.wrap(type(uint32).max))) revert RegistrationStorageInvalidError();
 
         self.value = StoredRegistration(
             address(newValue.market),
-            uint32(newValue.weight),
+            uint32(UFixed6.unwrap(newValue.weight)),
             uint32(UFixed6.unwrap(newValue.leverage)),
             bytes4(0)
         );

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1847,7 +1847,7 @@ describe('Vault', () => {
         expect(await btcPosition()).to.be.equal(parse6decimal('11000').mul(leverage).div(5).div(btcOriginalOraclePrice))
 
         // Deleverage the ETH market
-        await vault.updateMarket(0, 4, 0)
+        await vault.updateLeverage(0, 0)
 
         await vault.connect(user).update(user.address, 0, 0, 0)
         await updateOracle()
@@ -1884,7 +1884,7 @@ describe('Vault', () => {
         expect(await btcPosition()).to.be.equal(parse6decimal('11000').mul(leverage).div(5).div(btcOriginalOraclePrice))
 
         // Close the ETH market
-        await vault.updateMarket(0, 0, leverage)
+        await vault.updateWeights([0, parse6decimal('1')])
 
         await vault.connect(user).update(user.address, 0, 0, 0)
         await updateOracle()
@@ -1903,7 +1903,8 @@ describe('Vault', () => {
     context('add market', () => {
       beforeEach(async () => {
         // set ETH market to 0
-        await vault.updateMarket(0, 0, 0)
+        await vault.updateLeverage(0, 0)
+        await vault.updateWeights([0, parse6decimal('1')])
 
         // Seed vault with deposits
         const deposit0 = parse6decimal('1000')
@@ -1922,7 +1923,8 @@ describe('Vault', () => {
         expect(await btcPosition()).to.be.equal(parse6decimal('11000').mul(leverage).div(btcOriginalOraclePrice))
 
         // Open the ETH market
-        await vault.updateMarket(0, 9, leverage)
+        await vault.updateLeverage(0, leverage)
+        await vault.updateWeights([parse6decimal('0.9'), parse6decimal('0.1')])
 
         await vault.connect(user).update(user.address, 0, 0, 0)
         await updateOracle()


### PR DESCRIPTION
- Adds an invariant that vault weights must sum up to `UFixed6Lib.ONE` (and therefore represent percentages).

### Migration Note
- Vault weights must be reset to satisfy this variant prior to upgrade.