### PR TITLE
Remove v2.2 migration code

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -144,14 +144,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         _storeContext(context, account);
     }
 
-    /// @notice Updates the oracle of the market
-    /// @dev For the v2.1.1 -> v2.2 migration process, not to be used otherwise
-    /// @param newOracle The new oracle address
-    function updateOracle(IOracleProvider newOracle) external onlyOwner {
-        oracle = newOracle;
-        emit OracleUpdated(newOracle);
-    }
-
     /// @notice Updates the beneficiary, coordinator, and parameter set of the market
     /// @param newBeneficiary The new beneficiary address
     /// @param newCoordinator The new coordinator address

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -524,15 +524,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         settlementContext.latestVersion = _versions[context.latestPosition.global.timestamp].read();
         settlementContext.latestCheckpoint = _checkpoints[account][context.latestPosition.local.timestamp].read();
         settlementContext.orderOracleVersion = oracle.at(context.latestPosition.global.timestamp);
-
-        // v2.2 migration (if latest checkpoint is empty, initialize with latest local collateral)
-        if (
-            settlementContext.latestCheckpoint.tradeFee.isZero() &&
-            settlementContext.latestCheckpoint.settlementFee.isZero() &&
-            settlementContext.latestCheckpoint.transfer.isZero() &&
-            settlementContext.latestCheckpoint.collateral.isZero() &&
-            context.pending.local.collateral.isZero()
-        ) settlementContext.latestCheckpoint.collateral = context.local.collateral;
     }
 
     /// @notice Settles the account position up to the latest version

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -68,7 +68,6 @@ interface IMarket is IInstance {
     event ExposureClaimed(address indexed account, Fixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);
-    event OracleUpdated(IOracleProvider newOracle);
 
     // sig: 0x0fe90964
     error MarketInsufficientLiquidityError();
@@ -145,7 +144,6 @@ interface IMarket is IInstance {
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer) external;
     function parameter() external view returns (MarketParameter memory);
     function riskParameter() external view returns (RiskParameter memory);
-    function updateOracle(IOracleProvider newOracle) external;
     function updateParameter(address newBeneficiary, address newCoordinator, MarketParameter memory newParameter) external;
     function updateRiskParameter(RiskParameter memory newRiskParameter) external;
     function claimFee() external;

--- a/packages/perennial/contracts/types/Local.sol
+++ b/packages/perennial/contracts/types/Local.sol
@@ -72,9 +72,6 @@ library LocalLib {
 ///         int64 collateral;       // <= 9.22t
 ///         uint64 claimable;       // <= 18.44t
 ///         bytes4 __DEPRECATED;    // UNSAFE UNTIL RESET
-///
-///         /* slot 1 */
-///         bytes28 __DEPRECATED;   // UNSAFE UNTIL RESET
 ///     }
 ///
 library LocalStorageLib {
@@ -103,11 +100,9 @@ library LocalStorageLib {
             uint256(newValue.latestId << (256 - 32)) >> (256 - 32 - 32) |
             uint256(Fixed6.unwrap(newValue.collateral) << (256 - 64)) >> (256 - 32 - 32 - 64) |
             uint256(UFixed6.unwrap(newValue.claimable) << (256 - 64)) >> (256 - 32 - 32 - 64 - 64);
-        uint256 encoded1; // reset deprecated storage on settlement
 
         assembly {
             sstore(self.slot, encoded0)
-            sstore(add(self.slot, 1), encoded1)
         }
     }
 }

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -557,36 +557,6 @@ describe('Market', () => {
       await market.connect(owner).updateRiskParameter(riskParameter)
     })
 
-    describe('#updateOracle', async () => {
-      it('updates the oracle', async () => {
-        const oracle2 = await smock.fake<IOracleProvider>('IOracleProvider')
-
-        await expect(market.connect(owner).updateOracle(oracle2.address))
-          .to.emit(market, 'OracleUpdated')
-          .withArgs(oracle2.address)
-
-        expect(await market.oracle()).to.equal(oracle2.address)
-      })
-
-      it('reverts if not owner (user)', async () => {
-        const oracle2 = await smock.fake<IOracleProvider>('IOracleProvider')
-
-        await expect(market.connect(user).updateOracle(oracle2.address)).to.be.revertedWithCustomError(
-          market,
-          'InstanceNotOwnerError',
-        )
-      })
-
-      it('reverts if not owner (coordinator)', async () => {
-        const oracle2 = await smock.fake<IOracleProvider>('IOracleProvider')
-
-        await expect(market.connect(coordinator).updateOracle(oracle2.address)).to.be.revertedWithCustomError(
-          market,
-          'InstanceNotOwnerError',
-        )
-      })
-    })
-
     describe('#updateParameter', async () => {
       const defaultMarketParameter = {
         fundingFee: parse6decimal('0.03'),


### PR DESCRIPTION
## Changes
- Removed slot 1 from `Local` storage
- Eliminate loading of collateral data from `Local` into new `Checkpoint`
- Eliminate `Market::updateOracle()`

## Migration Notes
### Local
Slot 0 unchanged.  Slot 1 was deprecated in 2.2, where it was updated to write 0's.  Slot 1 is now eliminated.
Facility introduced in 2.2 to initialize `Checkpoint` with collateral from `Local` has been removed.  **Must go into no-order mode and settle all users prior to deployment.**