### PR TITLE
[Fix] Use local order

### DIFF
--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1508,7 +1508,7 @@ describe('Vault', () => {
       await vault.settle(user.address)
       await vault.settle(user2.address)
 
-      const totalAssets = BigNumber.from('10911886661')
+      const totalAssets = BigNumber.from('10913053329')
       expect((await vault.accounts(constants.AddressZero)).assets).to.equal(totalAssets)
     })
 
@@ -1637,6 +1637,8 @@ describe('Vault', () => {
             BigNumber.from('4428767485').add(EXPECTED_LIQUIDATION_FEE),
           ) // no shortfall
           expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 3))
+          expect((await btcMarket.locals(vault.address)).protectionAmount).to.equal(EXPECTED_LIQUIDATION_FEE)
+          expect((await btcMarket.locals(vault.address)).protectionInitiator).to.equal(user.address)
 
           await expect(vault.connect(user).update(user.address, 0, 0, 0)).to.be.reverted
 
@@ -1678,6 +1680,8 @@ describe('Vault', () => {
             BigNumber.from('-26673235277').add(EXPECTED_LIQUIDATION_FEE),
           ) // shortfall
           expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 3))
+          expect((await btcMarket.locals(vault.address)).protectionAmount).to.equal(EXPECTED_LIQUIDATION_FEE)
+          expect((await btcMarket.locals(vault.address)).protectionInitiator).to.equal(user.address)
 
           await expect(vault.connect(user).update(user.address, 0, 0, 0)).to.be.reverted
 
