### PR TITLE
[Fix] _credit incrementing collateral

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -51,6 +51,7 @@ export interface Local {
   currentId: BigNumberish
   latestId: BigNumberish
   collateral: BigNumberish
+  claimable: BigNumberish
 }
 
 export interface Version {
@@ -111,6 +112,7 @@ export function expectLocalEq(a: Local, b: Local): void {
   expect(a.currentId).to.equal(b.currentId, 'Local:Currentid')
   expect(a.latestId).to.equal(b.latestId, 'Local:LatestId')
   expect(a.collateral).to.equal(b.collateral, 'Local:Collateral')
+  expect(a.claimable).to.equal(b.claimable, 'Local:Claimable')
 }
 
 export function expectVersionEq(a: Version, b: Version): void {
@@ -171,6 +173,7 @@ export const DEFAULT_LOCAL: Local = {
   currentId: 0,
   latestId: 0,
   collateral: 0,
+  claimable: 0,
 }
 
 export const DEFAULT_ORDER: Order = {

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1797,8 +1797,7 @@ describe('Vault', () => {
           // We now be able to deposit.
           await updateOracle()
           await btcMarket.connect(user).update(vault.address, 0, 0, 0, 0, false)
-
-          await btcMarket.connect(user).update(user.address, 0, 0, 0, -2, false)
+          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()
@@ -1838,9 +1837,9 @@ describe('Vault', () => {
           // We now be able to deposit.
           await updateOracle()
           await btcMarket.connect(user).update(vault.address, 0, 0, 0, 0, false)
-
-          await btcMarket.connect(user).update(user.address, 0, 0, 0, -2, false)
+          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
+
           await updateOracle()
           await vault.settle(user.address)
 
@@ -1894,8 +1893,7 @@ describe('Vault', () => {
           // We now be able to deposit.
           await updateOracle()
           await btcMarket.connect(user).update(vault.address, 0, 0, 0, 0, false)
-
-          await btcMarket.connect(user).update(user.address, 0, 0, 0, -2, false)
+          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()
@@ -1933,8 +1931,7 @@ describe('Vault', () => {
           // We now be able to deposit.
           await updateOracle()
           await btcMarket.connect(user).update(vault.address, 0, 0, 0, 0, false)
-
-          await btcMarket.connect(user).update(user.address, 0, 0, 0, -2, false)
+          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -151,7 +151,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     }
 
     /// @notice Claims any available fee that the sender has accrued
-    /// @dev Applicable fees include: protocol, oracle, risk, and donation
+    /// @dev Applicable fees include: protocol, oracle, risk, donation, and claimable
     function claimFee() external {
         Global memory newGlobal = _global.read();
         Local memory newLocal = _locals[msg.sender].read();
@@ -167,8 +167,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         _locals[msg.sender].store(newLocal);
     }
 
-    /// @notice Claims any claimeable that the sender has accrued
-    /// @dev Applicable fees include: protocol, oracle, risk, and donation
+    /// @notice Settles any exposure that has accrued to the market
+    /// @dev Resets exposure to zero, caller pays or receives to net out the exposure
     function claimExposure() external onlyOwner {
         Global memory newGlobal = _global.read();
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -185,7 +185,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @param receiver The address to receive the fee
     /// @param fee The amount of the fee to claim
     function _claimFee(address receiver, UFixed6 fee) private returns (bool) {
-        if (msg.sender != receiver) return false;
+        if (msg.sender != receiver || fee.isZero()) return false;
 
         token.push(receiver, UFixed18Lib.from(fee));
         emit FeeClaimed(receiver, fee);

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -54,6 +54,7 @@ interface IMarket is IInstance {
     event BeneficiaryUpdated(address newBeneficiary);
     event CoordinatorUpdated(address newCoordinator);
     event FeeClaimed(address indexed account, UFixed6 amount);
+    event ExposureClaimed(address indexed account, Fixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);
 

--- a/packages/perennial/contracts/test/GlobalTester.sol
+++ b/packages/perennial/contracts/test/GlobalTester.sol
@@ -14,14 +14,16 @@ contract GlobalTester {
         return global.store(newGlobal);
     }
 
-    function incrementFees(
-        UFixed6 amount,
+    function update(
+        uint256 newLatestId,
+        UFixed6 marketFee,
         UFixed6 settlementFee,
+        Fixed6 marketExposure,
         MarketParameter memory marketParameter,
         ProtocolParameter memory protocolParameter
     ) external {
         Global memory newGlobal = global.read();
-        newGlobal.incrementFees(amount, settlementFee, marketParameter, protocolParameter);
+        newGlobal.update(newLatestId, marketFee, settlementFee, marketExposure, marketParameter, protocolParameter);
         global.store(newGlobal);
     }
 }

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -117,6 +117,8 @@ library GlobalStorageLib {
         if (newValue.oracleFee.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
         if (newValue.riskFee.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
         if (newValue.donation.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
+        if (newValue.exposure.gt(Fixed6.wrap(type(int64).max))) revert GlobalStorageInvalidError();
+        if (newValue.exposure.lt(Fixed6.wrap(type(int64).min))) revert GlobalStorageInvalidError();
         if (newValue.pAccumulator._value.gt(Fixed6.wrap(type(int32).max))) revert GlobalStorageInvalidError();
         if (newValue.pAccumulator._value.lt(Fixed6.wrap(type(int32).min))) revert GlobalStorageInvalidError();
         if (newValue.pAccumulator._skew.gt(Fixed6.wrap(type(int24).max))) revert GlobalStorageInvalidError();
@@ -132,7 +134,8 @@ library GlobalStorageLib {
 
         uint256 encoded1 =
             uint256(Fixed6.unwrap(newValue.pAccumulator._value) << (256 - 32)) >> (256 - 32) |
-            uint256(Fixed6.unwrap(newValue.pAccumulator._skew) << (256 - 24)) >> (256 - 32 - 24);
+            uint256(Fixed6.unwrap(newValue.pAccumulator._skew) << (256 - 24)) >> (256 - 32 - 24) |
+            uint256(Fixed6.unwrap(newValue.exposure) << (256 - 64)) >> (256 - 32 - 24 - 64 - 64);
 
         assembly {
             sstore(self.slot, encoded0)

--- a/packages/perennial/contracts/types/Local.sol
+++ b/packages/perennial/contracts/types/Local.sol
@@ -101,6 +101,7 @@ library LocalStorageLib {
         if (newValue.latestId > uint256(type(uint32).max)) revert LocalStorageInvalidError();
         if (newValue.collateral.gt(Fixed6.wrap(type(int64).max))) revert LocalStorageInvalidError();
         if (newValue.collateral.lt(Fixed6.wrap(type(int64).min))) revert LocalStorageInvalidError();
+        if (newValue.claimable.gt(UFixed6.wrap(type(uint64).max))) revert LocalStorageInvalidError();
 
         uint256 encoded0 =
             uint256(newValue.currentId << (256 - 32)) >> (256 - 32) |

--- a/packages/perennial/contracts/types/Local.sol
+++ b/packages/perennial/contracts/types/Local.sol
@@ -20,6 +20,9 @@ struct Local {
 
     /// @dev The collateral balance
     Fixed6 collateral;
+
+    /// @dev The claimable balance
+    UFixed6 claimable;
 }
 using LocalLib for Local global;
 struct LocalStorage { uint256 slot0; }
@@ -56,6 +59,13 @@ library LocalLib {
             .sub(Fixed6Lib.from(liquidationFee));
         self.latestId = newId;
     }
+
+    /// @notice Updates the claimable with the new amount
+    /// @param self The Local object to update
+    /// @param amount The amount to update the claimable by
+    function credit(Local memory self, UFixed6 amount) internal pure {
+        self.claimable = self.claimable.add(amount);
+    }
 }
 
 /// @dev Manually encodes and decodes the Local struct into storage.
@@ -65,7 +75,11 @@ library LocalLib {
 ///         uint32 currentId;       // <= 4.29b
 ///         uint32 latestId;        // <= 4.29b
 ///         int64 collateral;       // <= 9.22t
-///         uint96 __unallocated__;
+///         uint64 claimable;       // <= 18.44t
+///         bytes4 __DEPRECATED;    // UNSAFE UNTIL RESET
+///
+///         /* slot 1 */
+///         bytes28 __DEPRECATED;   // UNSAFE UNTIL RESET
 ///     }
 ///
 library LocalStorageLib {
@@ -77,7 +91,8 @@ library LocalStorageLib {
         return Local(
             uint256(slot0 << (256 - 32)) >> (256 - 32),
             uint256(slot0 << (256 - 32 - 32)) >> (256 - 32),
-            Fixed6.wrap(int256(slot0 << (256 - 32 - 32 - 64)) >> (256 - 64))
+            Fixed6.wrap(int256(slot0 << (256 - 32 - 32 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 64)) >> (256 - 64))
         );
     }
 
@@ -90,9 +105,13 @@ library LocalStorageLib {
         uint256 encoded0 =
             uint256(newValue.currentId << (256 - 32)) >> (256 - 32) |
             uint256(newValue.latestId << (256 - 32)) >> (256 - 32 - 32) |
-            uint256(Fixed6.unwrap(newValue.collateral) << (256 - 64)) >> (256 - 32 - 32 - 64);
+            uint256(Fixed6.unwrap(newValue.collateral) << (256 - 64)) >> (256 - 32 - 32 - 64) |
+            uint256(UFixed6.unwrap(newValue.claimable) << (256 - 64)) >> (256 - 32 - 32 - 64 - 64);
+        uint256 encoded1; // reset deprecated storage on settlement
+
         assembly {
             sstore(self.slot, encoded0)
+            sstore(add(self.slot, 1), encoded1)
         }
     }
 }

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -40,8 +40,8 @@ describe('Liquidate', () => {
 
     await chainlink.next()
     await market.connect(user).update(user.address, 0, 0, 0, 0, false) // settle
-    expect((await market.locals(userB.address)).collateral).to.equal(parse6decimal('10'))
-    await market.connect(userB).update(userB.address, 0, 0, 0, constants.MinInt256, false) // liquidator withdrawal
+    expect((await market.locals(userB.address)).claimable).to.equal(parse6decimal('10'))
+    await market.connect(userB).claimFee() // liquidator withdrawal
 
     expect(await dsu.balanceOf(userB.address)).to.equal(utils.parseEther('200010')) // Original 200000 + fee
     expect((await market.locals(user.address)).collateral).to.equal(parse6decimal('1000').sub(parse6decimal('10')))

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -737,7 +737,11 @@ describe('Market', () => {
             .to.emit(market, 'Updated')
             .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, 0, COLLATERAL.mul(-1), false)
             .to.emit(market, 'OrderCreated')
-            .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: -COLLATERAL })
+            .withArgs(user.address, {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              collateral: -COLLATERAL,
+            })
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
@@ -966,16 +970,13 @@ describe('Market', () => {
               .to.emit(market, 'Updated')
               .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, POSITION, 0, 0, COLLATERAL, false)
               .to.emit(market, 'OrderCreated')
-              .withArgs(
-                user.address,
-                {
-                  ...DEFAULT_ORDER,
-                  orders: 1,
-                  timestamp: ORACLE_VERSION_2.timestamp,
-                  collateral: COLLATERAL,
-                  makerPos: POSITION,
-                },
-              )
+              .withArgs(user.address, {
+                ...DEFAULT_ORDER,
+                orders: 1,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                collateral: COLLATERAL,
+                makerPos: POSITION,
+              })
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
@@ -1889,16 +1890,13 @@ describe('Market', () => {
                 .to.emit(market, 'Updated')
                 .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, POSITION, 0, COLLATERAL, false)
                 .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    collateral: COLLATERAL,
-                    orders: 1,
-                    longPos: POSITION,
-                  },
-                )
+                .withArgs(user.address, {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  collateral: COLLATERAL,
+                  orders: 1,
+                  longPos: POSITION,
+                })
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -3600,7 +3598,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -3806,7 +3804,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -4101,7 +4099,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
@@ -4194,7 +4192,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -4455,7 +4453,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
@@ -4592,16 +4590,13 @@ describe('Market', () => {
                 .to.emit(market, 'Updated')
                 .withArgs(user.address, user.address, ORACLE_VERSION_2.timestamp, 0, 0, POSITION, COLLATERAL, false)
                 .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    collateral: COLLATERAL,
-                    orders: 1,
-                    shortPos: POSITION,
-                  },
-                )
+                .withArgs(user.address, {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  collateral: COLLATERAL,
+                  orders: 1,
+                  shortPos: POSITION,
+                })
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -6331,7 +6326,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -6517,7 +6512,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -6809,7 +6804,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
@@ -6892,7 +6887,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -7164,7 +7159,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -9583,7 +9578,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -9818,7 +9813,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -10143,7 +10138,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
@@ -10243,7 +10238,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -10579,7 +10574,7 @@ describe('Market', () => {
                 ...DEFAULT_LOCAL,
                 currentId: 0,
                 latestId: 0,
-                collateral: EXPECTED_LIQUIDATION_FEE,
+                claimable: EXPECTED_LIQUIDATION_FEE,
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -11420,13 +11415,20 @@ describe('Market', () => {
             ...DEFAULT_LOCAL,
             currentId: 0,
             latestId: 0,
-            collateral: EXPECTED_LIQUIDATION_FEE,
+            claimable: EXPECTED_LIQUIDATION_FEE,
           })
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
             timestamp: ORACLE_VERSION_5.timestamp,
             short: POSITION.div(4),
           })
+
+          dsu.transfer.whenCalledWith(liquidator.address, EXPECTED_LIQUIDATION_FEE.mul(1e12)).returns(true)
+          await expect(market.connect(liquidator).claimFee())
+            .to.emit(market, 'FeeClaimed')
+            .withArgs(liquidator.address, EXPECTED_LIQUIDATION_FEE)
+
+          expectLocalEq(await market.locals(liquidator.address), DEFAULT_LOCAL)
         })
       })
 
@@ -11506,7 +11508,7 @@ describe('Market', () => {
             ...DEFAULT_LOCAL,
             currentId: 0,
             latestId: 0,
-            collateral: EXPECTED_LIQUIDATION_FEE, // does not double charge
+            claimable: EXPECTED_LIQUIDATION_FEE, // does not double charge
           })
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
@@ -11629,6 +11631,13 @@ describe('Market', () => {
                 .mul(-1),
             },
           })
+
+          dsu.transfer.whenCalledWith(liquidator.address, EXPECTED_LIQUIDATION_FEE.mul(1e12)).returns(true)
+          await expect(market.connect(liquidator).claimFee())
+            .to.emit(market, 'FeeClaimed')
+            .withArgs(liquidator.address, EXPECTED_LIQUIDATION_FEE)
+
+          expectLocalEq(await market.locals(liquidator.address), DEFAULT_LOCAL)
         })
       })
 

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -6,11 +6,25 @@ import HRE from 'hardhat'
 import { GlobalTester, GlobalTester__factory } from '../../../types/generated'
 import { BigNumber, BigNumberish } from 'ethers'
 import { parse6decimal } from '../../../../common/testutil/types'
-import { MarketParameterStruct } from '../../../types/generated/contracts/Market'
+import { GlobalStruct, MarketParameterStruct } from '../../../types/generated/contracts/Market'
 import { ProtocolParameterStruct } from '../../../types/generated/contracts/MarketFactory'
 
 const { ethers } = HRE
 use(smock.matchers)
+
+const DEFAULT_GLOBAL: GlobalStruct = {
+  currentId: 0,
+  latestId: 0,
+  protocolFee: 0,
+  oracleFee: 0,
+  riskFee: 0,
+  donation: 0,
+  pAccumulator: {
+    _value: 0,
+    _skew: 0,
+  },
+  exposure: 0,
+}
 
 function generateMarketParameter(oracleFee: BigNumberish, riskFee: BigNumberish): MarketParameterStruct {
   return {
@@ -64,6 +78,7 @@ describe('Global', () => {
           _value: 6,
           _skew: 7,
         },
+        exposure: 8,
       })
 
       const value = await global.read()
@@ -75,22 +90,15 @@ describe('Global', () => {
       expect(value.donation).to.equal(5)
       expect(value.pAccumulator._value).to.equal(6)
       expect(value.pAccumulator._skew).to.equal(7)
+      expect(value.exposure).to.equal(8)
     })
 
     context('.currentId', async () => {
       const STORAGE_SIZE = 32
       it('saves if in range', async () => {
         await global.store({
+          ...DEFAULT_GLOBAL,
           currentId: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
         })
         const value = await global.read()
         expect(value.currentId).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -99,16 +107,8 @@ describe('Global', () => {
       it('reverts if currentId out of range', async () => {
         await expect(
           global.store({
+            ...DEFAULT_GLOBAL,
             currentId: BigNumber.from(2).pow(STORAGE_SIZE),
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -118,16 +118,8 @@ describe('Global', () => {
       const STORAGE_SIZE = 32
       it('saves if in range', async () => {
         await global.store({
-          currentId: 0,
+          ...DEFAULT_GLOBAL,
           latestId: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
         })
         const value = await global.read()
         expect(value.latestId).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -136,16 +128,8 @@ describe('Global', () => {
       it('reverts if currentId out of range', async () => {
         await expect(
           global.store({
-            currentId: 0,
+            ...DEFAULT_GLOBAL,
             latestId: BigNumber.from(2).pow(STORAGE_SIZE),
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -155,16 +139,8 @@ describe('Global', () => {
       const STORAGE_SIZE = 48
       it('saves if in range', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
+          ...DEFAULT_GLOBAL,
           protocolFee: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
         })
         const value = await global.read()
         expect(value.protocolFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -173,16 +149,8 @@ describe('Global', () => {
       it('reverts if currentId out of range', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
+            ...DEFAULT_GLOBAL,
             protocolFee: BigNumber.from(2).pow(STORAGE_SIZE),
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -192,16 +160,8 @@ describe('Global', () => {
       const STORAGE_SIZE = 48
       it('saves if in range', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
+          ...DEFAULT_GLOBAL,
           oracleFee: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          riskFee: 0,
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
         })
         const value = await global.read()
         expect(value.oracleFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -210,16 +170,8 @@ describe('Global', () => {
       it('reverts if currentId out of range', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
+            ...DEFAULT_GLOBAL,
             oracleFee: BigNumber.from(2).pow(STORAGE_SIZE),
-            riskFee: 0,
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -229,16 +181,8 @@ describe('Global', () => {
       const STORAGE_SIZE = 48
       it('saves if in range', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
+          ...DEFAULT_GLOBAL,
           riskFee: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          donation: 0,
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
         })
         const value = await global.read()
         expect(value.riskFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -247,16 +191,8 @@ describe('Global', () => {
       it('reverts if currentId out of range', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
+            ...DEFAULT_GLOBAL,
             riskFee: BigNumber.from(2).pow(STORAGE_SIZE),
-            donation: 0,
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -266,16 +202,8 @@ describe('Global', () => {
       const STORAGE_SIZE = 48
       it('saves if in range', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
+          ...DEFAULT_GLOBAL,
           donation: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          pAccumulator: {
-            _value: 0,
-            _skew: 0,
-          },
         })
         const value = await global.read()
         expect(value.donation).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
@@ -284,16 +212,29 @@ describe('Global', () => {
       it('reverts if currentId out of range', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
+            ...DEFAULT_GLOBAL,
             donation: BigNumber.from(2).pow(STORAGE_SIZE),
-            pAccumulator: {
-              _value: 0,
-              _skew: 0,
-            },
+          }),
+        ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
+      })
+    })
+
+    context('.exposure', async () => {
+      const STORAGE_SIZE = 63
+      it('saves if in range', async () => {
+        await global.store({
+          ...DEFAULT_GLOBAL,
+          exposure: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+        })
+        const value = await global.read()
+        expect(value.exposure).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('reverts if currentId out of range', async () => {
+        await expect(
+          global.store({
+            ...DEFAULT_GLOBAL,
+            exposure: BigNumber.from(2).pow(STORAGE_SIZE),
           }),
         ).to.be.revertedWithCustomError(global, 'GlobalStorageInvalidError')
       })
@@ -303,12 +244,7 @@ describe('Global', () => {
       const STORAGE_SIZE = 31
       it('saves if in range (above)', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
+          ...DEFAULT_GLOBAL,
           pAccumulator: {
             _value: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
             _skew: 0,
@@ -320,12 +256,7 @@ describe('Global', () => {
 
       it('saves if in range (below)', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
+          ...DEFAULT_GLOBAL,
           pAccumulator: {
             _value: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1),
             _skew: 0,
@@ -338,12 +269,7 @@ describe('Global', () => {
       it('reverts if currentId out of range (above)', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
+            ...DEFAULT_GLOBAL,
             pAccumulator: {
               _value: BigNumber.from(2).pow(STORAGE_SIZE),
               _skew: 0,
@@ -355,12 +281,7 @@ describe('Global', () => {
       it('reverts if currentId out of range (below)', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
+            ...DEFAULT_GLOBAL,
             pAccumulator: {
               _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
               _skew: 0,
@@ -374,12 +295,7 @@ describe('Global', () => {
       const STORAGE_SIZE = 23
       it('saves if in range (above)', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
+          ...DEFAULT_GLOBAL,
           pAccumulator: {
             _value: 0,
             _skew: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
@@ -391,12 +307,7 @@ describe('Global', () => {
 
       it('saves if in range (below)', async () => {
         await global.store({
-          currentId: 0,
-          latestId: 0,
-          protocolFee: 0,
-          oracleFee: 0,
-          riskFee: 0,
-          donation: 0,
+          ...DEFAULT_GLOBAL,
           pAccumulator: {
             _value: 0,
             _skew: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1),
@@ -409,12 +320,7 @@ describe('Global', () => {
       it('reverts if currentId out of range (above)', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
+            ...DEFAULT_GLOBAL,
             pAccumulator: {
               _value: 0,
               _skew: BigNumber.from(2).pow(STORAGE_SIZE),
@@ -426,12 +332,7 @@ describe('Global', () => {
       it('reverts if currentId out of range (below)', async () => {
         await expect(
           global.store({
-            currentId: 0,
-            latestId: 0,
-            protocolFee: 0,
-            oracleFee: 0,
-            riskFee: 0,
-            donation: 0,
+            ...DEFAULT_GLOBAL,
             pAccumulator: {
               _value: 0,
               _skew: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
@@ -442,18 +343,21 @@ describe('Global', () => {
     })
   })
 
-  describe('#incrementFees', async () => {
+  describe('#update', async () => {
     context('zero settlement fee', async () => {
       it('no fees', async () => {
-        await global.incrementFees(123, 0, generateMarketParameter(0, 0), generateProtocolParameter(0))
+        await global.update(1, 123, 0, 0, generateMarketParameter(0, 0), generateProtocolParameter(0))
 
         const value = await global.read()
+        expect(value.latestId).to.equal(1)
         expect(value.donation).to.equal(123)
       })
 
       it('protocol fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(0, 0),
           generateProtocolParameter(parse6decimal('0.1')),
@@ -465,8 +369,10 @@ describe('Global', () => {
       })
 
       it('risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(0, parse6decimal('0.1')),
           generateProtocolParameter(0),
@@ -478,8 +384,10 @@ describe('Global', () => {
       })
 
       it('oracle fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), 0),
           generateProtocolParameter(0),
@@ -491,8 +399,10 @@ describe('Global', () => {
       })
 
       it('oracle / risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
           generateProtocolParameter(0),
@@ -505,8 +415,10 @@ describe('Global', () => {
       })
 
       it('oracle / risk fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.9')),
           generateProtocolParameter(0),
@@ -520,8 +432,10 @@ describe('Global', () => {
 
       it('oracle / risk fee over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(parse6decimal('0.1'), parse6decimal('1.0')),
             generateProtocolParameter(0),
@@ -530,8 +444,10 @@ describe('Global', () => {
       })
 
       it('protocol / risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(0, parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('0.2')),
@@ -544,8 +460,10 @@ describe('Global', () => {
       })
 
       it('protocol / risk fee zero marketFee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(0, parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('1.0')),
@@ -558,8 +476,10 @@ describe('Global', () => {
       })
 
       it('protocol / risk fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(0, parse6decimal('1.0')),
           generateProtocolParameter(parse6decimal('0.2')),
@@ -573,8 +493,10 @@ describe('Global', () => {
 
       it('protocol / risk fee protocol over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(0, parse6decimal('0.1')),
             generateProtocolParameter(parse6decimal('1.1')),
@@ -584,8 +506,10 @@ describe('Global', () => {
 
       it('protocol / risk fee oracle over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(0, parse6decimal('1.1')),
             generateProtocolParameter(parse6decimal('0.2')),
@@ -594,8 +518,10 @@ describe('Global', () => {
       })
 
       it('protocol / oracle fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), 0),
           generateProtocolParameter(parse6decimal('0.2')),
@@ -608,8 +534,10 @@ describe('Global', () => {
       })
 
       it('protocol / oracle fee zero marketFee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), 0),
           generateProtocolParameter(parse6decimal('1.0')),
@@ -622,8 +550,10 @@ describe('Global', () => {
       })
 
       it('protocol / oracle fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('1.0'), 0),
           generateProtocolParameter(parse6decimal('0.2')),
@@ -637,8 +567,10 @@ describe('Global', () => {
 
       it('protocol / oracle fee protocol over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(parse6decimal('0.1'), 0),
             generateProtocolParameter(parse6decimal('1.1')),
@@ -648,8 +580,10 @@ describe('Global', () => {
 
       it('protocol / oracle fee oracle over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(parse6decimal('1.1'), 0),
             generateProtocolParameter(parse6decimal('0.2')),
@@ -658,8 +592,10 @@ describe('Global', () => {
       })
 
       it('protocol / oracle / risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('0.2')),
@@ -673,8 +609,10 @@ describe('Global', () => {
       })
 
       it('protocol / oracle / risk fee zero marketFee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('1.0')),
@@ -688,8 +626,10 @@ describe('Global', () => {
       })
 
       it('protocol / oracle / risk fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
+          0,
           0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.9')),
           generateProtocolParameter(parse6decimal('0.2')),
@@ -702,10 +642,26 @@ describe('Global', () => {
         expect(value.donation).to.equal(1) // due to rounding
       })
 
+      it('exposure', async () => {
+        await global.update(
+          1,
+          0,
+          0,
+          123,
+          generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.9')),
+          generateProtocolParameter(parse6decimal('0.2')),
+        )
+
+        const value = await global.read()
+        expect(value.exposure).to.equal(123)
+      })
+
       it('protocol / oracle / risk fee protocol over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
             generateProtocolParameter(parse6decimal('1.1')),
@@ -715,8 +671,10 @@ describe('Global', () => {
 
       it('protocol / oracle / risk fee oracle over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(parse6decimal('0.1'), parse6decimal('1.0')),
             generateProtocolParameter(parse6decimal('0.2')),
@@ -727,16 +685,18 @@ describe('Global', () => {
 
     context('non-zero settlement fee', async () => {
       it('no fees', async () => {
-        await global.incrementFees(123, 456, generateMarketParameter(0, 0), generateProtocolParameter(0))
+        await global.update(1, 123, 456, 0, generateMarketParameter(0, 0), generateProtocolParameter(0))
 
         const value = await global.read()
         expect(value.donation).to.equal(123)
       })
 
       it('protocol fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(0, 0),
           generateProtocolParameter(parse6decimal('0.1')),
         )
@@ -747,9 +707,11 @@ describe('Global', () => {
       })
 
       it('risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(0, parse6decimal('0.1')),
           generateProtocolParameter(0),
         )
@@ -760,9 +722,11 @@ describe('Global', () => {
       })
 
       it('oracle fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), 0),
           generateProtocolParameter(0),
         )
@@ -773,9 +737,11 @@ describe('Global', () => {
       })
 
       it('oracle / risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
           generateProtocolParameter(0),
         )
@@ -787,9 +753,11 @@ describe('Global', () => {
       })
 
       it('oracle / risk fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.9')),
           generateProtocolParameter(0),
         )
@@ -802,9 +770,11 @@ describe('Global', () => {
 
       it('oracle / risk fee over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
             456,
+            0,
             generateMarketParameter(parse6decimal('0.1'), parse6decimal('1.0')),
             generateProtocolParameter(0),
           ),
@@ -812,9 +782,11 @@ describe('Global', () => {
       })
 
       it('protocol / risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(0, parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('0.2')),
         )
@@ -827,9 +799,11 @@ describe('Global', () => {
       })
 
       it('protocol / risk fee zero marketFee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(0, parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('1.0')),
         )
@@ -842,9 +816,11 @@ describe('Global', () => {
       })
 
       it('protocol / risk fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(0, parse6decimal('1.0')),
           generateProtocolParameter(parse6decimal('0.2')),
         )
@@ -858,9 +834,11 @@ describe('Global', () => {
 
       it('protocol / risk fee protocol over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
             456,
+            0,
             generateMarketParameter(0, parse6decimal('0.1')),
             generateProtocolParameter(parse6decimal('1.1')),
           ),
@@ -869,9 +847,11 @@ describe('Global', () => {
 
       it('protocol / risk fee oracle over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
             456,
+            0,
             generateMarketParameter(0, parse6decimal('1.1')),
             generateProtocolParameter(parse6decimal('0.2')),
           ),
@@ -879,9 +859,11 @@ describe('Global', () => {
       })
 
       it('protocol / oracle fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), 0),
           generateProtocolParameter(parse6decimal('0.2')),
         )
@@ -893,9 +875,11 @@ describe('Global', () => {
       })
 
       it('protocol / oracle fee zero marketFee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), 0),
           generateProtocolParameter(parse6decimal('1.0')),
         )
@@ -907,9 +891,11 @@ describe('Global', () => {
       })
 
       it('protocol / oracle fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('1.0'), 0),
           generateProtocolParameter(parse6decimal('0.2')),
         )
@@ -922,8 +908,10 @@ describe('Global', () => {
 
       it('protocol / oracle fee protocol over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
+            0,
             0,
             generateMarketParameter(parse6decimal('0.1'), 0),
             generateProtocolParameter(parse6decimal('1.1')),
@@ -933,9 +921,11 @@ describe('Global', () => {
 
       it('protocol / oracle fee oracle over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
             456,
+            0,
             generateMarketParameter(parse6decimal('1.1'), 0),
             generateProtocolParameter(parse6decimal('0.2')),
           ),
@@ -943,9 +933,11 @@ describe('Global', () => {
       })
 
       it('protocol / oracle / risk fee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('0.2')),
         )
@@ -958,9 +950,11 @@ describe('Global', () => {
       })
 
       it('protocol / oracle / risk fee zero marketFee', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('1.0')),
         )
@@ -973,9 +967,11 @@ describe('Global', () => {
       })
 
       it('protocol / oracle / risk fee zero donation', async () => {
-        await global.incrementFees(
+        await global.update(
+          1,
           123,
           456,
+          0,
           generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.9')),
           generateProtocolParameter(parse6decimal('0.2')),
         )
@@ -989,9 +985,11 @@ describe('Global', () => {
 
       it('protocol / oracle / risk fee protocol over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
             456,
+            0,
             generateMarketParameter(parse6decimal('0.1'), parse6decimal('0.3')),
             generateProtocolParameter(parse6decimal('1.1')),
           ),
@@ -1000,9 +998,11 @@ describe('Global', () => {
 
       it('protocol / oracle / risk fee oracle over', async () => {
         await expect(
-          global.incrementFees(
+          global.update(
+            1,
             123,
             456,
+            0,
             generateMarketParameter(parse6decimal('0.1'), parse6decimal('1.0')),
             generateProtocolParameter(parse6decimal('0.2')),
           ),

--- a/packages/perennial/test/unit/types/Local.test.ts
+++ b/packages/perennial/test/unit/types/Local.test.ts
@@ -14,6 +14,7 @@ const DEFAULT_LOCAL: LocalStruct = {
   currentId: 0,
   latestId: 0,
   collateral: 0,
+  claimable: 0,
 }
 
 const DEFAULT_ADDRESS = '0x0123456789abcdef0123456789abcdef01234567'
@@ -34,6 +35,7 @@ describe('Local', () => {
       currentId: 1,
       latestId: 5,
       collateral: 2,
+      claimable: 3,
     }
     it('stores a new value', async () => {
       await local.store(VALID_STORED_VALUE)
@@ -42,6 +44,7 @@ describe('Local', () => {
       expect(value.currentId).to.equal(1)
       expect(value.latestId).to.equal(5)
       expect(value.collateral).to.equal(2)
+      expect(value.claimable).to.equal(3)
     })
 
     context('.currentId', async () => {
@@ -120,6 +123,27 @@ describe('Local', () => {
           local.store({
             ...VALID_STORED_VALUE,
             collateral: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
+          }),
+        ).to.be.revertedWithCustomError(local, 'LocalStorageInvalidError')
+      })
+    })
+
+    context('.claimable', async () => {
+      const STORAGE_SIZE = 64
+      it('saves if in range', async () => {
+        await local.store({
+          ...VALID_STORED_VALUE,
+          claimable: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+        })
+        const value = await local.read()
+        expect(value.claimable).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('reverts if claimable out of range', async () => {
+        await expect(
+          local.store({
+            ...VALID_STORED_VALUE,
+            claimable: BigNumber.from(2).pow(STORAGE_SIZE),
           }),
         ).to.be.revertedWithCustomError(local, 'LocalStorageInvalidError')
       })

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -45,6 +45,7 @@ const GLOBAL: GlobalStruct = {
     _value: 6,
     _skew: 7,
   },
+  exposure: 0,
 }
 
 const FROM_POSITION: PositionStruct = {


### PR DESCRIPTION
In the new checkpoint system, `_credit` directly incrementing an out-of-path account's collateral creates an out-of-sync balance.

This creates a separate `claimable` balance on a `Local` to store liquidation fees, and any future off-path fees like interface fees.

Similarly this creates a separate `exposure` account on the `Global` instead of using `account(0)'s` collateral as the spillover for adiabatic exposure.