### PR TITLE
[Cleanup] Only load Version / Checkpoint once

### DIFF
--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -25,10 +25,12 @@ interface IMarket is IInstance {
         MarketParameter marketParameter;
         RiskParameter riskParameter;
         uint256 currentTimestamp;
-        OracleVersion latestVersion;
-        OracleVersion positionVersion;
+        OracleVersion latestOracleVersion;
+        OracleVersion orderOracleVersion;
         Global global;
         Local local;
+        Version latestVersion;
+        Checkpoint latestCheckpoint;
         PositionContext latestPosition;
         PositionContext currentPosition;
         OrderContext order;

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -45,10 +45,10 @@ using OrderStorageLocalLib for OrderStorageLocal global;
 /// @title Order
 /// @notice Holds the state for an account's update order
 library OrderLib {
-    /// @notice Returns whether the position is ready to be settled
-    /// @param self The position object to check
+    /// @notice Returns whether the order is ready to be settled
+    /// @param self The order object to check
     /// @param latestVersion The latest oracle version
-    /// @return Whether the position is ready to be settled
+    /// @return Whether the order is ready to be settled
     function ready(Order memory self, OracleVersion memory latestVersion) internal pure returns (bool) {
         return latestVersion.timestamp >= self.timestamp;
     }


### PR DESCRIPTION
Moves `latestVersion` and `latestCheckpoint` into the settlement context so that they only need to be loaded from storage once.