### PR TITLE
[Cleanup] Remove timestamp from OrderCreated event

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -375,7 +375,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         // events
         emit Updated(msg.sender, account, context.currentTimestamp, newMaker, newLong, newShort, collateral, protect);
-        emit OrderCreated(account, context.currentTimestamp, newOrder, collateral);
+        emit OrderCreated(account, newOrder, collateral);
     }
 
     /// @notice Loads the context of the transaction

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -52,7 +52,7 @@ interface IMarket is IInstance {
     }
 
     event Updated(address indexed sender, address indexed account, uint256 version, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect);
-    event OrderCreated(address indexed account, uint256 version, Order order, Fixed6 collateral);
+    event OrderCreated(address indexed account, Order order, Fixed6 collateral);
     event PositionProcessed(uint256 indexed fromOracleVersion, uint256 indexed toOracleVersion, uint256 fromPosition, uint256 toPosition, VersionAccumulationResult accumulationResult);
     event AccountPositionProcessed(address indexed account, uint256 indexed fromOracleVersion, uint256 indexed toOracleVersion, uint256 fromPosition, uint256 toPosition, LocalAccumulationResult accumulationResult);
     event BeneficiaryUpdated(address newBeneficiary);

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -117,7 +117,6 @@ describe('Happy Path', () => {
       .to.emit(market, 'OrderCreated')
       .withArgs(
         user.address,
-        TIMESTAMP_1,
         {
           ...DEFAULT_ORDER,
           timestamp: TIMESTAMP_1,
@@ -343,7 +342,6 @@ describe('Happy Path', () => {
       .to.emit(market, 'OrderCreated')
       .withArgs(
         user.address,
-        TIMESTAMP_2,
         {
           ...DEFAULT_ORDER,
           timestamp: TIMESTAMP_2,
@@ -490,7 +488,6 @@ describe('Happy Path', () => {
       .to.emit(market, 'OrderCreated')
       .withArgs(
         userB.address,
-        TIMESTAMP_1,
         {
           ...DEFAULT_ORDER,
           timestamp: TIMESTAMP_1,
@@ -760,7 +757,6 @@ describe('Happy Path', () => {
       .to.emit(market, 'OrderCreated')
       .withArgs(
         userB.address,
-        TIMESTAMP_2,
         {
           ...DEFAULT_ORDER,
           timestamp: TIMESTAMP_2,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -700,12 +700,7 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, COLLATERAL, false)
             .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
-              COLLATERAL,
-            )
+            .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL }, COLLATERAL)
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
@@ -750,12 +745,7 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, COLLATERAL.mul(-1), false)
             .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: -COLLATERAL },
-              COLLATERAL.mul(-1),
-            )
+            .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: -COLLATERAL }, COLLATERAL.mul(-1))
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
@@ -986,7 +976,6 @@ describe('Market', () => {
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                ORACLE_VERSION_2.timestamp,
                 {
                   ...DEFAULT_ORDER,
                   orders: 1,
@@ -1911,7 +1900,6 @@ describe('Market', () => {
                 .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  ORACLE_VERSION_2.timestamp,
                   {
                     ...DEFAULT_ORDER,
                     timestamp: ORACLE_VERSION_2.timestamp,
@@ -4620,7 +4608,6 @@ describe('Market', () => {
                 .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  ORACLE_VERSION_2.timestamp,
                   {
                     ...DEFAULT_ORDER,
                     timestamp: ORACLE_VERSION_2.timestamp,


### PR DESCRIPTION
`Order` type now includes the timestamp internally.