### PR TITLE
[Docs] Add storage expansion warnings

### DIFF
--- a/packages/perennial-vault/contracts/types/VaultParameter.sol
+++ b/packages/perennial-vault/contracts/types/VaultParameter.sol
@@ -13,7 +13,7 @@ struct StoredVaultParameter {
     uint64 cap;
     bytes24 __unallocated0__;
 }
-struct VaultParameterStorage { StoredVaultParameter value; }
+struct VaultParameterStorage { StoredVaultParameter value; } // SECURITY: must remain at (1) slots
 using VaultParameterStorageLib for VaultParameterStorage global;
 
 library VaultParameterStorageLib {

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -32,7 +32,7 @@ struct Global {
     Fixed6 latestPrice;
 }
 using GlobalLib for Global global;
-struct GlobalStorage { uint256 slot0; uint256 slot1; }
+struct GlobalStorage { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using GlobalStorageLib for GlobalStorage global;
 
 /// @title Global

--- a/packages/perennial/contracts/types/MarketParameter.sol
+++ b/packages/perennial/contracts/types/MarketParameter.sol
@@ -40,7 +40,7 @@ struct MarketParameter {
     /// @dev Whether the market is in close-only mode
     bool closed;
 }
-struct MarketParameterStorage { uint256 slot0; }
+struct MarketParameterStorage { uint256 slot0; } // SECURITY: must remain at (1) slots
 using MarketParameterStorageLib for MarketParameterStorage global;
 
 /// @dev Manually encodes and decodes the MarketParameter struct into storage.

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -34,9 +34,9 @@ struct Order {
     UFixed6 shortNeg;
 }
 using OrderLib for Order global;
-struct OrderStorageGlobal { uint256 slot0; uint256 slot1; }
+struct OrderStorageGlobal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using OrderStorageGlobalLib for OrderStorageGlobal global;
-struct OrderStorageLocal { uint256 slot0; }
+struct OrderStorageLocal { uint256 slot0; } // SECURITY: must remain at (1) slots
 using OrderStorageLocalLib for OrderStorageLocal global;
 
 /// @title Order

--- a/packages/perennial/contracts/types/Position.sol
+++ b/packages/perennial/contracts/types/Position.sol
@@ -22,9 +22,9 @@ struct Position {
     UFixed6 short;
 }
 using PositionLib for Position global;
-struct PositionStorageGlobal { uint256 slot0; uint256 slot1; uint256 slot2; }
+struct PositionStorageGlobal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using PositionStorageGlobalLib for PositionStorageGlobal global;
-struct PositionStorageLocal { uint256 slot0; uint256 slot1; }
+struct PositionStorageLocal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using PositionStorageLocalLib for PositionStorageLocal global;
 
 /// @title Position

--- a/packages/perennial/contracts/types/ProtocolParameter.sol
+++ b/packages/perennial/contracts/types/ProtocolParameter.sol
@@ -36,7 +36,7 @@ struct StoredProtocolParameter {
     uint24 minMaintenance;     // <= 1677%
     uint24 minEfficiency;      // <= 1677%
 }
-struct ProtocolParameterStorage { StoredProtocolParameter value; }
+struct ProtocolParameterStorage { StoredProtocolParameter value; } // SECURITY: must remain at (1) slots
 using ProtocolParameterStorageLib for ProtocolParameterStorage global;
 
 library ProtocolParameterStorageLib {

--- a/packages/perennial/contracts/types/RiskParameter.sol
+++ b/packages/perennial/contracts/types/RiskParameter.sol
@@ -56,7 +56,7 @@ struct RiskParameter {
     /// @dev Whether or not the maker should always receive positive funding
     bool makerReceiveOnly;
 }
-struct RiskParameterStorage { uint256 slot0; uint256 slot1; uint256 slot2; uint256 slot3; }
+struct RiskParameterStorage { uint256 slot0; uint256 slot1; uint256 slot2; uint256 slot3; } // SECURITY: must remain at (3) slots
 using RiskParameterStorageLib for RiskParameterStorage global;
 
 //    struct StoredRiskParameter {


### PR DESCRIPTION
Adds warnings to each storage struct that change slot count due to it being used at the top-level of a contract.

#### Additional Notes:
- Removes extra unneeded slot introduced in: https://github.com/equilibria-xyz/perennial-v2/pull/208.
- Leaves the additional slot in `RiskParameter` similarly introduced as a follow-up.