### PR TITLE
Remove maker/takerCloseAlways

### DIFF
--- a/packages/perennial-deploy/deploy/004_deploy_market.ts
+++ b/packages/perennial-deploy/deploy/004_deploy_market.ts
@@ -32,8 +32,6 @@ const DEFAULT_MARKET_PARAMETER = {
   maxPendingGlobal: 12,
   maxPendingLocal: 6,
   settlementFee: utils.parseUnits('1.5', 6),
-  makerCloseAlways: false,
-  takerCloseAlways: true,
   closed: false,
 }
 

--- a/packages/perennial-deploy/test/verification/arbitrum/perennial/verifyMarkets.test.ts
+++ b/packages/perennial-deploy/test/verification/arbitrum/perennial/verifyMarkets.test.ts
@@ -72,8 +72,6 @@ describe('Verify Markets', () => {
     expect(parameter.maxPendingGlobal).to.equal(12)
     expect(parameter.maxPendingLocal).to.equal(6)
     expect(parameter.settlementFee).to.equal(utils.parseUnits('1.50', 6))
-    expect(parameter.makerCloseAlways).to.be.false
-    expect(parameter.takerCloseAlways).to.be.true
     expect(parameter.closed).to.be.false
 
     const riskParameter = await ethMarket.callStatic.riskParameter()
@@ -119,8 +117,6 @@ describe('Verify Markets', () => {
     expect(parameter.maxPendingGlobal).to.equal(12)
     expect(parameter.maxPendingLocal).to.equal(6)
     expect(parameter.settlementFee).to.equal(utils.parseUnits('1.50', 6))
-    expect(parameter.makerCloseAlways).to.be.false
-    expect(parameter.takerCloseAlways).to.be.true
     expect(parameter.closed).to.be.false
 
     const riskParameter = await btcMarket.callStatic.riskParameter()
@@ -166,8 +162,6 @@ describe('Verify Markets', () => {
     expect(parameter.maxPendingGlobal).to.equal(12)
     expect(parameter.maxPendingLocal).to.equal(6)
     expect(parameter.settlementFee).to.equal(utils.parseUnits('1.50', 6))
-    expect(parameter.makerCloseAlways).to.be.false
-    expect(parameter.takerCloseAlways).to.be.true
     expect(parameter.closed).to.be.false
 
     const riskParameter = await solMarket.callStatic.riskParameter()
@@ -213,8 +207,6 @@ describe('Verify Markets', () => {
     expect(parameter.maxPendingGlobal).to.equal(12)
     expect(parameter.maxPendingLocal).to.equal(6)
     expect(parameter.settlementFee).to.equal(utils.parseUnits('1.50', 6))
-    expect(parameter.makerCloseAlways).to.be.false
-    expect(parameter.takerCloseAlways).to.be.true
     expect(parameter.closed).to.be.false
 
     const riskParameter = await maticMarket.callStatic.riskParameter()

--- a/packages/perennial-deploy/test/verification/arbitrum/perennial/verifyMigration.test.ts
+++ b/packages/perennial-deploy/test/verification/arbitrum/perennial/verifyMigration.test.ts
@@ -87,8 +87,6 @@ describe('Verify Markets Migration', () => {
     expect(parameter.maxPendingGlobal).to.equal(parameterBefore.maxPendingGlobal)
     expect(parameter.maxPendingLocal).to.equal(parameterBefore.maxPendingLocal)
     expect(parameter.settlementFee).to.equal(parameterBefore.settlementFee)
-    expect(parameter.makerCloseAlways).to.equal(parameterBefore.makerCloseAlways)
-    expect(parameter.takerCloseAlways).to.equal(parameterBefore.takerCloseAlways)
     expect(parameter.closed).to.equal(parameterBefore.closed)
 
     expect(riskParameter.margin).to.equal(riskParameterBefore.margin)

--- a/packages/perennial-deploy/test/verification/base/perennial/verifyMarkets.test.ts
+++ b/packages/perennial-deploy/test/verification/base/perennial/verifyMarkets.test.ts
@@ -75,8 +75,6 @@ describe('Verify Markets', () => {
     expect(parameter.longRewardRate).to.equal(0)
     expect(parameter.shortRewardRate).to.equal(0)
     expect(parameter.settlementFee).to.equal(utils.parseUnits('1.50', 6))
-    expect(parameter.makerCloseAlways).to.be.false
-    expect(parameter.takerCloseAlways).to.be.true
     expect(parameter.closed).to.be.false
 
     const riskParameter = await ethMarket.callStatic.riskParameter()
@@ -125,8 +123,6 @@ describe('Verify Markets', () => {
     expect(parameter.longRewardRate).to.equal(0)
     expect(parameter.shortRewardRate).to.equal(0)
     expect(parameter.settlementFee).to.equal(utils.parseUnits('1.50', 6))
-    expect(parameter.makerCloseAlways).to.be.false
-    expect(parameter.takerCloseAlways).to.be.true
     expect(parameter.closed).to.be.false
 
     const riskParameter = await btcMarket.callStatic.riskParameter()

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -307,8 +307,6 @@ export async function createMarket(
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
     settlementFee: 0,
-    makerCloseAlways: false,
-    takerCloseAlways: false,
     closed: false,
     settle: false,
     ...marketParamOverrides,

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -363,8 +363,6 @@ testOracles.forEach(testOracle => {
         maxPendingGlobal: 8,
         maxPendingLocal: 8,
         settlementFee: 0,
-        makerCloseAlways: false,
-        takerCloseAlways: false,
         closed: false,
         settle: false,
       }

--- a/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -292,8 +292,6 @@ testOracles.forEach(testOracle => {
         maxPendingGlobal: 8,
         maxPendingLocal: 8,
         settlementFee: 0,
-        makerCloseAlways: false,
-        takerCloseAlways: false,
         closed: false,
         settle: false,
       }

--- a/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -342,8 +342,6 @@ testOracles.forEach(testOracle => {
         maxPendingGlobal: 8,
         maxPendingLocal: 8,
         settlementFee: 0,
-        makerCloseAlways: false,
-        takerCloseAlways: false,
         closed: false,
         settle: false,
       }

--- a/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
@@ -79,8 +79,6 @@ export async function deployProductOnMainnetFork({
     settlementFee: 0,
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
-    makerCloseAlways: false,
-    takerCloseAlways: false,
     closed: false,
     settle: false,
   }

--- a/packages/perennial/contracts/libs/InvariantLib.sol
+++ b/packages/perennial/contracts/libs/InvariantLib.sol
@@ -88,13 +88,13 @@ library InvariantLib {
             revert IMarket.MarketProtectedError();
 
         if (
-            newOrder.liquidityCheckApplicable(context.marketParameter) &&
+            newOrder.liquidityCheckApplicable(context.marketParameter.closed) &&
             newOrder.decreasesEfficiency(updateContext.currentPosition.global) &&
             updateContext.currentPosition.global.efficiency().lt(context.riskParameter.efficiencyLimit)
         ) revert IMarket.MarketEfficiencyUnderLimitError();
 
         if (
-            newOrder.liquidityCheckApplicable(context.marketParameter) &&
+            newOrder.liquidityCheckApplicable(context.marketParameter.closed) &&
             updateContext.currentPosition.global.socialized() &&
             newOrder.decreasesLiquidity(updateContext.currentPosition.global)
         ) revert IMarket.MarketInsufficientLiquidityError();

--- a/packages/perennial/contracts/test/OrderTester.sol
+++ b/packages/perennial/contracts/test/OrderTester.sol
@@ -24,8 +24,8 @@ abstract contract OrderTester {
         return read().decreasesLiquidity(currentPosition);
     }
 
-    function liquidityCheckApplicable(MarketParameter memory marketParameter) external view returns (bool) {
-        return read().liquidityCheckApplicable(marketParameter);
+    function liquidityCheckApplicable(bool isMarketClosed) external view returns (bool) {
+        return read().liquidityCheckApplicable(isMarketClosed);
     }
 
     function isEmpty() external view returns (bool) {

--- a/packages/perennial/contracts/types/MarketParameter.sol
+++ b/packages/perennial/contracts/types/MarketParameter.sol
@@ -31,12 +31,6 @@ struct MarketParameter {
     /// @dev The fixed fee that is charge whenever an oracle request occurs
     UFixed6 settlementFee;
 
-    /// @dev Whether longs and shorts can always close even when they'd put the market into socialization
-    bool takerCloseAlways;
-
-    /// @dev Whether makers can always close even when they'd put the market into socialization
-    bool makerCloseAlways;
-
     /// @dev Whether the market is in close-only mode
     bool closed;
 
@@ -69,8 +63,8 @@ library MarketParameterStorageLib {
         uint256 slot0 = self.slot0;
 
         uint256 flags = uint256(slot0) >> (256 - 8);
-        (bool takerCloseAlways, bool makerCloseAlways, bool closed, bool settle) =
-            (flags & 0x01 == 0x01, flags & 0x02 == 0x02, flags & 0x04 == 0x04, flags & 0x08 == 0x08);
+        (bool closed, bool settle) =
+            (flags & 0x04 == 0x04, flags & 0x08 == 0x08);
 
         return MarketParameter(
             UFixed6.wrap(uint256(slot0 << (256 - 24)) >> (256 - 24)),
@@ -81,8 +75,6 @@ library MarketParameterStorageLib {
             uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16)) >> (256 - 16),
             uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16)) >> (256 - 16),
             UFixed6.wrap(uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 48)) >> (256 - 48)),
-            takerCloseAlways,
-            makerCloseAlways,
             closed,
             settle
         );
@@ -111,9 +103,7 @@ library MarketParameterStorageLib {
     }
 
     function _store(MarketParameterStorage storage self, MarketParameter memory newValue) private {
-        uint256 flags = (newValue.takerCloseAlways ? 0x01 : 0x00) |
-            (newValue.makerCloseAlways ? 0x02 : 0x00) |
-            (newValue.closed ? 0x04 : 0x00) |
+        uint256 flags = (newValue.closed ? 0x04 : 0x00) |
             (newValue.settle ? 0x08 : 0x00);
 
         uint256 encoded0 =

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -167,11 +167,21 @@ library OrderLib {
     /// @return Whether the order is applicable for liquidity checks
     function liquidityCheckApplicable(
         Order memory self,
-        MarketParameter memory marketParameter
+        MarketParameter memory marketParameter // TODO: consider changing this to a isMarketClosed bool to save gas
     ) internal pure returns (bool) {
         return !marketParameter.closed &&
-            ((maker(self).isZero()) || increasesMaker(self)) &&
-            ((long(self).isZero() && short(self).isZero()) || increasesTaker(self));
+            // TODO: optimize for gas, minimizing unwraps and <> comparisons 
+            (maker(self).lt(Fixed6Lib.ZERO) || long(self).gt(Fixed6Lib.ZERO) || short(self).gt(Fixed6Lib.ZERO));
+
+        // TODO: write an Order unit test which breaks using the implementation below
+        //  (!self.makerNeg.isZero() || !self.longPos.isZero() || !self.shortPos.isZero());
+
+        // TODO: use or remove Kevin's implementation below
+        // not "a taker order that is increasing" ->
+        // not (any of the following)
+        //  - taker is empty (not a taker order)
+        //  - taker is increasing (position going more long or short)
+            // ((long(self).isZero() && short(self).isZero()) || increasesTaker(self));
     }
 
     /// @notice Returns whether the order is protected

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -170,18 +170,11 @@ library OrderLib {
         MarketParameter memory marketParameter // TODO: consider changing this to a isMarketClosed bool to save gas
     ) internal pure returns (bool) {
         return !marketParameter.closed &&
-            // TODO: optimize for gas, minimizing unwraps and <> comparisons 
-            (maker(self).lt(Fixed6Lib.ZERO) || long(self).gt(Fixed6Lib.ZERO) || short(self).gt(Fixed6Lib.ZERO));
-
-        // TODO: write an Order unit test which breaks using the implementation below
-        //  (!self.makerNeg.isZero() || !self.longPos.isZero() || !self.shortPos.isZero());
-
-        // TODO: use or remove Kevin's implementation below
         // not "a taker order that is increasing" ->
         // not (any of the following)
         //  - taker is empty (not a taker order)
         //  - taker is increasing (position going more long or short)
-            // ((long(self).isZero() && short(self).isZero()) || increasesTaker(self));
+            ((long(self).isZero() && short(self).isZero()) || increasesTaker(self));
     }
 
     /// @notice Returns whether the order is protected

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -170,8 +170,8 @@ library OrderLib {
         MarketParameter memory marketParameter
     ) internal pure returns (bool) {
         return !marketParameter.closed &&
-            ((maker(self).isZero()) || !marketParameter.makerCloseAlways || increasesMaker(self)) &&
-            ((long(self).isZero() && short(self).isZero()) || !marketParameter.takerCloseAlways || increasesTaker(self));
+            ((maker(self).isZero()) || increasesMaker(self)) &&
+            ((long(self).isZero() && short(self).isZero()) || increasesTaker(self));
     }
 
     /// @notice Returns whether the order is protected

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -163,13 +163,13 @@ library OrderLib {
 
     /// @notice Returns whether the order is applicable for liquidity checks
     /// @param self The Order object to check
-    /// @param marketParameter The market parameter
+    /// @param isMarketClosed True if market is not accepting orders
     /// @return Whether the order is applicable for liquidity checks
     function liquidityCheckApplicable(
         Order memory self,
-        MarketParameter memory marketParameter // TODO: consider changing this to a isMarketClosed bool to save gas
+        bool isMarketClosed
     ) internal pure returns (bool) {
-        return !marketParameter.closed &&
+        return !isMarketClosed &&
         // not "a taker order that is increasing" ->
         // not (any of the following)
         //  - taker is empty (not a taker order)

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -93,8 +93,6 @@ describe('Happy Path', () => {
       maxPendingGlobal: 8,
       maxPendingLocal: 8,
       settlementFee: 0,
-      makerCloseAlways: false,
-      takerCloseAlways: false,
       closed: false,
       settle: false,
     }
@@ -1092,8 +1090,6 @@ describe('Happy Path', () => {
       maxPendingGlobal: 8,
       maxPendingLocal: 8,
       positionFee: positionFeesOn ? parse6decimal('0.1') : 0,
-      makerCloseAlways: false,
-      takerCloseAlways: false,
       closed: false,
       settle: false,
     }
@@ -1251,8 +1247,6 @@ describe('Happy Path', () => {
       maxPendingGlobal: 8,
       maxPendingLocal: 8,
       positionFee: positionFeesOn ? parse6decimal('0.1') : 0,
-      makerCloseAlways: false,
-      takerCloseAlways: false,
       closed: false,
       settle: false,
     }

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -248,8 +248,6 @@ export async function createMarket(
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
     settlementFee: 0,
-    makerCloseAlways: false,
-    takerCloseAlways: false,
     closed: false,
     settle: false,
     ...marketParamOverrides,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14375,11 +14375,7 @@ describe('Market', () => {
               await settle(market, user)
             })
 
-            it('allows closing when takerCloseAlways', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.takerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
-
+            it('allows closing long', async () => {
               await expect(
                 market
                   .connect(user)
@@ -14387,19 +14383,7 @@ describe('Market', () => {
               ).to.not.be.reverted
             })
 
-            it('disallows closing when not takerCloseAlways', async () => {
-              await expect(
-                market
-                  .connect(user)
-                  ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
-              ).to.revertedWithCustomError(market, 'MarketInsufficientLiquidityError')
-            })
-
             it('disallows short increasing (efficiency)', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.takerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
-
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.5')
               await market.updateRiskParameter(riskParameter)
@@ -14419,10 +14403,6 @@ describe('Market', () => {
             })
 
             it('disallows short increasing (liquidity)', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.takerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
-
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.3')
               await market.updateRiskParameter(riskParameter)
@@ -14474,10 +14454,8 @@ describe('Market', () => {
               await settle(market, user)
             })
 
-            it('allows closing when takerCloseAlways', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.takerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
+            it('allows closing short position', async () => {
+              console.log(await market.positions(user.address))
 
               await expect(
                 market
@@ -14486,19 +14464,7 @@ describe('Market', () => {
               ).to.not.be.reverted
             })
 
-            it('disallows closing when not takerCloseAlways', async () => {
-              await expect(
-                market
-                  .connect(user)
-                  ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
-              ).to.revertedWithCustomError(market, 'MarketInsufficientLiquidityError')
-            })
-
             it('disallows long increasing (efficiency)', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.takerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
-
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.5')
               await market.updateRiskParameter(riskParameter)
@@ -14518,10 +14484,6 @@ describe('Market', () => {
             })
 
             it('disallows long increasing (liquidity)', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.takerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
-
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.3')
               await market.updateRiskParameter(riskParameter)
@@ -14572,25 +14534,13 @@ describe('Market', () => {
               oracle.request.whenCalledWith(user.address).returns()
               await settle(market, user)
             })
-
-            it('allows closing when makerCloseAlways', async () => {
-              const marketParameter = { ...(await market.parameter()) }
-              marketParameter.makerCloseAlways = true
-              await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
-
+            // FIXME: was there sufficient liquidity to close the position?
+            it('allows closing maker', async () => {
               await expect(
                 market
                   .connect(userB)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
               ).to.not.be.reverted
-            })
-
-            it('disallows closing when not makerCloseAlways', async () => {
-              await expect(
-                market
-                  .connect(userB)
-                  ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
-              ).to.revertedWithCustomError(market, 'MarketEfficiencyUnderLimitError')
             })
           })
         })

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14534,13 +14534,13 @@ describe('Market', () => {
               oracle.request.whenCalledWith(user.address).returns()
               await settle(market, user)
             })
-            // FIXME: was there sufficient liquidity to close the position?
-            it('allows closing maker', async () => {
+
+            it('disallows closing maker', async () => {
               await expect(
                 market
                   .connect(userB)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
-              ).to.not.be.reverted
+              ).to.revertedWithCustomError(market, 'MarketInsufficientLiquidityError')
             })
           })
         })

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14540,7 +14540,7 @@ describe('Market', () => {
                 market
                   .connect(userB)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
-              ).to.revertedWithCustomError(market, 'MarketInsufficientLiquidityError')
+              ).to.revertedWithCustomError(market, 'MarketEfficiencyUnderLimitError')
             })
           })
         })

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -466,8 +466,6 @@ describe('Market', () => {
       maxPendingGlobal: 5,
       maxPendingLocal: 3,
       settlementFee: 0,
-      makerCloseAlways: false,
-      takerCloseAlways: false,
       closed: false,
       settle: false,
     }
@@ -597,8 +595,6 @@ describe('Market', () => {
         maxPendingGlobal: 5,
         maxPendingLocal: 3,
         settlementFee: parse6decimal('0.09'),
-        makerCloseAlways: true,
-        takerCloseAlways: true,
         closed: true,
         settle: true,
       }

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -81,8 +81,6 @@ function generateMarketParameter(oracleFee: BigNumberish, riskFee: BigNumberish)
     riskFee,
     closed: false,
     settle: false,
-    makerCloseAlways: false,
-    takerCloseAlways: false,
   }
 }
 

--- a/packages/perennial/test/unit/types/MarketParameter.test.ts
+++ b/packages/perennial/test/unit/types/MarketParameter.test.ts
@@ -72,8 +72,6 @@ describe('MarketParameter', () => {
       expect(value.maxPendingGlobal).to.equal(10)
       expect(value.maxPendingLocal).to.equal(11)
       expect(value.settlementFee).to.equal(6)
-      expect(value.takerCloseAlways).to.equal(false)
-      expect(value.makerCloseAlways).to.equal(false)
       expect(value.closed).to.equal(false)
       expect(value.settle).to.equal(false)
     })
@@ -328,30 +326,6 @@ describe('MarketParameter', () => {
     })
 
     context('.flags', async () => {
-      it('saves takerCloseAlways', async () => {
-        await marketParameter.validateAndStore(
-          {
-            ...VALID_MARKET_PARAMETER,
-            takerCloseAlways: true,
-          },
-          PROTOCOL_PARAMETER,
-        )
-        const value = await marketParameter.read()
-        expect(value.takerCloseAlways).to.equal(true)
-      })
-
-      it('saves makerCloseAlways', async () => {
-        await marketParameter.validateAndStore(
-          {
-            ...VALID_MARKET_PARAMETER,
-            makerCloseAlways: true,
-          },
-          PROTOCOL_PARAMETER,
-        )
-        const value = await marketParameter.read()
-        expect(value.makerCloseAlways).to.equal(true)
-      })
-
       it('saves closed', async () => {
         await marketParameter.validateAndStore(
           {

--- a/packages/perennial/test/unit/types/MarketParameter.test.ts
+++ b/packages/perennial/test/unit/types/MarketParameter.test.ts
@@ -26,8 +26,6 @@ export const VALID_MARKET_PARAMETER: MarketParameterStruct = {
   maxPendingGlobal: 10,
   maxPendingLocal: 11,
   settlementFee: 6,
-  takerCloseAlways: false,
-  makerCloseAlways: false,
   closed: false,
   settle: false,
 }

--- a/packages/perennial/test/unit/types/Order.test.ts
+++ b/packages/perennial/test/unit/types/Order.test.ts
@@ -780,17 +780,6 @@ describe('Order', () => {
       })
 
       context('market is open', () => {
-        context('maker increase', () => {
-          it('returns false', async () => {
-            await order.store({ ...DEFAULT_ORDER, makerPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
-
-            expect(result).to.be.false
-          })
-        })
-
         context('long increase', () => {
           it('returns true', async () => {
             await order.store({ ...DEFAULT_ORDER, longPos: 10 })
@@ -810,17 +799,6 @@ describe('Order', () => {
             })
 
             expect(result).to.be.true
-          })
-        })
-
-        context('no increase', () => {
-          it('returns false', async () => {
-            await order.store(DEFAULT_ORDER)
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
-
-            expect(result).to.be.false
           })
         })
 

--- a/packages/perennial/test/unit/types/Order.test.ts
+++ b/packages/perennial/test/unit/types/Order.test.ts
@@ -779,16 +779,15 @@ describe('Order', () => {
         })
       })
 
-      context('makerCloseAlways is true', () => {
+      context('market is open', () => {
         context('maker increase', () => {
-          it('returns true', async () => {
+          it('returns false', async () => {
             await order.store({ ...DEFAULT_ORDER, makerPos: 10 })
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
-            expect(result).to.be.true
+            expect(result).to.be.false
           })
         })
 
@@ -797,7 +796,6 @@ describe('Order', () => {
             await order.store({ ...DEFAULT_ORDER, longPos: 10 })
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
             expect(result).to.be.true
@@ -809,7 +807,6 @@ describe('Order', () => {
             await order.store({ ...DEFAULT_ORDER, shortPos: 10 })
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
             expect(result).to.be.true
@@ -821,19 +818,17 @@ describe('Order', () => {
             await order.store(DEFAULT_ORDER)
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
-            expect(result).to.be.true
+            expect(result).to.be.false
           })
         })
 
         context('maker decrease', () => {
-          it('returns false', async () => {
+          it('returns true', async () => {
             await order.store({ ...DEFAULT_ORDER, makerNeg: 10 })
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
             expect(result).to.be.true
@@ -845,7 +840,6 @@ describe('Order', () => {
             await order.store({ ...DEFAULT_ORDER, longNeg: 10 })
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
             expect(result).to.be.false
@@ -857,167 +851,9 @@ describe('Order', () => {
             await order.store({ ...DEFAULT_ORDER, shortNeg: 10 })
             const result = await order.liquidityCheckApplicable({
               ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
             })
 
             expect(result).to.be.false
-          })
-        })
-      })
-
-      context('takerCloseAlways is true', () => {
-        context('maker increase', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, makerPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('long increase', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, longPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('short increase', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, shortPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('no increase', () => {
-          it('returns false', async () => {
-            await order.store(DEFAULT_ORDER)
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('maker decrease', () => {
-          it('returns false', async () => {
-            await order.store({ ...DEFAULT_ORDER, makerNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('long decrease', () => {
-          it('returns false', async () => {
-            await order.store({ ...DEFAULT_ORDER, longNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.false
-          })
-        })
-
-        context('short decrease', () => {
-          it('returns false', async () => {
-            await order.store({ ...DEFAULT_ORDER, shortNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.false
-          })
-        })
-      })
-
-      context('closed, makerCloseAlways, and takerCloseAlways are false', () => {
-        context('maker increase', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, makerPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('long increase', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, longPos: 10 })
-            const result = await order.liquidityCheckApplicable(VALID_MARKET_PARAMETER)
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('short increase', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, shortPos: 10 })
-            const result = await order.liquidityCheckApplicable(VALID_MARKET_PARAMETER)
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('no increase', () => {
-          it('returns true', async () => {
-            await order.store(DEFAULT_ORDER)
-            const result = await order.liquidityCheckApplicable(VALID_MARKET_PARAMETER)
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('maker decrease', () => {
-          it('returns false', async () => {
-            await order.store({ ...DEFAULT_ORDER, makerNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-              takerCloseAlways: true,
-            })
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('long decrease', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, longNeg: 10 })
-            const result = await order.liquidityCheckApplicable(VALID_MARKET_PARAMETER)
-
-            expect(result).to.be.true
-          })
-        })
-
-        context('short decrease', () => {
-          it('returns true', async () => {
-            await order.store({ ...DEFAULT_ORDER, shortNeg: 10 })
-            const result = await order.liquidityCheckApplicable(VALID_MARKET_PARAMETER)
-
-            expect(result).to.be.true
           })
         })
       })

--- a/packages/perennial/test/unit/types/Order.test.ts
+++ b/packages/perennial/test/unit/types/Order.test.ts
@@ -770,10 +770,7 @@ describe('Order', () => {
       context('market is closed', () => {
         it('returns false', async () => {
           await order.store(DEFAULT_ORDER)
-          const result = await order.liquidityCheckApplicable({
-            ...VALID_MARKET_PARAMETER,
-            closed: true,
-          })
+          const result = await order.liquidityCheckApplicable(true)
 
           expect(result).to.be.false
         })
@@ -783,9 +780,7 @@ describe('Order', () => {
         context('long increase', () => {
           it('returns true', async () => {
             await order.store({ ...DEFAULT_ORDER, longPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
+            const result = await order.liquidityCheckApplicable(false)
 
             expect(result).to.be.true
           })
@@ -794,9 +789,7 @@ describe('Order', () => {
         context('short increase', () => {
           it('returns true', async () => {
             await order.store({ ...DEFAULT_ORDER, shortPos: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
+            const result = await order.liquidityCheckApplicable(false)
 
             expect(result).to.be.true
           })
@@ -805,9 +798,7 @@ describe('Order', () => {
         context('maker decrease', () => {
           it('returns true', async () => {
             await order.store({ ...DEFAULT_ORDER, makerNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
+            const result = await order.liquidityCheckApplicable(false)
 
             expect(result).to.be.true
           })
@@ -816,9 +807,7 @@ describe('Order', () => {
         context('long decrease', () => {
           it('returns false', async () => {
             await order.store({ ...DEFAULT_ORDER, longNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
+            const result = await order.liquidityCheckApplicable(false)
 
             expect(result).to.be.false
           })
@@ -827,9 +816,7 @@ describe('Order', () => {
         context('short decrease', () => {
           it('returns false', async () => {
             await order.store({ ...DEFAULT_ORDER, shortNeg: 10 })
-            const result = await order.liquidityCheckApplicable({
-              ...VALID_MARKET_PARAMETER,
-            })
+            const result = await order.liquidityCheckApplicable(false)
 
             expect(result).to.be.false
           })


### PR DESCRIPTION
Remove two market parameter knobs, adjusting logic such that makerCloseAlways=false and takerCloseAlways=true.  Reworked unit tests, removing those which specifically tested the behavior of these knobs.