### PR TITLE
Update settle unit test helper

### DIFF
--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1488,7 +1488,7 @@ describe('Fees', () => {
         expect(accountProcessEventC.accumulationResult.settlementFee).to.equal(expectedSettlementFee.div(2))
 
         expectGlobalEq(await market.global(), {
-          currentId: 3,
+          currentId: 2,
           latestId: 2,
           protocolFee: 0,
           riskFee: 0,

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants, utils } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, settle, updateNoOp } from '../helpers/setupHelpers'
 import {
   DEFAULT_CHECKPOINT,
   DEFAULT_POSITION,
@@ -103,7 +103,7 @@ describe('Fees', () => {
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
-      const tx = await settle(market, user)
+      const tx = await updateNoOp(market, user)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -192,7 +192,7 @@ describe('Fees', () => {
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
-      const tx = await settle(market, user)
+      const tx = await updateNoOp(market, user)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -295,7 +295,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await updateNoOp(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -379,7 +379,7 @@ describe('Fees', () => {
 
       // Settle maker to give them portion of fees
       await nextWithConstantPrice()
-      await settle(market, user)
+      await updateNoOp(market, user)
 
       await expect(
         market
@@ -407,7 +407,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await updateNoOp(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -467,7 +467,7 @@ describe('Fees', () => {
         long: LONG_POSITION,
       })
 
-      const txMaker = await settle(market, user)
+      const txMaker = await updateNoOp(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -556,8 +556,8 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      await settle(market, userB)
-      await settle(market, user)
+      await updateNoOp(market, userB)
+      await updateNoOp(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
       await market.updateRiskParameter({
@@ -579,7 +579,7 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await updateNoOp(market, userB)
 
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
@@ -637,7 +637,7 @@ describe('Fees', () => {
         timestamp: TIMESTAMP_2,
       })
 
-      const txMaker = await settle(market, user)
+      const txMaker = await updateNoOp(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -712,7 +712,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await updateNoOp(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -824,7 +824,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await updateNoOp(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -996,7 +996,7 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await updateNoOp(market, userB)
 
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
@@ -1422,7 +1422,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const tx = await settle(market, instanceVars.user)
+        const tx = await updateNoOp(market, instanceVars.user)
 
         const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
@@ -1543,7 +1543,7 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await updateNoOp(market, userB)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1574,7 +1574,7 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await updateNoOp(market, userB)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1648,7 +1648,7 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await updateNoOp(market, userB)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1679,7 +1679,7 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await updateNoOp(market, userB)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1620,7 +1620,7 @@ describe('Fees', () => {
     })
   })
 
-  describe.only('funding fee', () => {
+  describe('funding fee', () => {
     const MAKER_POSITION = parse6decimal('10')
     const SHORT_POSITION = parse6decimal('1')
     const LONG_POSITION = parse6decimal('1')

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1529,7 +1529,7 @@ describe('Fees', () => {
       await settle(market, user)
     })
 
-    it.only('charges interest fee for long position', async () => {
+    it('charges interest fee for long position', async () => {
       const { userB } = instanceVars
 
       await market
@@ -1537,13 +1537,13 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, LONG_POSITION, 0, COLLATERAL, false)
 
       await nextWithConstantPrice()
-      await updateNoOp(market, userB)
+      await settle(market, userB)
 
       await nextWithConstantPrice()
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await updateNoOp(market, userB)
+      const tx = await settle(market, userB)
       const txEvents = (await tx.wait()).events!
       const accountProcessEvents: Array<AccountPositionProcessedEventObject> = txEvents
         .filter(e => e.event === 'AccountPositionProcessed')
@@ -1551,15 +1551,6 @@ describe('Fees', () => {
       const positionProcessEvents: Array<PositionProcessedEventObject> = txEvents
         .filter(e => e.event === 'PositionProcessed')
         .map(e => e.args as PositionProcessedEventObject)
-
-      // TODO: remove before flight
-      // with "real" settle:
-      // VersionLib::_accumulateInterest for time diff 915: 0
-      // VersionLib::_accumulateInterest for time diff 4912: 177
-      // with no-op update:
-      // VersionLib::_accumulateInterest for time diff 915: 0
-      // VersionLib::_accumulateInterest for time diff 186: 6     <-- this was what old test was looking at
-      // VersionLib::_accumulateInterest for time diff 4726: 170
 
       // payoffPrice = 3374.655169**2 * 0.00001 = 113.882975
       const expectedInterest = BigNumber.from('177') // payoffPrice * 0.01 * 4912 seconds / 365 days
@@ -1577,9 +1568,9 @@ describe('Fees', () => {
         (acc: BigNumber, e) => acc.add(e.accumulationResult.interestFee.add(e.accumulationResult.interestMaker)),
         BigNumber.from(0),
       )
-      expect(accumulatedInterest).to.equal(expectedInterest.mul(-1).add(1))
+      expect(accumulatedInterest).to.equal(expectedInterest.mul(-1))
       expect(accumulatedInterestFee).to.equal(expectedInterestFee)
-      expect(accumulatedInterestMaker).to.equal(expectedInterest.sub(1))
+      expect(accumulatedInterestMaker).to.equal(expectedInterest)
     })
 
     it('charges interest fee for short position', async () => {
@@ -1596,21 +1587,34 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await updateNoOp(market, userB)
-      const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
-        e => e.event === 'AccountPositionProcessed',
-      )?.args as unknown as AccountPositionProcessedEventObject
-      const positionProcessEvent: PositionProcessedEventObject = (await tx.wait()).events?.find(
-        e => e.event === 'PositionProcessed',
-      )?.args as unknown as PositionProcessedEventObject
+      const tx = await settle(market, userB)
+      const txEvents = (await tx.wait()).events!
+      const accountProcessEvents: Array<AccountPositionProcessedEventObject> = txEvents
+        .filter(e => e.event === 'AccountPositionProcessed')
+        .map(e => e.args as AccountPositionProcessedEventObject)
+      const positionProcessEvents: Array<PositionProcessedEventObject> = txEvents
+        .filter(e => e.event === 'PositionProcessed')
+        .map(e => e.args as PositionProcessedEventObject)
 
-      const expectedInterest = BigNumber.from('6') // = 3374.655169**2 * 0.00001 * 0.01 * 186 seconds / 365 days
-      const expectedInterestFee = BigNumber.from('1') // = 6 * .2
-      expect(accountProcessEvent.accumulationResult.collateral).to.equal(expectedInterest.mul(-1))
-      expect(positionProcessEvent.accumulationResult.interestFee).to.equal(expectedInterestFee)
-      expect(
-        positionProcessEvent.accumulationResult.interestFee.add(positionProcessEvent.accumulationResult.interestMaker),
-      ).to.equal(expectedInterest)
+      // payoffPrice = 3374.655169**2 * 0.00001 = 113.882975
+      const expectedInterest = BigNumber.from('177') // payoffPrice * 0.01 * 4912 seconds / 365 days
+      const expectedInterestFee = BigNumber.from('35') // expectedInterest * .2
+
+      const accumulatedInterest = accountProcessEvents.reduce(
+        (acc: BigNumber, e) => acc.add(e.accumulationResult.collateral),
+        BigNumber.from(0),
+      )
+      const accumulatedInterestFee = positionProcessEvents.reduce(
+        (acc: BigNumber, e) => acc.add(e.accumulationResult.interestFee),
+        BigNumber.from(0),
+      )
+      const accumulatedInterestMaker = positionProcessEvents.reduce(
+        (acc: BigNumber, e) => acc.add(e.accumulationResult.interestFee.add(e.accumulationResult.interestMaker)),
+        BigNumber.from(0),
+      )
+      expect(accumulatedInterest).to.equal(expectedInterest.mul(-1))
+      expect(accumulatedInterestFee).to.equal(expectedInterestFee)
+      expect(accumulatedInterestMaker).to.equal(expectedInterest)
     })
   })
 

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, settle, updateNoOp } from '../helpers/setupHelpers'
 import {
   DEFAULT_ORDER,
   DEFAULT_POSITION,
@@ -179,7 +179,7 @@ describe('Happy Path', () => {
 
     // Settle the market with a new oracle version
     await chainlink.next()
-    await settle(market, user)
+    await updateNoOp(market, user)
 
     // check user state
     expectLocalEq(await market.locals(user.address), {
@@ -291,7 +291,7 @@ describe('Happy Path', () => {
 
     // Settle the market with a new oracle version
     await chainlink.next()
-    await settle(market, user)
+    await updateNoOp(market, user)
 
     // check user state
     expectLocalEq(await market.locals(user.address), {
@@ -593,7 +593,7 @@ describe('Happy Path', () => {
 
     // Another round
     await chainlink.next()
-    await settle(market, userB)
+    await updateNoOp(market, userB)
 
     expectGlobalEq(await market.global(), {
       currentId: 2,
@@ -721,7 +721,7 @@ describe('Happy Path', () => {
 
     // Another round
     await chainlink.next()
-    await settle(market, userB)
+    await updateNoOp(market, userB)
 
     expectGlobalEq(await market.global(), {
       currentId: 2,

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -260,8 +260,7 @@ describe('Liquidate', () => {
     await chainlink.nextWithPriceModification(price => price.mul(9).div(10)) // 10% drop
     await settle(market, user)
     await chainlink.nextWithPriceModification(price => price.mul(8).div(10)) // 20% drop
-    // TODO: replace setupHelper.settle with this implementation, renaming the existing
-    await market.connect(user)['settle(address)'](user.address) // avoid invariant violation
+    await settle(market, user)
     price = (await chainlink.oracle.latest()).price
 
     // ensure user's collateral is now lower than minMaintenance but above maintenance requirement
@@ -278,8 +277,8 @@ describe('Liquidate', () => {
     ) // liquidate
       .to.emit(market, 'Updated')
       .withArgs(userC.address, user.address, TIMESTAMP_3, 0, 0, 0, 0, true, constants.AddressZero)
-    expect((await market.pendingOrders(user.address, 3)).protection).to.eq(1)
-    expect(await market.liquidators(user.address, 3)).to.eq(userC.address)
+    expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
+    expect(await market.liquidators(user.address, 2)).to.eq(userC.address)
     expect(await dsu.balanceOf(market.address)).to.equal(utils.parseEther('1500'))
     await chainlink.next()
     await settle(market, user)

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -264,7 +264,7 @@ export async function createMarket(
   return market
 }
 
-export async function settle(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
+export async function updateNoOp(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
   return market
     .connect(account)
     ['update(address,uint256,uint256,uint256,int256,bool)'](
@@ -275,4 +275,8 @@ export async function settle(market: IMarket, account: SignerWithAddress): Promi
       0,
       false,
     )
+}
+
+export async function settle(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
+  return market.connect(account)['settle(address)'](account.address)
 }


### PR DESCRIPTION
**Changes**
- Update existing settle helper to actually call `settle`, which was new for 2.2.
- Introduce new `updateNoOp` helper replacing the old call.  Use it in places where changes to position IDs would be confusing.
- Fix issue with interest and funding fee tests, which were only looking at the first emitted event of the desired type.  Use a map-reduce solution to parse and aggregate desired fields from events.