@@ -1704,6 +1708,8 @@ describe('Vault', () => {
 
       context('short', () => {
         beforeEach(async () => {
+          await updateOracle()
+
           await market.connect(user2).update(user2.address, 0, 0, 0, 0, false)
           await btcMarket.connect(btcUser2).update(btcUser2.address, 0, 0, 0, 0, false)
           await updateOracle()
@@ -1731,9 +1737,11 @@ describe('Vault', () => {
           const EXPECTED_LIQUIDATION_FEE = BigNumber.from('2059819000')
           await btcMarket.connect(user).update(vault.address, 0, 0, 0, 0, true)
           expect((await btcMarket.locals(vault.address)).collateral).to.equal(
-            BigNumber.from('350784004').add(EXPECTED_LIQUIDATION_FEE),
+            BigNumber.from('350411418').add(EXPECTED_LIQUIDATION_FEE),
           ) // no shortfall
-          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 5))
+          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 6))
+          expect((await btcMarket.locals(vault.address)).protectionAmount).to.equal(EXPECTED_LIQUIDATION_FEE)
+          expect((await btcMarket.locals(vault.address)).protectionInitiator).to.equal(user.address)
 
           // 3. Settle the liquidation.
           // We now be able to deposit.
@@ -1746,10 +1754,10 @@ describe('Vault', () => {
           await updateOracle()
           await vault.settle(user.address)
 
-          const finalPosition = BigNumber.from('98136381')
-          const finalCollateral = BigNumber.from('65717442312')
-          const btcFinalPosition = BigNumber.from('2321109')
-          const btcFinalCollateral = BigNumber.from('14643063212')
+          const finalPosition = BigNumber.from('98133199')
+          const finalCollateral = BigNumber.from('65714574536')
+          const btcFinalPosition = BigNumber.from('2320984')
+          const btcFinalCollateral = BigNumber.from('14642304708')
           expect(await position()).to.equal(finalPosition)
           expect(await collateralInVault()).to.equal(finalCollateral)
           expect(await btcPosition()).to.equal(btcFinalPosition)
@@ -1770,9 +1778,11 @@ describe('Vault', () => {
           const EXPECTED_LIQUIDATION_FEE = BigNumber.from('1956828050')
           await btcMarket.connect(user).update(vault.address, 0, 0, 0, 0, true)
           expect((await btcMarket.locals(vault.address)).collateral).to.equal(
-            BigNumber.from('-479967521').add(EXPECTED_LIQUIDATION_FEE),
+            BigNumber.from('-480340107').add(EXPECTED_LIQUIDATION_FEE),
           ) // shortfall
-          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 5))
+          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 6))
+          expect((await btcMarket.locals(vault.address)).protectionAmount).to.equal(EXPECTED_LIQUIDATION_FEE)
+          expect((await btcMarket.locals(vault.address)).protectionInitiator).to.equal(user.address)
 
           // 3. Settle the liquidation.
           // We now be able to deposit.
@@ -1785,10 +1795,10 @@ describe('Vault', () => {
           await updateOracle()
           await vault.settle(user.address)
 
-          const finalPosition = BigNumber.from('97121779')
-          const finalCollateral = BigNumber.from('65063451819')
-          const btcFinalPosition = BigNumber.from('2401296')
-          const btcFinalCollateral = BigNumber.from('14466272441')
+          const finalPosition = BigNumber.from('97118608')
+          const finalCollateral = BigNumber.from('65060591415')
+          const btcFinalPosition = BigNumber.from('2401165')
+          const btcFinalCollateral = BigNumber.from('14465516159')
           expect(await position()).to.equal(finalPosition)
           expect(await collateralInVault()).to.equal(finalCollateral)
           expect(await btcPosition()).to.equal(btcFinalPosition)

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -63,13 +63,13 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     mapping(uint256 => OrderStorageGlobal) private _pendingOrder;
 
     /// @dev The local pending order for each id for each account
-    mapping(address => mapping(uint256 => OrderStorageGlobal)) private _pendingOrders;
+    mapping(address => mapping(uint256 => OrderStorageLocal)) private _pendingOrders;
 
     /// @dev The global aggregate pending order
     OrderStorageGlobal private _pending;
 
     /// @dev The local aggregate pending order for each account
-    mapping(address => OrderStorageGlobal) private _pendings;
+    mapping(address => OrderStorageLocal) private _pendings;
 
     /// @dev The local checkpoint for each id for each account
     mapping(address => mapping(uint256 => CheckpointStorage)) private _checkpoints;

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -337,26 +337,11 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         context.currentPosition.global.update(newOrder, true);
         context.currentPosition.local.update(newOrder, true);
 
-        // rewind local order
-        context.order.global.sub(context.order.local);
-        context.pending.global.sub(context.order.local);
-        context.pending.local.sub(context.order.local);
-
-        // create new order
-        context.order.local = OrderLib.from(
-            context.currentTimestamp,
-            context.latestPosition.local,
-            context.pending.local,
-            newMaker,
-            newLong,
-            newShort
-        );
-
         // apply new order
-        context.order.global.add(context.order.local);
-        context.pending.global.add(context.order.local);
-        context.pending.local.add(context.order.local);
-        
+        context.order.local.add(newOrder);
+        context.order.global.add(newOrder);
+        context.pending.global.add(newOrder);
+        context.pending.local.add(newOrder);
 
         // update collateral
         context.local.update(collateral);

--- a/packages/perennial/test/integration/core/closedProduct.test.ts
+++ b/packages/perennial/test/integration/core/closedProduct.test.ts
@@ -60,7 +60,10 @@ describe('Closed Market', () => {
     })
 
     it('reverts on new open positions', async () => {
-      const { user } = instanceVars
+      const { user, chainlink } = instanceVars
+
+      await chainlink.next()
+
       await expect(market.connect(user).update(user.address, 0, POSITION, 0, 0, false)).to.be.revertedWithCustomError(
         market,
         'MarketClosedError',

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -243,7 +243,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrders(user.address, 1), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_1,
-      orders: 1,
+      orders: 2,
       makerPos: POSITION,
     })
     expectCheckpointEq(await market.checkpoints(user.address, 1), {
@@ -267,7 +267,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_1,
-      orders: 1,
+      orders: 2,
       makerPos: POSITION,
     })
     expectPositionEq(await market.position(), {
@@ -429,7 +429,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrders(user.address, 2), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_2,
-      orders: 1,
+      orders: 2,
       makerNeg: POSITION,
     })
     expectCheckpointEq(await market.checkpoints(user.address, 2), {
@@ -454,7 +454,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_2,
-      orders: 1,
+      orders: 2,
       makerNeg: POSITION,
     })
     expectPositionEq(await market.position(), {
@@ -858,7 +858,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrders(userB.address, 2), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_2,
-      orders: 1,
+      orders: 2,
       longNeg: POSITION_B,
     })
     expectCheckpointEq(await market.checkpoints(userB.address, 2), {
@@ -883,7 +883,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_2,
-      orders: 1,
+      orders: 2,
       longNeg: POSITION_B,
     })
     expectPositionEq(await market.position(), {

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -653,7 +653,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrders(userB.address, 1), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_1,
-      orders: 1,
+      orders: 2,
       longPos: POSITION_B,
     })
     expectCheckpointEq(await market.checkpoints(userB.address, 1), {
@@ -677,7 +677,7 @@ describe('Happy Path', () => {
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
       timestamp: TIMESTAMP_1,
-      orders: 2,
+      orders: 3,
       makerPos: POSITION,
       longPos: POSITION_B,
     })

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -1123,7 +1123,7 @@ describe('Market', () => {
             expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
               timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
+              orders: 2,
               makerPos: POSITION.mul(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, 1), {
@@ -1145,7 +1145,7 @@ describe('Market', () => {
             expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
               timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
+              orders: 2,
               makerPos: POSITION.mul(2),
             })
           })
@@ -1447,121 +1447,6 @@ describe('Market', () => {
             await market.connect(user).update(user.address, POSITION, 0, 0, COLLATERAL, false)
           })
 
-          it('closes the position', async () => {
-            await expect(market.connect(user).update(user.address, 0, 0, 0, 0, false))
-              .to.emit(market, 'Updated')
-              .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, 0, false)
-              .to.emit(market, 'OrderCreated')
-              .withArgs(
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                {
-                  ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_2.timestamp,
-                  orders: 1,
-                  makerNeg: POSITION,
-                },
-                0,
-              )
-
-            expectLocalEq(await market.locals(user.address), {
-              ...DEFAULT_LOCAL,
-              currentId: 1,
-              collateral: COLLATERAL,
-            })
-            expectPositionEq(await market.positions(user.address), {
-              ...DEFAULT_POSITION,
-              timestamp: ORACLE_VERSION_1.timestamp,
-            })
-            expectOrderEq(await market.pendingOrders(user.address, 1), {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-            })
-            expectCheckpointEq(await market.checkpoints(user.address, 1), {
-              ...DEFAULT_CHECKPOINT,
-              delta: COLLATERAL,
-            })
-            expectGlobalEq(await market.global(), {
-              currentId: 1,
-              latestId: 0,
-              protocolFee: 0,
-              oracleFee: 0,
-              riskFee: 0,
-              donation: 0,
-            })
-            expectPositionEq(await market.position(), {
-              ...DEFAULT_POSITION,
-              timestamp: ORACLE_VERSION_1.timestamp,
-            })
-            expectOrderEq(await market.pendingOrder(1), {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-            })
-            expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-              ...DEFAULT_VERSION,
-            })
-          })
-
-          it('closes the position partially', async () => {
-            await expect(market.connect(user).update(user.address, POSITION.div(2), 0, 0, 0, false))
-              .to.emit(market, 'Updated')
-              .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, POSITION.div(2), 0, 0, 0, false)
-              .to.emit(market, 'OrderCreated')
-              .withArgs(
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                {
-                  ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_2.timestamp,
-                  orders: 1,
-                  makerNeg: POSITION.div(2),
-                },
-                0,
-              )
-
-            expectLocalEq(await market.locals(user.address), {
-              ...DEFAULT_LOCAL,
-              currentId: 1,
-              latestId: 0,
-              collateral: COLLATERAL,
-            })
-            expectPositionEq(await market.positions(user.address), {
-              ...DEFAULT_POSITION,
-              timestamp: ORACLE_VERSION_1.timestamp,
-            })
-            expectOrderEq(await market.pendingOrders(user.address, 1), {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              makerPos: POSITION.div(2),
-            })
-            expectCheckpointEq(await market.checkpoints(user.address, 1), {
-              ...DEFAULT_CHECKPOINT,
-              delta: COLLATERAL,
-            })
-            expectGlobalEq(await market.global(), {
-              currentId: 1,
-              latestId: 0,
-              protocolFee: 0,
-              oracleFee: 0,
-              riskFee: 0,
-              donation: 0,
-            })
-            expectPositionEq(await market.position(), {
-              ...DEFAULT_POSITION,
-              timestamp: ORACLE_VERSION_1.timestamp,
-            })
-            expectOrderEq(await market.pendingOrder(1), {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              makerPos: POSITION.div(2),
-            })
-            expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-              ...DEFAULT_VERSION,
-            })
-          })
-
           context('settles first', async () => {
             beforeEach(async () => {
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1692,7 +1577,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
+                orders: 2,
                 makerNeg: POSITION,
               })
               expectCheckpointEq(await market.checkpoints(user.address, 2), {
@@ -1715,7 +1600,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
+                orders: 2,
                 makerNeg: POSITION,
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
@@ -2155,7 +2040,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
+                orders: 2,
                 longPos: POSITION,
               })
               expectCheckpointEq(await market.checkpoints(user.address, 1), {
@@ -2177,7 +2062,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 2,
+                orders: 3,
                 makerPos: POSITION,
                 longPos: POSITION,
               })
@@ -2714,125 +2599,6 @@ describe('Market', () => {
               await market.connect(user).update(user.address, 0, POSITION.div(2), 0, COLLATERAL, false)
             })
 
-            it('closes the position partially', async () => {
-              await expect(market.connect(user).update(user.address, 0, POSITION.div(4), 0, 0, false))
-                .to.emit(market, 'Updated')
-                .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, POSITION.div(4), 0, 0, false)
-                .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    orders: 1,
-                    longNeg: POSITION.div(4),
-                  },
-                  0,
-                )
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 1,
-                latestId: 0,
-                collateral: COLLATERAL,
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(4),
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, 1), {
-                ...DEFAULT_CHECKPOINT,
-                delta: COLLATERAL,
-              })
-              expectGlobalEq(await market.global(), {
-                currentId: 1,
-                latestId: 0,
-                protocolFee: 0,
-                oracleFee: 0,
-                riskFee: 0,
-                donation: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrder(1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 2,
-                makerPos: POSITION,
-                longPos: POSITION.div(4),
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-                ...DEFAULT_VERSION,
-              })
-            })
-
-            it('closes the position', async () => {
-              await expect(market.connect(user).update(user.address, 0, 0, 0, 0, false))
-                .to.emit(market, 'Updated')
-                .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, 0, false)
-                .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    orders: 1,
-                    longNeg: POSITION.div(2),
-                  },
-                  0,
-                )
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 1,
-                latestId: 0,
-                collateral: COLLATERAL,
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, 1), {
-                ...DEFAULT_CHECKPOINT,
-                delta: COLLATERAL,
-              })
-              expectGlobalEq(await market.global(), {
-                currentId: 1,
-                latestId: 0,
-                protocolFee: 0,
-                oracleFee: 0,
-                riskFee: 0,
-                donation: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrder(1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                makerPos: POSITION,
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-                ...DEFAULT_VERSION,
-              })
-            })
-
             context('settles first', async () => {
               beforeEach(async () => {
                 oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2994,7 +2760,7 @@ describe('Market', () => {
                 expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_3.timestamp,
-                  orders: 1,
+                  orders: 2,
                   longNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, 2), {
@@ -3018,7 +2784,7 @@ describe('Market', () => {
                 expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_3.timestamp,
-                  orders: 1,
+                  orders: 2,
                   longNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
@@ -5030,7 +4796,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
+                orders: 2,
                 shortPos: POSITION,
               })
               expectCheckpointEq(await market.checkpoints(user.address, 1), {
@@ -5052,7 +4818,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 2,
+                orders: 3,
                 makerPos: POSITION,
                 shortPos: POSITION,
               })
@@ -5602,125 +5368,6 @@ describe('Market', () => {
               await market.connect(user).update(user.address, 0, 0, POSITION.div(2), COLLATERAL, false)
             })
 
-            it('closes the position partially', async () => {
-              await expect(market.connect(user).update(user.address, 0, 0, POSITION.div(4), 0, false))
-                .to.emit(market, 'Updated')
-                .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, POSITION.div(4), 0, false)
-                .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    orders: 1,
-                    shortNeg: POSITION.div(4),
-                  },
-                  0,
-                )
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 1,
-                latestId: 0,
-                collateral: COLLATERAL,
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(4),
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, 1), {
-                ...DEFAULT_CHECKPOINT,
-                delta: COLLATERAL,
-              })
-              expectGlobalEq(await market.global(), {
-                currentId: 1,
-                latestId: 0,
-                protocolFee: 0,
-                oracleFee: 0,
-                riskFee: 0,
-                donation: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrder(1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 2,
-                makerPos: POSITION,
-                shortPos: POSITION.div(4),
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-                ...DEFAULT_VERSION,
-              })
-            })
-
-            it('closes the position', async () => {
-              await expect(market.connect(user).update(user.address, 0, 0, 0, 0, false))
-                .to.emit(market, 'Updated')
-                .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, 0, false)
-                .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    orders: 1,
-                    shortNeg: POSITION.div(2),
-                  },
-                  0,
-                )
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 1,
-                latestId: 0,
-                collateral: COLLATERAL,
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, 1), {
-                ...DEFAULT_CHECKPOINT,
-                delta: COLLATERAL,
-              })
-              expectGlobalEq(await market.global(), {
-                currentId: 1,
-                latestId: 0,
-                protocolFee: 0,
-                oracleFee: 0,
-                riskFee: 0,
-                donation: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrder(1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                makerPos: POSITION,
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-                ...DEFAULT_VERSION,
-              })
-            })
-
             context('settles first', async () => {
               beforeEach(async () => {
                 oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -5883,7 +5530,7 @@ describe('Market', () => {
                 expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_3.timestamp,
-                  orders: 1,
+                  orders: 2,
                   shortNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, 2), {
@@ -5907,7 +5554,7 @@ describe('Market', () => {
                 expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_3.timestamp,
-                  orders: 1,
+                  orders: 2,
                   shortNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
@@ -8024,7 +7671,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
+                orders: 2,
                 longPos: POSITION,
               })
               expectCheckpointEq(await market.checkpoints(user.address, 1), {
@@ -8046,7 +7693,7 @@ describe('Market', () => {
               expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 3,
+                orders: 4,
                 makerPos: POSITION,
                 longPos: POSITION,
                 shortPos: POSITION,
@@ -8955,103 +8602,6 @@ describe('Market', () => {
               await market.connect(user).update(user.address, 0, POSITION.div(2), 0, COLLATERAL, false)
             })
 
-            it('closes the position partially', async () => {
-              await expect(market.connect(user).update(user.address, 0, POSITION.div(4), 0, 0, false))
-                .to.emit(market, 'Updated')
-                .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, POSITION.div(4), 0, 0, false)
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 1,
-                latestId: 0,
-                collateral: COLLATERAL,
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(4),
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, 1), {
-                ...DEFAULT_CHECKPOINT,
-                delta: COLLATERAL,
-              })
-              expectGlobalEq(await market.global(), {
-                currentId: 1,
-                latestId: 0,
-                protocolFee: 0,
-                oracleFee: 0,
-                riskFee: 0,
-                donation: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrder(1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 3,
-                makerPos: POSITION,
-                longPos: POSITION.div(4),
-                shortPos: POSITION,
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-                ...DEFAULT_VERSION,
-              })
-            })
-
-            it('closes the position', async () => {
-              await expect(market.connect(user).update(user.address, 0, 0, 0, 0, false))
-                .to.emit(market, 'Updated')
-                .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, 0, false)
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 1,
-                latestId: 0,
-                collateral: COLLATERAL,
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, 1), {
-                ...DEFAULT_CHECKPOINT,
-                delta: COLLATERAL,
-              })
-              expectGlobalEq(await market.global(), {
-                currentId: 1,
-                latestId: 0,
-                protocolFee: 0,
-                oracleFee: 0,
-                riskFee: 0,
-                donation: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_1.timestamp,
-              })
-              expectOrderEq(await market.pendingOrder(1), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 2,
-                makerPos: POSITION,
-                shortPos: POSITION,
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
-                ...DEFAULT_VERSION,
-              })
-            })
-
             context('settles first', async () => {
               beforeEach(async () => {
                 oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -9229,7 +8779,7 @@ describe('Market', () => {
                 expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_3.timestamp,
-                  orders: 1,
+                  orders: 2,
                   longNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, 2), {
@@ -9254,7 +8804,7 @@ describe('Market', () => {
                 expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_3.timestamp,
-                  orders: 1,
+                  orders: 2,
                   longNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
@@ -14828,11 +14378,13 @@ describe('Market', () => {
           dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
         })
 
-        it('can switch current before settlement', async () => {
+        it('cant switch current before settlement', async () => {
           await market.connect(userB).update(userB.address, POSITION, 0, 0, COLLATERAL, false)
           await market.connect(user).update(user.address, 0, POSITION, 0, COLLATERAL, false)
 
-          await expect(market.connect(user).update(user.address, 0, 0, POSITION, 0, false)).to.not.be.reverted
+          await expect(
+            market.connect(user).update(user.address, 0, 0, POSITION, 0, false),
+          ).to.be.revertedWithCustomError(market, 'MarketOverCloseError')
         })
 
         it('cant switch current after latest settles', async () => {


### PR DESCRIPTION
- Properly hooks up the local implementation of `Order` storage from: https://github.com/equilibria-xyz/perennial-v2/pull/208.
- Removes order simplification when opening and closing two orders in a single version
  - Records opening and closing separately along with total order count.

### Invariant
#### Increases Strictness
- No longer can open an close or open and switch sides during a single current version.