### PR TITLE
[Cleanup] Remove latestPrice from Market

### DIFF
--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -154,6 +154,8 @@ contract KeeperOracle is IKeeperOracle, Instance {
         if (block.timestamp <= (next() + timeout)) {
             if (!version.valid) revert KeeperOracleInvalidPriceError();
             _prices[version.timestamp] = version.price;
+        } else {
+            _prices[version.timestamp] = _prices[_global.latestVersion];
         }
         _global.latestIndex++;
         return true;

--- a/packages/perennial-vault/contracts/lib/StrategyLib.sol
+++ b/packages/perennial-vault/contracts/lib/StrategyLib.sol
@@ -179,8 +179,7 @@ library StrategyLib {
         marketContext.marketParameter = registration.market.parameter();
         marketContext.riskParameter = registration.market.riskParameter();
         marketContext.local = registration.market.locals(address(this));
-        Global memory global = registration.market.global();
-        marketContext.latestPrice = global.latestPrice;
+        OracleVersion memory latestVersion = registration.market.oracle().latest();
 
         marketContext.latestAccountPosition = registration.market.positions(address(this));
         marketContext.currentAccountPosition = marketContext.latestAccountPosition.clone();
@@ -190,9 +189,10 @@ library StrategyLib {
 
         marketContext.margin = PositionLib.margin(
             marketContext.latestAccountPosition.magnitude().add(pendingLocal.pos()),
-            OracleVersion(0, marketContext.latestPrice, true),
+            latestVersion,
             marketContext.riskParameter
         );
+        marketContext.latestPrice = latestVersion.price;
 
         marketContext.closable = marketContext.latestAccountPosition.magnitude().sub(pendingLocal.neg());
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -129,7 +129,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     function updateRiskParameter(RiskParameter memory newRiskParameter) external onlyCoordinator {
 
         // credit impact update fee to the protocol account
-        Global memory latestGlobal = _global.read();
         Position memory latestPosition = _position.read();
         RiskParameter memory latestRiskParameter = _riskParameter.read();
         OracleVersion memory latestVersion = oracle.at(latestPosition.timestamp);

--- a/packages/perennial/contracts/interfaces/IOracleProvider.sol
+++ b/packages/perennial/contracts/interfaces/IOracleProvider.sol
@@ -5,16 +5,15 @@ import "../types/OracleVersion.sol";
 import "./IMarket.sol";
 
 /// @dev OracleVersion Invariants
-///       - Each newly requested version must be increasing, but does not need to incrementing
-///         - We recommend using something like timestamps or blocks for versions so that intermediary non-requested
-///           versions may be posted for the purpose of expedient liquidations
+///       - Version are requested at a timestamp, the current timestamp is determined by the oracle
+///         - The current timestamp may not be equal to block.timestamp, for example when batching timestamps
 ///       - Versions are allowed to "fail" and will be marked as .valid = false
+///         - Invalid versions will always include the latest valid price as its price field
 ///       - Versions must be committed in order, i.e. all requested versions prior to latestVersion must be available
 ///       - Non-requested versions may be committed, but will not receive a keeper fee
 ///         - This is useful for immediately liquidating an account with a valid off-chain price in between orders
 ///         - Satisfying the above constraints, only versions more recent than the latest version may be committed
 ///       - Current must always be greater than Latest, never equal
-///       - Request must register the same current version that was returned by Current within the same transaction
 interface IOracleProvider {
     // sig: 0x652fafab
     error OracleProviderUnauthorizedError();

--- a/packages/perennial/contracts/test/GlobalTester.sol
+++ b/packages/perennial/contracts/test/GlobalTester.sol
@@ -24,10 +24,4 @@ contract GlobalTester {
         newGlobal.incrementFees(amount, keeper, marketParameter, protocolParameter);
         global.store(newGlobal);
     }
-
-    function update(uint256 latestId, Fixed6 latestPrice) external {
-        Global memory newGlobal = global.read();
-        newGlobal.update(latestId, latestPrice);
-        global.store(newGlobal);
-    }
 }

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14724,6 +14724,7 @@ describe('Market', () => {
 
           // Fulfill oracle version 3 (invalid)
           const oracleVersion3 = {
+            price: parse6decimal('100'),
             timestamp: TIMESTAMP + 200,
             valid: false,
           }
@@ -14779,6 +14780,7 @@ describe('Market', () => {
 
           // invalid oracle version
           const oracleVersion3 = {
+            price: parse6decimal('100'),
             timestamp: TIMESTAMP + 200,
             valid: false,
           }

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -12290,8 +12290,13 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(liquidator.address, user.address, ORACLE_VERSION_4.timestamp, 0, 0, 0, 0, true)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4, valid: false })
-          oracle.status.returns([{ ...ORACLE_VERSION_4, valid: false }, ORACLE_VERSION_5.timestamp])
+          oracle.at
+            .whenCalledWith(ORACLE_VERSION_4.timestamp)
+            .returns({ ...ORACLE_VERSION_4, price: oracleVersionLowerPrice.price, valid: false })
+          oracle.status.returns([
+            { ...ORACLE_VERSION_4, price: oracleVersionLowerPrice.price, valid: false },
+            ORACLE_VERSION_5.timestamp,
+          ])
           oracle.request.whenCalledWith(user.address).returns()
 
           await expect(market.connect(liquidator).update(user.address, 0, 0, 0, 0, true))
@@ -12489,8 +12494,8 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_3.timestamp, 0, POSITION.div(2), 0, COLLATERAL, false)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, price: 0, valid: false })
-          oracle.status.returns([{ ...ORACLE_VERSION_3, price: 0, valid: false }, ORACLE_VERSION_4.timestamp])
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
+          oracle.status.returns([{ ...ORACLE_VERSION_3, valid: false }, ORACLE_VERSION_4.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
 
           await settle(market, user)
@@ -12616,8 +12621,8 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_3.timestamp, 0, POSITION.div(2), 0, COLLATERAL, false)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, price: 0, valid: false })
-          oracle.status.returns([{ ...ORACLE_VERSION_3, price: 0, valid: false }, ORACLE_VERSION_4.timestamp])
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
+          oracle.status.returns([{ ...ORACLE_VERSION_3, valid: false }, ORACLE_VERSION_4.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
 
           await expect(market.connect(user).update(user.address, 0, POSITION.div(2), 0, 0, false))
@@ -12777,16 +12782,16 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_3.timestamp, 0, POSITION.div(2), 0, COLLATERAL, false)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, price: 0, valid: false })
-          oracle.status.returns([{ ...ORACLE_VERSION_3, price: 0, valid: false }, ORACLE_VERSION_4.timestamp])
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
+          oracle.status.returns([{ ...ORACLE_VERSION_3, valid: false }, ORACLE_VERSION_4.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
 
           await expect(market.connect(user).update(user.address, 0, POSITION.div(2), 0, 0, false))
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_4.timestamp, 0, POSITION.div(2), 0, 0, false)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4, price: 0, valid: false })
-          oracle.status.returns([{ ...ORACLE_VERSION_4, price: 0, valid: false }, ORACLE_VERSION_5.timestamp])
+          oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4, valid: false })
+          oracle.status.returns([{ ...ORACLE_VERSION_4, valid: false }, ORACLE_VERSION_5.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
 
           await settle(market, user)
@@ -12942,7 +12947,7 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_4.timestamp, 0, POSITION.div(2), 0, 0, false)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, price: 0, valid: false })
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4 })
           oracle.status.returns([{ ...ORACLE_VERSION_4 }, ORACLE_VERSION_5.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
@@ -13094,7 +13099,7 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_4.timestamp, 0, POSITION.div(2), 0, 0, false)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, price: 0, valid: false })
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4 })
           oracle.status.returns([{ ...ORACLE_VERSION_4 }, ORACLE_VERSION_5.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
@@ -13251,8 +13256,8 @@ describe('Market', () => {
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
-          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, price: 0, valid: false })
-          oracle.status.returns([{ ...ORACLE_VERSION_3, price: 0, valid: false }, ORACLE_VERSION_4.timestamp])
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
+          oracle.status.returns([{ ...ORACLE_VERSION_3, valid: false }, ORACLE_VERSION_4.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
 
           await settle(market, user)
@@ -14719,7 +14724,6 @@ describe('Market', () => {
 
           // Fulfill oracle version 3 (invalid)
           const oracleVersion3 = {
-            price: 0,
             timestamp: TIMESTAMP + 200,
             valid: false,
           }
@@ -14775,7 +14779,6 @@ describe('Market', () => {
 
           // invalid oracle version
           const oracleVersion3 = {
-            price: 0,
             timestamp: TIMESTAMP + 200,
             valid: false,
           }

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -64,7 +64,6 @@ describe('Global', () => {
           _value: 6,
           _skew: 7,
         },
-        latestPrice: 8,
       })
 
       const value = await global.read()
@@ -76,7 +75,6 @@ describe('Global', () => {
       expect(value.donation).to.equal(5)
       expect(value.pAccumulator._value).to.equal(6)
       expect(value.pAccumulator._skew).to.equal(7)
-      expect(value.latestPrice).to.equal(8)
     })
 
     context('.currentId', async () => {
@@ -93,7 +91,6 @@ describe('Global', () => {
             _value: 0,
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.currentId).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -112,7 +109,6 @@ describe('Global', () => {
               _value: 0,
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -132,7 +128,6 @@ describe('Global', () => {
             _value: 0,
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.latestId).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -151,7 +146,6 @@ describe('Global', () => {
               _value: 0,
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -171,7 +165,6 @@ describe('Global', () => {
             _value: 0,
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.protocolFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -190,7 +183,6 @@ describe('Global', () => {
               _value: 0,
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -210,7 +202,6 @@ describe('Global', () => {
             _value: 0,
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.oracleFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -229,7 +220,6 @@ describe('Global', () => {
               _value: 0,
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -249,7 +239,6 @@ describe('Global', () => {
             _value: 0,
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.riskFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -268,7 +257,6 @@ describe('Global', () => {
               _value: 0,
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -288,7 +276,6 @@ describe('Global', () => {
             _value: 0,
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.donation).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -307,7 +294,6 @@ describe('Global', () => {
               _value: 0,
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -327,7 +313,6 @@ describe('Global', () => {
             _value: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.pAccumulator._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -345,7 +330,6 @@ describe('Global', () => {
             _value: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1),
             _skew: 0,
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.pAccumulator._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
@@ -364,7 +348,6 @@ describe('Global', () => {
               _value: BigNumber.from(2).pow(STORAGE_SIZE),
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -382,7 +365,6 @@ describe('Global', () => {
               _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
               _skew: 0,
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -402,7 +384,6 @@ describe('Global', () => {
             _value: 0,
             _skew: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.pAccumulator._skew).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -420,7 +401,6 @@ describe('Global', () => {
             _value: 0,
             _skew: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1),
           },
-          latestPrice: 0,
         })
         const value = await global.read()
         expect(value.pAccumulator._skew).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
@@ -439,7 +419,6 @@ describe('Global', () => {
               _value: 0,
               _skew: BigNumber.from(2).pow(STORAGE_SIZE),
             },
-            latestPrice: 0,
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -457,82 +436,6 @@ describe('Global', () => {
               _value: 0,
               _skew: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
             },
-            latestPrice: 0,
-          }),
-        ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
-      })
-    })
-
-    context('.latestPrice', async () => {
-      const STORAGE_SIZE = 63
-      it('saves if in range (above)', async () => {
-        await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
-          latestPrice: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-        })
-        const value = await global.read()
-        expect(value.latestPrice).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-      })
-
-      it('saves if in range (below)', async () => {
-        await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
-          latestPrice: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1),
-        })
-        const value = await global.read()
-        expect(value.latestPrice).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
-      })
-
-      it('reverts if currentId out of range (above)', async () => {
-        await expect(
-          global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
-            latestPrice: BigNumber.from(2).pow(STORAGE_SIZE),
-          }),
-        ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
-      })
-
-      it('reverts if currentId out of range (below)', async () => {
-        await expect(
-          global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
-            latestPrice: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -1105,22 +1008,6 @@ describe('Global', () => {
           ),
         ).revertedWithPanic(0x11)
       })
-    })
-  })
-
-  describe('#update', async () => {
-    it('updates the latestPrice', async () => {
-      await global.update(12, 123)
-      expect((await global.read()).latestId).to.equal(12)
-      expect((await global.read()).latestPrice).to.equal(123)
-
-      await global.update(23, 456)
-      expect((await global.read()).latestId).to.equal(23)
-      expect((await global.read()).latestPrice).to.equal(456)
-
-      await global.update(34, 0)
-      expect((await global.read()).latestId).to.equal(34)
-      expect((await global.read()).latestPrice).to.equal(0)
     })
   })
 })


### PR DESCRIPTION
Moves the `latestPrice` handling from the Market to the Oracle latest by ensure the Oracle keeps track of and returns the correct `latestPrice` in the event of an invalid version.

#### Migration Note
`latest()` must return a valid version on all oracles before upgrading.