### PR TITLE
[Docs] Fix local slots

### DIFF
--- a/packages/perennial/contracts/types/Local.sol
+++ b/packages/perennial/contracts/types/Local.sol
@@ -27,7 +27,7 @@ struct Local {
     UFixed6 claimable;
 }
 using LocalLib for Local global;
-struct LocalStorage { uint256 slot0; }
+struct LocalStorage { uint256 slot0; uint256 slot1; }
 using LocalStorageLib for LocalStorage global;
 
 /// @title Local


### PR DESCRIPTION
Fixes the storage definition for `Local` from one slot to two.

This does not have any effect on the underlying logic, but should maintain consistency for readability.