### PR TITLE
[Cleanup] Split tradeFee in Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@codechecks/client": "^0.1.10",
     "@defi-wonderland/smock": "^2.0.7",
-    "@equilibria/root": "2.2.0-rc16",
+    "@equilibria/root": "2.2.0-rc17",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",

--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -59,6 +59,10 @@ export interface Version {
   makerValue: Accumulator
   longValue: Accumulator
   shortValue: Accumulator
+  makerLinearFee: Accumulator
+  makerProportionalFee: Accumulator
+  takerLinearFee: Accumulator
+  takerProportionalFee: Accumulator
   makerPosFee: Accumulator
   makerNegFee: Accumulator
   takerPosFee: Accumulator
@@ -195,6 +199,10 @@ export const DEFAULT_VERSION: Version = {
   makerValue: { _value: 0 },
   longValue: { _value: 0 },
   shortValue: { _value: 0 },
+  makerLinearFee: { _value: 0 },
+  makerProportionalFee: { _value: 0 },
+  takerLinearFee: { _value: 0 },
+  takerProportionalFee: { _value: 0 },
   makerPosFee: { _value: 0 },
   makerNegFee: { _value: 0 },
   takerPosFee: { _value: 0 },

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1448,8 +1448,8 @@ describe('Vault', () => {
       expect(await position()).to.be.equal(collateralForRebalance.mul(leverage).mul(4).div(5).div(originalOraclePrice))
       expect(await btcPosition()).to.be.equal(collateralForRebalance.mul(leverage).div(5).div(btcOriginalOraclePrice))
 
-      const balanceOf2 = BigNumber.from('9220781249')
-      const totalAssets = BigNumber.from('11079021399')
+      const balanceOf2 = BigNumber.from('9220781262')
+      const totalAssets = BigNumber.from('11079021396')
       expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('1000'))
       expect((await vault.accounts(user2.address)).shares).to.equal(balanceOf2)
       expect(await vault.totalAssets()).to.equal(totalAssets)
@@ -1488,9 +1488,9 @@ describe('Vault', () => {
       const btcCurrentSettlementFee = (await btcMarket.checkpoints(vault.address, btcMarketPreviousCurrenTimestamp))
         .settlementFee
 
-      const unclaimed1 = BigNumber.from('1072467940')
-      const unclaimed2 = BigNumber.from('9903141462')
-      const finalTotalAssets = BigNumber.from('49861153') // last position fee + keeper
+      const unclaimed1 = BigNumber.from('1072467932')
+      const unclaimed2 = BigNumber.from('9903141436')
+      const finalTotalAssets = BigNumber.from('49861154') // last position fee + keeper
       expect(await totalCollateralInVault()).to.equal(unclaimed1.add(unclaimed2).mul(1e12))
       expect((await vault.accounts(user.address)).shares).to.equal(0)
       expect((await vault.accounts(user2.address)).shares).to.equal(0)

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -93,7 +93,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Context memory context = _loadContext(account);
 
         _settle(context, account);
-        
+
         _storeContext(context, account);
     }
 
@@ -116,7 +116,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         _settle(context, account);
         _update(context, account, newMaker, newLong, newShort, collateral, protect);
-        
+
         _storeContext(context, account);
     }
 
@@ -156,8 +156,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         newGlobal.exposure = newGlobal.exposure.sub(updateFee);
         _global.store(newGlobal);
-        
-        // update 
+
+        // update
         _riskParameter.validateAndStore(newRiskParameter, IMarketFactory(address(factory())).parameter());
         emit RiskParameterUpdated(newRiskParameter);
     }
@@ -186,7 +186,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         if (newGlobal.exposure.sign() == 1) token.push(msg.sender, UFixed18Lib.from(newGlobal.exposure.abs()));
         if (newGlobal.exposure.sign() == -1) token.pull(msg.sender, UFixed18Lib.from(newGlobal.exposure.abs()));
-        
+
         emit ExposureClaimed(msg.sender, newGlobal.exposure);
 
         newGlobal.exposure = Fixed6Lib.ZERO;
@@ -518,7 +518,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Order memory newOrder
     ) private {
         OracleVersion memory oracleVersion = oracle.at(newOrder.timestamp);
-        
+
         (uint256 fromTimestamp, uint256 fromId) = (context.latestPosition.global.timestamp, context.global.latestId);
         (
             VersionAccumulationResult memory accumulationResult,
@@ -576,7 +576,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         context.local.update(
             newOrderId,
             accumulationResult.collateral,
-            accumulationResult.tradeFee,
+            accumulationResult.linearFee.add(accumulationResult.proportionalFee).add(accumulationResult.adiabaticFee),
             accumulationResult.settlementFee,
             accumulationResult.liquidationFee
         );

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -221,6 +221,20 @@ library OrderLib {
         return self.shortPos.add(self.longNeg);
     }
 
+    /// @notice Returns the total maker delta of the order
+    /// @param self The order object to check
+    /// @return The total maker delta of the order
+    function makerTotal(Order memory self) internal pure returns (UFixed6) {
+        return self.makerPos.add(self.makerNeg);
+    }
+
+    /// @notice Returns the total taker delta of the order
+    /// @param self The order object to check
+    /// @return The total taker delta of the order
+    function takerTotal(Order memory self) internal pure returns (UFixed6) {
+        return self.takerPos().add(self.takerNeg());
+    }
+
     /// @notice Returns the positive delta of the order
     /// @param self The order object to check
     /// @return The positive delta of the order
@@ -252,7 +266,7 @@ library OrderLib {
         );
     }
 
-    /// @notice Subtracts the latest local order from current global order 
+    /// @notice Subtracts the latest local order from current global order
     /// @param self The order object to update
     /// @param order The latest order
     function sub(Order memory self, Order memory order) internal pure {

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -1047,7 +1047,7 @@ describe('Happy Path', () => {
       ...DEFAULT_LOCAL,
       currentId: 3,
       latestId: 2,
-      collateral: '986141051',
+      collateral: '986141042',
     })
     expectOrderEq(await market.pendingOrders(user.address, 3), {
       ...DEFAULT_ORDER,
@@ -1072,7 +1072,7 @@ describe('Happy Path', () => {
       protocolFee: '308688',
       riskFee: 0,
       oracleFee: 0,
-      donation: '308689',
+      donation: '308690',
     })
     expectOrderEq(await market.pendingOrder(3), {
       ...DEFAULT_ORDER,
@@ -1089,7 +1089,7 @@ describe('Happy Path', () => {
     })
     expectVersionEq(await market.versions(TIMESTAMP_4), {
       ...DEFAULT_VERSION,
-      makerValue: { _value: '-3545882' },
+      makerValue: { _value: '-3545883' },
       longValue: { _value: '3620965' },
       shortValue: { _value: 0 },
       liquidationFee: { _value: -riskParameter.liquidationFee },

--- a/packages/perennial/test/unit/types/Checkpoint.test.ts
+++ b/packages/perennial/test/unit/types/Checkpoint.test.ts
@@ -204,6 +204,10 @@ describe('Checkpoint', () => {
       makerValue: { _value: parse6decimal('100') },
       longValue: { _value: parse6decimal('200') },
       shortValue: { _value: parse6decimal('300') },
+      makerLinearFee: { _value: parse6decimal('1400') },
+      makerProportionalFee: { _value: parse6decimal('1500') },
+      takerLinearFee: { _value: parse6decimal('1600') },
+      takerProportionalFee: { _value: parse6decimal('1700') },
       makerPosFee: { _value: parse6decimal('400') },
       makerNegFee: { _value: parse6decimal('500') },
       takerPosFee: { _value: parse6decimal('600') },
@@ -217,6 +221,10 @@ describe('Checkpoint', () => {
       makerValue: { _value: parse6decimal('1000') },
       longValue: { _value: parse6decimal('2000') },
       shortValue: { _value: parse6decimal('3000') },
+      makerLinearFee: { _value: parse6decimal('14000') },
+      makerProportionalFee: { _value: parse6decimal('15000') },
+      takerLinearFee: { _value: parse6decimal('16000') },
+      takerProportionalFee: { _value: parse6decimal('17000') },
       makerPosFee: { _value: parse6decimal('4000') },
       makerNegFee: { _value: parse6decimal('5000') },
       takerPosFee: { _value: parse6decimal('6000') },
@@ -307,6 +315,82 @@ describe('Checkpoint', () => {
         expect(value.collateral).to.equal(parse6decimal('1000'))
       })
 
+      it('accumulates fees (maker linear)', async () => {
+        const result = await checkpoint.callStatic.accumulate(
+          { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, makerLinearFee: { _value: parse6decimal('-2') } },
+        )
+        await checkpoint.accumulate(
+          { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, makerPosFee: { _value: parse6decimal('-2') } },
+        )
+        expect(result.linearFee).to.equal(parse6decimal('20'))
+
+        const value = await checkpoint.read()
+        expect(value.tradeFee).to.equal(parse6decimal('20'))
+      })
+
+      it('accumulates fees (maker proportional)', async () => {
+        const result = await checkpoint.callStatic.accumulate(
+          { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, makerProportionalFee: { _value: parse6decimal('-2') } },
+        )
+        await checkpoint.accumulate(
+          { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, makerPosFee: { _value: parse6decimal('-2') } },
+        )
+        expect(result.proportionalFee).to.equal(parse6decimal('20'))
+
+        const value = await checkpoint.read()
+        expect(value.tradeFee).to.equal(parse6decimal('20'))
+      })
+
+      it('accumulates fees (taker linear)', async () => {
+        const result = await checkpoint.callStatic.accumulate(
+          { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, takerLinearFee: { _value: parse6decimal('-2') } },
+        )
+        await checkpoint.accumulate(
+          { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, takerLinearFee: { _value: parse6decimal('-2') } },
+        )
+        expect(result.linearFee).to.equal(parse6decimal('20'))
+
+        const value = await checkpoint.read()
+        expect(value.tradeFee).to.equal(parse6decimal('20'))
+      })
+
+      it('accumulates fees (taker proportional)', async () => {
+        const result = await checkpoint.callStatic.accumulate(
+          { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, takerProportionalFee: { _value: parse6decimal('-2') } },
+        )
+        await checkpoint.accumulate(
+          { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
+          { ...DEFAULT_POSITION },
+          { ...DEFAULT_VERSION },
+          { ...DEFAULT_VERSION, takerProportionalFee: { _value: parse6decimal('-2') } },
+        )
+        expect(result.proportionalFee).to.equal(parse6decimal('20'))
+
+        const value = await checkpoint.read()
+        expect(value.tradeFee).to.equal(parse6decimal('20'))
+      })
+
       it('accumulates fees (maker pos)', async () => {
         const result = await checkpoint.callStatic.accumulate(
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
@@ -320,7 +404,7 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerPosFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(result.adiabaticFee).to.equal(parse6decimal('20'))
 
         const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
@@ -339,7 +423,7 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerNegFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(result.adiabaticFee).to.equal(parse6decimal('20'))
 
         const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
@@ -358,7 +442,7 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(result.adiabaticFee).to.equal(parse6decimal('20'))
 
         const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
@@ -377,7 +461,7 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(result.adiabaticFee).to.equal(parse6decimal('20'))
 
         const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
@@ -396,7 +480,7 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(result.adiabaticFee).to.equal(parse6decimal('20'))
 
         const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
@@ -415,7 +499,7 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(result.adiabaticFee).to.equal(parse6decimal('20'))
 
         const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -26,6 +26,10 @@ const VALID_VERSION: VersionStruct = {
   makerValue: { _value: 1 },
   longValue: { _value: 2 },
   shortValue: { _value: 3 },
+  makerLinearFee: { _value: 14 },
+  makerProportionalFee: { _value: 15 },
+  takerLinearFee: { _value: 16 },
+  takerProportionalFee: { _value: 17 },
   makerPosFee: { _value: 4 },
   makerNegFee: { _value: 5 },
   takerPosFee: { _value: 6 },
@@ -137,6 +141,10 @@ describe('Version', () => {
       expect(value.makerValue._value).to.equal(1)
       expect(value.longValue._value).to.equal(2)
       expect(value.shortValue._value).to.equal(3)
+      expect(value.makerLinearFee._value).to.equal(14)
+      expect(value.makerProportionalFee._value).to.equal(15)
+      expect(value.takerLinearFee._value).to.equal(16)
+      expect(value.takerProportionalFee._value).to.equal(17)
       expect(value.makerPosFee._value).to.equal(4)
       expect(value.makerNegFee._value).to.equal(5)
       expect(value.takerPosFee._value).to.equal(6)
@@ -268,6 +276,162 @@ describe('Version', () => {
           version.store({
             ...VALID_VERSION,
             shortValue: { _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+    })
+
+    describe('.makerLinearFee', async () => {
+      const STORAGE_SIZE = 47
+      it('saves if in range (above)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          makerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).sub(1) },
+        })
+        const value = await version.read()
+        expect(value.makerLinearFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('saves if in range (below)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          makerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1) },
+        })
+        const value = await version.read()
+        expect(value.makerLinearFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
+      })
+
+      it('reverts if out of range (above)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            makerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+
+      it('reverts if out of range (below)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            makerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+    })
+
+    describe('.makerProportionalFee', async () => {
+      const STORAGE_SIZE = 47
+      it('saves if in range (above)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          makerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).sub(1) },
+        })
+        const value = await version.read()
+        expect(value.makerProportionalFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('saves if in range (below)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          makerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1) },
+        })
+        const value = await version.read()
+        expect(value.makerProportionalFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
+      })
+
+      it('reverts if out of range (above)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            makerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+
+      it('reverts if out of range (below)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            makerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+    })
+
+    describe('.takerLinearFee', async () => {
+      const STORAGE_SIZE = 47
+      it('saves if in range (above)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          takerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).sub(1) },
+        })
+        const value = await version.read()
+        expect(value.takerLinearFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('saves if in range (below)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          takerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1) },
+        })
+        const value = await version.read()
+        expect(value.takerLinearFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
+      })
+
+      it('reverts if out of range (above)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            takerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+
+      it('reverts if out of range (below)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            takerLinearFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+    })
+
+    describe('.takerProportionalFee', async () => {
+      const STORAGE_SIZE = 47
+      it('saves if in range (above)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          takerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).sub(1) },
+        })
+        const value = await version.read()
+        expect(value.takerProportionalFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('saves if in range (below)', async () => {
+        await version.store({
+          ...VALID_VERSION,
+          takerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).mul(-1) },
+        })
+        const value = await version.read()
+        expect(value.takerProportionalFee._value).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).mul(-1))
+      })
+
+      it('reverts if out of range (above)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            takerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE) },
+          }),
+        ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
+      })
+
+      it('reverts if out of range (below)', async () => {
+        await expect(
+          version.store({
+            ...VALID_VERSION,
+            takerProportionalFee: { _value: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1) },
           }),
         ).to.be.revertedWithCustomError(version, 'VersionStorageInvalidError')
       })
@@ -683,11 +847,15 @@ describe('Version', () => {
         const makerExposure = parse6decimal('0.0') // 100 -> 100 / 100 = 199 / 100 = 1.0 * 0 * 0.2
         const exposure = takerExposure.add(makerExposure).mul(2) // price delta
 
-        const fee1 = parse6decimal('1.75') // 50 * 0.01 + 50 * 0.025
-        const fee2 = parse6decimal('2.4') // 60 * 0.01 + 60 * 0.03
-        const fee3 = parse6decimal('0.0')
-        const fee4 = parse6decimal('0.3') // 10 * 0.02 + 10 * 0.01
-        const fee = fee1.add(fee2).add(fee3).add(fee4).mul(123) // price
+        const linear1 = parse6decimal('0.2') // 10 * 0.02
+        const linear2 = parse6decimal('1.1') // 110 * 0.01
+        const linear = linear1.add(linear2).mul(123) // price
+
+        const proportional1 = parse6decimal('0.1') // 10 * 0.01
+        const proportional2 = parse6decimal('6.05') // 110 * 0.055
+        const proportional = proportional1.add(proportional2).mul(123) // price
+
+        const fee = linear.add(proportional)
 
         const impact1 = parse6decimal('.75') // -10 -> 40 / 100 = 15 / 100 = 0.15 * 50 * 0.1
         const impact2 = parse6decimal('-0.6') // 40 -> -20 / 100 = -10 / 100 = -0.1 * 60 * 0.1
@@ -698,10 +866,14 @@ describe('Version', () => {
         expect(value.makerValue._value).to.equal(1)
         expect(value.longValue._value).to.equal(parse6decimal('2').add(2)) // pnl
         expect(value.shortValue._value).to.equal(parse6decimal('-2').mul(2).div(3).sub(1).add(3)) // pnl
-        expect(value.makerPosFee._value).to.equal(impact4.add(fee4).mul(-1).mul(123).div(10))
+        expect(value.makerLinearFee._value).to.equal(linear1.mul(-1).mul(123).div(10))
+        expect(value.makerProportionalFee._value).to.equal(proportional1.mul(-1).mul(123).div(10))
+        expect(value.takerLinearFee._value).to.equal(linear2.mul(-1).mul(123).div(110))
+        expect(value.takerProportionalFee._value).to.equal(proportional2.mul(-1).mul(123).div(110))
+        expect(value.makerPosFee._value).to.equal(impact4.mul(-1).mul(123).div(10))
         expect(value.makerNegFee._value).to.equal(0)
-        expect(value.takerPosFee._value).to.equal(impact1.add(fee1).mul(-1).mul(123).div(50))
-        expect(value.takerNegFee._value).to.equal(impact2.add(fee2).mul(-1).mul(123).div(60))
+        expect(value.takerPosFee._value).to.equal(impact1.mul(-1).mul(123).div(50))
+        expect(value.takerNegFee._value).to.equal(impact2.mul(-1).mul(123).div(60))
         expect(value.settlementFee._value).to.equal(-2)
 
         expect(ret[0].positionFee).to.equal(fee)
@@ -759,11 +931,15 @@ describe('Version', () => {
         const makerExposure = parse6decimal('-7.5') // 100 -> 50 / 100 = 75 / 100 = 0.75 * 50 * 0.2
         const exposure = takerExposure.add(makerExposure).mul(2) // price delta
 
-        const fee1 = parse6decimal('1.75') // 50 * 0.01 + 50 * 0.025
-        const fee2 = parse6decimal('2.4') // 60 * 0.01 + 60 * 0.03
-        const fee3 = parse6decimal('0.3') // 10 * 0.02 + 10 * 0.01
-        const fee4 = parse6decimal('0.8') // 20 * 0.02 + 20 * 0.02
-        const fee = fee1.add(fee2).add(fee3).add(fee4).mul(123) // price
+        const linear1 = parse6decimal('0.6') // 30 * 0.02
+        const linear2 = parse6decimal('1.1') // 110 * 0.01
+        const linear = linear1.add(linear2).mul(123) // price
+
+        const proportional1 = parse6decimal('0.9') // 30 * 0.03
+        const proportional2 = parse6decimal('6.05') // 110 * 0.055
+        const proportional = proportional1.add(proportional2).mul(123) // price
+
+        const fee = linear.add(proportional)
 
         const impact1 = parse6decimal('.75') // -10 -> 40 / 100 = 15 / 100 = 0.15 * 50 * 0.1
         const impact2 = parse6decimal('-0.6') // 40 -> -20 / 100 = -10 / 100 = -0.1 * 60 * 0.1
@@ -776,10 +952,14 @@ describe('Version', () => {
         )
         expect(value.longValue._value).to.equal(parse6decimal('2').add(2))
         expect(value.shortValue._value).to.equal(parse6decimal('-2').add(3))
-        expect(value.makerPosFee._value).to.equal(impact4.add(fee4).mul(-1).mul(123).div(20))
-        expect(value.makerNegFee._value).to.equal(impact3.add(fee3).mul(-1).mul(123).div(10))
-        expect(value.takerPosFee._value).to.equal(impact1.add(fee1).mul(-1).mul(123).div(50))
-        expect(value.takerNegFee._value).to.equal(impact2.add(fee2).mul(-1).mul(123).div(60))
+        expect(value.makerLinearFee._value).to.equal(linear1.mul(-1).mul(123).div(30))
+        expect(value.makerProportionalFee._value).to.equal(proportional1.mul(-1).mul(123).div(30))
+        expect(value.takerLinearFee._value).to.equal(linear2.mul(-1).mul(123).div(110))
+        expect(value.takerProportionalFee._value).to.equal(proportional2.mul(-1).mul(123).div(110))
+        expect(value.makerPosFee._value).to.equal(impact4.mul(-1).mul(123).div(20))
+        expect(value.makerNegFee._value).to.equal(impact3.mul(-1).mul(123).div(10))
+        expect(value.takerPosFee._value).to.equal(impact1.mul(-1).mul(123).div(50))
+        expect(value.takerNegFee._value).to.equal(impact2.mul(-1).mul(123).div(60))
         expect(value.settlementFee._value).to.equal(-2)
 
         expect(ret[0].positionFee).to.equal(fee)

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
   dependencies:
     "@openzeppelin/contracts" "4.6.0"
 
-"@equilibria/root@2.2.0-rc16":
-  version "2.2.0-rc16"
-  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-2.2.0-rc16.tgz#c69ba8e84af0f3403dd1753c2692af577cc1bc94"
-  integrity sha512-eFFpzU1RVY+LWboldexmeTY7fVGP9+BKqpO9JPOrjAkSYcjX6hSIokIIypc70cTURAt5KCSzWI6ChId/mNWoPQ==
+"@equilibria/root@2.2.0-rc17":
+  version "2.2.0-rc17"
+  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-2.2.0-rc17.tgz#f8bd5e84affe7a0ccf88b1dd13daf6e2617f3d09"
+  integrity sha512-GJmhsBpzR8mzi5EBDuipTcjeU6JSWFvc9OUjaEdvQTWF5U7Cg7O3BK28WkGEM7DGaFnAsCMrKkLAeBLrW4Zy2Q==
   dependencies:
     "@openzeppelin/contracts" "4.6.0"
 


### PR DESCRIPTION
So that we can have `linear / proportiona / adiabatic`-level logic in the `Checkpoint`.