### PR TITLE
[Cleanup] Add order protection

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -51,7 +51,6 @@ export interface Local {
   currentId: BigNumberish
   latestId: BigNumberish
   collateral: BigNumberish
-  protection: BigNumberish
 }
 
 export interface Version {
@@ -112,7 +111,6 @@ export function expectLocalEq(a: Local, b: Local): void {
   expect(a.currentId).to.equal(b.currentId, 'Local:Currentid')
   expect(a.latestId).to.equal(b.latestId, 'Local:LatestId')
   expect(a.collateral).to.equal(b.collateral, 'Local:Collateral')
-  expect(a.protection).to.equal(b.protection, 'Local:Protection')
 }
 
 export function expectVersionEq(a: Version, b: Version): void {

--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -28,6 +28,7 @@ export interface Order {
   longNeg: BigNumberish
   shortPos: BigNumberish
   shortNeg: BigNumberish
+  protection: BigNumberish
 }
 
 export interface Position {
@@ -88,6 +89,7 @@ export function expectOrderEq(a: Order, b: Order): void {
   expect(a.longNeg).to.equal(b.longNeg, 'Order:LongNeg')
   expect(a.shortPos).to.equal(b.shortPos, 'Order:ShortPos')
   expect(a.shortNeg).to.equal(b.shortNeg, 'Order:ShortNeg')
+  expect(a.protection).to.equal(b.protection, 'Order:Protection')
 }
 
 export function expectPositionEq(a: Position, b: Position): void {
@@ -184,6 +186,7 @@ export const DEFAULT_ORDER: Order = {
   shortPos: 0,
   shortNeg: 0,
   collateral: 0,
+  protection: 0,
 }
 
 export const DEFAULT_VERSION: Version = {

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1789,7 +1789,7 @@ describe('Vault', () => {
           expect((await btcMarket.locals(vault.address)).collateral).to.equal(
             BigNumber.from('4428767485').add(EXPECTED_LIQUIDATION_FEE),
           ) // no shortfall
-          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 3))
+          expect((await btcMarket.pendingOrders(vault.address, 2)).protection).to.equal(1)
 
           await expect(vault.connect(user).update(user.address, 0, 0, 0)).to.be.reverted
 
@@ -1830,7 +1830,7 @@ describe('Vault', () => {
           expect((await btcMarket.locals(vault.address)).collateral).to.equal(
             BigNumber.from('-26673235277').add(EXPECTED_LIQUIDATION_FEE),
           ) // shortfall
-          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 3))
+          expect((await btcMarket.pendingOrders(vault.address, 2)).protection).to.equal(1)
 
           await expect(vault.connect(user).update(user.address, 0, 0, 0)).to.be.reverted
 
@@ -1888,7 +1888,7 @@ describe('Vault', () => {
           expect((await btcMarket.locals(vault.address)).collateral).to.equal(
             BigNumber.from('350411418').add(EXPECTED_LIQUIDATION_FEE),
           ) // no shortfall
-          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 6))
+          expect((await btcMarket.pendingOrders(vault.address, 3)).protection).to.equal(1)
 
           // 3. Settle the liquidation.
           // We now be able to deposit.
@@ -1927,7 +1927,7 @@ describe('Vault', () => {
           expect((await btcMarket.locals(vault.address)).collateral).to.equal(
             BigNumber.from('-480340107').add(EXPECTED_LIQUIDATION_FEE),
           ) // shortfall
-          expect((await btcMarket.locals(vault.address)).protection).to.equal(STARTING_TIMESTAMP.add(3600 * 6))
+          expect((await btcMarket.pendingOrders(vault.address, 3)).protection).to.equal(1)
 
           // 3. Settle the liquidation.
           // We now be able to deposit.

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -336,7 +336,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             collateral,
             newMaker,
             newLong,
-            newShort
+            newShort,
+            protect
         );
         context.currentPosition.global.update(newOrder, true);
         context.currentPosition.local.update(newOrder, true);

--- a/packages/perennial/contracts/test/CheckpointTester.sol
+++ b/packages/perennial/contracts/test/CheckpointTester.sol
@@ -16,13 +16,12 @@ contract CheckpointTester {
 
     function accumulate(
         Order memory order,
-        Local memory local,
         Position memory fromPosition,
         Version memory fromVersion,
         Version memory toVersion
     ) external returns (CheckpointAccumulationResult memory result) {
         Checkpoint memory newCheckpoint = checkpoint.read();
-        result = newCheckpoint.accumulate(order, local, fromPosition, fromVersion, toVersion);
+        result = newCheckpoint.accumulate(order, fromPosition, fromVersion, toVersion);
         checkpoint.store(newCheckpoint);
     }
 }

--- a/packages/perennial/contracts/test/LocalTester.sol
+++ b/packages/perennial/contracts/test/LocalTester.sol
@@ -31,14 +31,4 @@ contract LocalTester {
         newLocal.update(newId, collateral, tradeFee, settlementFee, liquidationFee);
         local.store(newLocal);
     }
-
-    function protect(
-        OracleVersion memory latestVersion,
-        uint256 currentTimestamp,
-        bool tryProtect
-    ) external returns (bool result) {
-        Local memory newLocal = local.read();
-        result = newLocal.protect(latestVersion, currentTimestamp, tryProtect);
-        local.store(newLocal);
-    }
 }

--- a/packages/perennial/contracts/types/Checkpoint.sol
+++ b/packages/perennial/contracts/types/Checkpoint.sol
@@ -46,7 +46,6 @@ library CheckpointLib {
     function accumulate(
         Checkpoint memory self,
         Order memory order,
-        Local memory local,
         Position memory fromPosition,
         Version memory fromVersion,
         Version memory toVersion
@@ -55,7 +54,7 @@ library CheckpointLib {
         result.collateral = _accumulateCollateral(fromPosition, fromVersion, toVersion);
         result.tradeFee = _accumulateTradeFee(order, toVersion);
         result.settlementFee = _accumulateSettlementFee(order, toVersion);
-        result.liquidationFee = _accumulateLiquidationFee(order, local, toVersion);
+        result.liquidationFee = _accumulateLiquidationFee(order, toVersion);
 
         // update checkpoint
         self.collateral = self.collateral
@@ -108,14 +107,12 @@ library CheckpointLib {
 
     /// @notice Accumulate liquidation fees for the next position
     /// @param order The next order
-    /// @param local The local state
     /// @param toVersion The next version
     function _accumulateLiquidationFee(
         Order memory order,
-        Local memory local,
         Version memory toVersion
     ) private pure returns (UFixed6 liquidationFee) {
-        if (local.protection == order.timestamp)
+        if (order.protected())
             return toVersion.liquidationFee.accumulated(Accumulator6(Fixed6Lib.ZERO), UFixed6Lib.ONE).abs();
     }
 }

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -27,7 +27,6 @@ struct Global {
 
     /// @dev The current PAccumulator state
     PAccumulator6 pAccumulator;
-
 }
 using GlobalLib for Global global;
 struct GlobalStorage { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -35,6 +35,9 @@ struct Order {
 
     /// @dev The negative skew short order size
     UFixed6 shortNeg;
+
+    /// @dev The protection status semaphore
+    uint256 protection;
 }
 using OrderLib for Order global;
 struct OrderStorageGlobal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
@@ -57,8 +60,8 @@ library OrderLib {
     /// @param self The order object to update
     /// @param timestamp The current timestamp
     function next(Order memory self, uint256 timestamp) internal pure  {
-        (self.timestamp, self.orders, self.collateral) =
-            (timestamp, 0, Fixed6Lib.ZERO);
+        (self.timestamp, self.orders, self.collateral, self.protection) =
+            (timestamp, 0, Fixed6Lib.ZERO, 0);
         (self.makerPos, self.makerNeg, self.longPos, self.longNeg, self.shortPos, self.shortNeg) =
             (UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
     }
@@ -70,6 +73,7 @@ library OrderLib {
     /// @param newMaker The new maker
     /// @param newLong The new long
     /// @param newShort The new short
+    /// @param protect Whether to protect the order
     /// @return newOrder The resulting order
     function from(
         uint256 timestamp,
@@ -77,7 +81,8 @@ library OrderLib {
         Fixed6 collateral,
         UFixed6 newMaker,
         UFixed6 newLong,
-        UFixed6 newShort
+        UFixed6 newShort,
+        bool protect
     ) internal pure returns (Order memory newOrder) {
         (Fixed6 makerAmount, Fixed6 longAmount, Fixed6 shortAmount) = (
             Fixed6Lib.from(newMaker).sub(Fixed6Lib.from(position.maker)),
@@ -94,7 +99,8 @@ library OrderLib {
             longAmount.max(Fixed6Lib.ZERO).abs(),
             longAmount.min(Fixed6Lib.ZERO).abs(),
             shortAmount.max(Fixed6Lib.ZERO).abs(),
-            shortAmount.min(Fixed6Lib.ZERO).abs()
+            shortAmount.min(Fixed6Lib.ZERO).abs(),
+            protect ? 1 : 0
         );
         if (!isEmpty(newOrder)) newOrder.orders = 1;
     }
@@ -226,7 +232,8 @@ library OrderLib {
     /// @param self The order object to update
     /// @param order The new order
     function add(Order memory self, Order memory order) internal pure {
-        (self.orders, self.collateral) = (self.orders + order.orders, self.collateral.add(order.collateral));
+        (self.orders, self.collateral, self.protection) =
+            (self.orders + order.orders, self.collateral.add(order.collateral), self.protection + order.protection);
 
         (self.makerPos, self.makerNeg, self.longPos, self.longNeg, self.shortPos, self.shortNeg) = (
             self.makerPos.add(order.makerPos),
@@ -242,7 +249,8 @@ library OrderLib {
     /// @param self The order object to update
     /// @param order The latest order
     function sub(Order memory self, Order memory order) internal pure {
-        (self.orders, self.collateral) = (self.orders - order.orders, self.collateral.sub(order.collateral));
+        (self.orders, self.collateral, self.protection) =
+            (self.orders - order.orders, self.collateral.sub(order.collateral), self.protection - order.protection);
 
         (self.makerPos, self.makerNeg, self.longPos, self.longNeg, self.shortPos, self.shortNeg) = (
             self.makerPos.sub(order.makerPos),
@@ -285,7 +293,8 @@ library OrderStorageGlobalLib {
             UFixed6.wrap(uint256(slot1 << (256 - 64)) >> (256 - 64)),
             UFixed6.wrap(uint256(slot1 << (256 - 64 - 64)) >> (256 - 64)),
             UFixed6.wrap(uint256(slot1 << (256 - 64 - 64 - 64)) >> (256 - 64)),
-            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64 - 64 - 64)) >> (256 - 64))
+            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64 - 64 - 64)) >> (256 - 64)),
+            0
         );
     }
 
@@ -326,8 +335,9 @@ library OrderStorageGlobalLib {
 ///         uint32 orders;
 ///         int64 collateral;
 ///         uint2 direction;
-///         uint63 magnitudePos;
-///         uint63 magnitudeNeg;
+///         uint62 magnitudePos;
+///         uint62 magnitudeNeg;
+///         uint1 protection;
 ///     }
 ///
 library OrderStorageLocalLib {
@@ -335,8 +345,8 @@ library OrderStorageLocalLib {
         uint256 slot0 = self.slot0;
 
         uint256 direction = uint256(slot0 << (256 - 32 - 32 - 64 - 2)) >> (256 - 2);
-        UFixed6 magnitudePos = UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 63)) >> (256 - 63));
-        UFixed6 magnitudeNeg = UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 63 - 63)) >> (256 - 63));
+        UFixed6 magnitudePos = UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 62)) >> (256 - 62));
+        UFixed6 magnitudeNeg = UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 62 - 62)) >> (256 - 62));
 
         return Order(
             uint256(slot0 << (256 - 32)) >> (256 - 32),
@@ -347,7 +357,8 @@ library OrderStorageLocalLib {
             direction == 1 ? magnitudePos : UFixed6Lib.ZERO,
             direction == 1 ? magnitudeNeg : UFixed6Lib.ZERO,
             direction == 2 ? magnitudePos : UFixed6Lib.ZERO,
-            direction == 2 ? magnitudeNeg : UFixed6Lib.ZERO
+            direction == 2 ? magnitudeNeg : UFixed6Lib.ZERO,
+            uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 62 - 62 - 1)) >> (256 - 1)
         );
     }
 
@@ -358,14 +369,16 @@ library OrderStorageLocalLib {
 
         if (magnitudePos.gt(UFixed6.wrap(2 ** 63 - 1))) revert OrderStorageLib.OrderStorageInvalidError();
         if (magnitudeNeg.gt(UFixed6.wrap(2 ** 63 - 1))) revert OrderStorageLib.OrderStorageInvalidError();
+        if (newValue.protection > 1) revert OrderStorageLib.OrderStorageInvalidError();
 
         uint256 encoded =
             uint256(newValue.timestamp << (256 - 32)) >> (256 - 32) |
             uint256(newValue.orders << (256 - 32)) >> (256 - 32 - 32) |
             uint256(Fixed6.unwrap(newValue.collateral) << (256 - 64)) >> (256 - 32 - 32 - 64) |
             uint256(newValue.direction() << (256 - 2)) >> (256 - 32 - 32 - 64 - 2) |
-            uint256(UFixed6.unwrap(magnitudePos) << (256 - 63)) >> (256 - 32 - 32 - 64 - 2 - 63) |
-            uint256(UFixed6.unwrap(magnitudeNeg) << (256 - 63)) >> (256 - 32 - 32 - 64 - 2 - 63 - 63);
+            uint256(UFixed6.unwrap(magnitudePos) << (256 - 62)) >> (256 - 32 - 32 - 64 - 2 - 62) |
+            uint256(UFixed6.unwrap(magnitudeNeg) << (256 - 62)) >> (256 - 32 - 32 - 64 - 2 - 62 - 62) |
+            uint256(newValue.protection << (256 - 1)) >> (256 - 32 - 32 - 64 - 2 - 62 - 62 - 1);
 
         assembly {
             sstore(self.slot, encoded)

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -154,6 +154,13 @@ library OrderLib {
             ((long(self).isZero() && short(self).isZero()) || !marketParameter.takerCloseAlways || increasesTaker(self));
     }
 
+    /// @notice Returns whether the order is protected
+    /// @param self The order object to check
+    /// @return Whether the order is empty
+    function protected(Order memory self) internal pure returns (bool) {
+        return self.protection != 0;
+    }
+
     /// @notice Returns whether the order is empty
     /// @param self The order object to check
     /// @return Whether the order is empty

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -156,7 +156,7 @@ library OrderLib {
 
     /// @notice Returns whether the order is protected
     /// @param self The order object to check
-    /// @return Whether the order is empty
+    /// @return Whether the order is protected
     function protected(Order memory self) internal pure returns (bool) {
         return self.protection != 0;
     }

--- a/packages/perennial/test/integration/core/closedProduct.test.ts
+++ b/packages/perennial/test/integration/core/closedProduct.test.ts
@@ -134,7 +134,7 @@ describe('Closed Market', () => {
     await chainlink.next()
     await chainlink.nextWithPriceModification(price => price.mul(2))
     await expect(market.connect(userB).update(user.address, 0, 0, 0, 0, true)).to.not.be.reverted
-    expect((await market.locals(user.address)).protection).to.eq(TIMESTAMP_3)
+    expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
     const parameters = { ...(await market.parameter()) }
     parameters.closed = true
     await market.updateParameter(beneficiaryB.address, AddressZero, parameters)
@@ -144,7 +144,7 @@ describe('Closed Market', () => {
     await settle(market, userB)
 
     expect((await market.position()).timestamp).to.eq(TIMESTAMP_3)
-    expect((await market.locals(user.address)).protection).to.eq(TIMESTAMP_3)
+    expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
     const userCollateralBefore = (await market.locals(user.address)).collateral
     const userBCollateralBefore = (await market.locals(userB.address)).collateral
     const feesABefore = (await market.global()).protocolFee

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -32,7 +32,7 @@ describe('Liquidate', () => {
       .to.emit(market, 'Updated')
       .withArgs(userB.address, user.address, TIMESTAMP_2, 0, 0, 0, 0, true)
 
-    expect((await market.locals(user.address)).protection).to.eq(TIMESTAMP_2)
+    expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
     expect(await market.liquidators(user.address, 2)).to.eq(userB.address)
 
     expect((await market.locals(user.address)).collateral).to.equal(COLLATERAL)
@@ -50,7 +50,7 @@ describe('Liquidate', () => {
     await market.connect(user).update(user.address, 0, 0, 0, constants.MinInt256, false) // withdraw everything
 
     expect((await market.position()).timestamp).to.eq(TIMESTAMP_2)
-    expect((await market.locals(user.address)).protection).to.eq(TIMESTAMP_2)
+    expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
   })
 
   it('creates and resolves a shortfall', async () => {

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -3635,7 +3635,6 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_150)
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(22), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -3830,7 +3829,6 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_150.add(EXPECTED_INTEREST_WITHOUT_FEE_2).mul(4).div(5))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(16), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -4010,7 +4008,6 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .sub(EXPECTED_PNL)
                   .sub(8), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -4023,6 +4020,7 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
                 makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -4110,7 +4108,6 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -4191,7 +4188,6 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
                   .sub(EXPECTED_FUNDING_WITH_FEE_2_5_96.add(EXPECTED_INTEREST_5_96))
                   .sub(EXPECTED_LIQUIDATION_FEE),
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectLocalEq(await market.locals(liquidator.address), {
@@ -4341,7 +4337,6 @@ describe('Market', () => {
                 collateral: parse6decimal('216')
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
                   .sub(EXPECTED_PNL),
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -4354,6 +4349,7 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
                 longNeg: POSITION.div(2),
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -4453,7 +4449,6 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectLocalEq(await market.locals(liquidator.address), {
@@ -6367,7 +6362,6 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_5_96))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(20), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -6558,7 +6552,6 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_2).mul(4).div(5))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(17), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -6730,7 +6723,6 @@ describe('Market', () => {
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
                   .sub(EXPECTED_PNL)
                   .sub(8), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectOrderEq(await market.pendingOrders(userB.address, 3), {
@@ -6738,6 +6730,7 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
                 makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -6823,7 +6816,6 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -6912,7 +6904,6 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_2_5_150)
                   .sub(EXPECTED_INTEREST_5_150)
                   .sub(EXPECTED_LIQUIDATION_FEE),
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -7061,7 +7052,6 @@ describe('Market', () => {
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(EXPECTED_PNL),
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -7074,6 +7064,7 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
                 shortNeg: POSITION.div(2),
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -7180,7 +7171,6 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -9630,7 +9620,6 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_45_ALL)
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(25), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -9867,7 +9856,6 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_2.mul(10).div(12))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(19), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -10054,7 +10042,6 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(EXPECTED_PNL)
                   .sub(13), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -10067,6 +10054,7 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
                 makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -10162,7 +10150,6 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
@@ -10269,7 +10256,6 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_96_ALL.div(3))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(9), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -10471,7 +10457,6 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(EXPECTED_PNL)
                   .sub(2), // loss of precision
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -10484,6 +10469,7 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
                 longNeg: POSITION.div(2),
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -10600,7 +10586,6 @@ describe('Market', () => {
                 currentId: 4,
                 latestId: 3,
                 collateral: 0,
-                protection: ORACLE_VERSION_4.timestamp,
               })
               expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
@@ -11290,7 +11275,6 @@ describe('Market', () => {
             collateral: parse6decimal('216')
               .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
               .sub(EXPECTED_PNL),
-            protection: ORACLE_VERSION_4.timestamp,
           })
           expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
           expectPositionEq(await market.positions(user.address), {
@@ -11303,6 +11287,7 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             orders: 1,
             longNeg: POSITION.div(2),
+            protection: 1,
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -11534,7 +11519,6 @@ describe('Market', () => {
               .sub(EXPECTED_INTEREST_5_150)
               .sub(EXPECTED_ROUND_3_ACC)
               .sub(EXPECTED_LIQUIDATION_FEE), // does not double charge
-            protection: ORACLE_VERSION_5.timestamp,
           })
           expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
           expectPositionEq(await market.positions(user.address), {

--- a/packages/perennial/test/unit/types/Checkpoint.test.ts
+++ b/packages/perennial/test/unit/types/Checkpoint.test.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_CHECKPOINT,
   DEFAULT_VERSION,
   DEFAULT_POSITION,
-  DEFAULT_LOCAL,
   parse6decimal,
 } from '../../../../common/testutil/types'
 
@@ -236,14 +235,12 @@ describe('Checkpoint', () => {
       it('accumulates transfer', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, collateral: parse6decimal('123') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, collateral: parse6decimal('123') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION },
@@ -256,14 +253,12 @@ describe('Checkpoint', () => {
       it('accumulates pnl (maker)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION, maker: parse6decimal('10') },
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('200') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION, maker: parse6decimal('10') },
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('200') } },
@@ -277,14 +272,12 @@ describe('Checkpoint', () => {
       it('accumulates pnl (long)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION, long: parse6decimal('10') },
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('200') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION, long: parse6decimal('10') },
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('200') } },
@@ -298,14 +291,12 @@ describe('Checkpoint', () => {
       it('accumulates pnl (short)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION, short: parse6decimal('10') },
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('200') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION, short: parse6decimal('10') },
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('200') } },
@@ -319,14 +310,12 @@ describe('Checkpoint', () => {
       it('accumulates fees (maker pos)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerPosFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerPosFee: { _value: parse6decimal('-2') } },
@@ -340,14 +329,12 @@ describe('Checkpoint', () => {
       it('accumulates fees (maker neg)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, makerNeg: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerNegFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, makerNeg: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerNegFee: { _value: parse6decimal('-2') } },
@@ -361,14 +348,12 @@ describe('Checkpoint', () => {
       it('accumulates fees (long pos)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosFee: { _value: parse6decimal('-2') } },
@@ -382,14 +367,12 @@ describe('Checkpoint', () => {
       it('accumulates fees (short neg)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, shortNeg: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, shortNeg: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosFee: { _value: parse6decimal('-2') } },
@@ -403,14 +386,12 @@ describe('Checkpoint', () => {
       it('accumulates fees (long neg)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, longNeg: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, longNeg: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegFee: { _value: parse6decimal('-2') } },
@@ -424,14 +405,12 @@ describe('Checkpoint', () => {
       it('accumulates fees (short pos)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, shortPos: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, shortPos: parse6decimal('10') },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegFee: { _value: parse6decimal('-2') } },
@@ -445,14 +424,12 @@ describe('Checkpoint', () => {
       it('accumulates settlement fee', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, orders: 2 },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, settlementFee: { _value: parse6decimal('-4') } },
         )
         await checkpoint.accumulate(
           { ...DEFAULT_ORDER, orders: 2 },
-          { ...DEFAULT_LOCAL },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, settlementFee: { _value: parse6decimal('-4') } },
@@ -465,15 +442,13 @@ describe('Checkpoint', () => {
 
       it('accumulates liquidation fee', async () => {
         const result = await checkpoint.callStatic.accumulate(
-          { ...DEFAULT_ORDER, timestamp: 123 },
-          { ...DEFAULT_LOCAL, protection: 123 },
+          { ...DEFAULT_ORDER, protection: 1 },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, liquidationFee: { _value: parse6decimal('-4') } },
         )
         await checkpoint.accumulate(
-          { ...DEFAULT_ORDER },
-          { ...DEFAULT_LOCAL },
+          { ...DEFAULT_ORDER, protection: 1 },
           { ...DEFAULT_POSITION },
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, liquidationFee: { _value: parse6decimal('-4') } },

--- a/packages/perennial/test/unit/types/Position.test.ts
+++ b/packages/perennial/test/unit/types/Position.test.ts
@@ -35,6 +35,7 @@ const VALID_ORDER = {
   longNeg: parse6decimal('3'),
   shortPos: parse6decimal('6'),
   shortNeg: parse6decimal('3'),
+  protection: 1,
 }
 
 describe('Position', () => {

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -45,7 +45,6 @@ const GLOBAL: GlobalStruct = {
     _value: 6,
     _skew: 7,
   },
-  latestPrice: 8,
 }
 
 const FROM_POSITION: PositionStruct = {
@@ -65,6 +64,7 @@ const ORDER: OrderStruct = {
   longNeg: 0,
   shortPos: 45,
   shortNeg: 0,
+  protection: 1,
 }
 
 const TIMESTAMP = 1636401093


### PR DESCRIPTION
- Adds a `1-bit` protection semaphore to the `Order`
- Account-level protection can be access via pending `Order`