### PR TITLE
[v2.2 Audit Fix] Resolves double-subtraction issue with asset ineligibility calculation

### DIFF
--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -399,7 +399,7 @@ contract Vault is IVault, Instance {
             .allocate(
                 deposit,
                 withdrawal,
-                _ineligable(context, withdrawal)
+                _ineligible(context, withdrawal)
             );
 
         for (uint256 marketId; marketId < context.registrations.length; marketId++)
@@ -410,24 +410,24 @@ contract Vault is IVault, Instance {
                 _retarget(context.registrations[marketId], targets[marketId], rebalance);
     }
 
-    /// @notice Returns the amount of collateral is ineligable for allocation
+    /// @notice Returns the amount of collateral is ineligible for allocation
     /// @param context The context to use
     /// @param withdrawal The amount of assets that need to be withdrawn from the markets into the vault
-    /// @return The amount of assets that are ineligable from being allocated
-    function _ineligable(Context memory context, UFixed6 withdrawal) private pure returns (UFixed6) {
-        // assets eligable for redemption
-        UFixed6 redemptionEligable = UFixed6Lib.unsafeFrom(context.totalCollateral)
+    /// @return The amount of assets that are ineligible from being allocated
+    function _ineligible(Context memory context, UFixed6 withdrawal) private pure returns (UFixed6) {
+        // assets eligible for redemption
+        UFixed6 redemptionEligible = UFixed6Lib.unsafeFrom(context.totalCollateral)
             // assets pending claim (use latest global assets before withdrawal for redeemability)
             .unsafeSub(context.global.assets.add(withdrawal))
             // assets pending deposit
             .unsafeSub(context.global.deposit);
 
-        return redemptionEligable
+        return redemptionEligible
             // approximate assets up for redemption
             .mul(context.global.redemption.unsafeDiv(context.global.shares.add(context.global.redemption)))
             // assets pending claim (use new global assets after withdrawal for eligability)
             .add(context.global.assets);
-            // assets pending deposit are eligable for allocation
+            // assets pending deposit are eligible for allocation
     }
 
     /// @notice Adjusts the position on `market` to `targetPosition`

--- a/packages/perennial-vault/contracts/Vault.sol
+++ b/packages/perennial-vault/contracts/Vault.sol
@@ -417,17 +417,17 @@ contract Vault is IVault, Instance {
     function _ineligable(Context memory context, UFixed6 withdrawal) private pure returns (UFixed6) {
         // assets eligable for redemption
         UFixed6 redemptionEligable = UFixed6Lib.unsafeFrom(context.totalCollateral)
-            .unsafeSub(withdrawal)
-            .unsafeSub(context.global.assets)
+            // assets pending claim (use latest global assets before withdrawal for redeemability)
+            .unsafeSub(context.global.assets.add(withdrawal))
+            // assets pending deposit
             .unsafeSub(context.global.deposit);
 
         return redemptionEligable
             // approximate assets up for redemption
             .mul(context.global.redemption.unsafeDiv(context.global.shares.add(context.global.redemption)))
-            // assets pending claim
-            .add(context.global.assets)
-            // assets withdrawing
-            .add(withdrawal);
+            // assets pending claim (use new global assets after withdrawal for eligability)
+            .add(context.global.assets);
+            // assets pending deposit are eligable for allocation
     }
 
     /// @notice Adjusts the position on `market` to `targetPosition`

--- a/packages/perennial-vault/contracts/lib/StrategyLib.sol
+++ b/packages/perennial-vault/contracts/lib/StrategyLib.sol
@@ -108,15 +108,15 @@ library StrategyLib {
     /// @param strategy The strategy of the vault
     /// @param deposit The amount of assets that are being deposited into the vault
     /// @param withdrawal The amount of assets to make available for withdrawal
-    /// @param ineligable The amount of assets that are inapplicable for allocation
+    /// @param ineligible The amount of assets that are inapplicable for allocation
     function allocate(
         Strategy memory strategy,
         UFixed6 deposit,
         UFixed6 withdrawal,
-        UFixed6 ineligable
+        UFixed6 ineligible
     ) internal pure returns (MarketTarget[] memory targets) {
         UFixed6 collateral = UFixed6Lib.unsafeFrom(strategy.totalCollateral).add(deposit).unsafeSub(withdrawal);
-        UFixed6 assets = collateral.unsafeSub(ineligable);
+        UFixed6 assets = collateral.unsafeSub(ineligible);
 
         if (collateral.lt(strategy.totalMargin)) revert StrategyLibInsufficientCollateralError();
         if (assets.lt(strategy.minAssets)) revert StrategyLibInsufficientAssetsError();

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -781,6 +781,68 @@ describe('Vault', () => {
       expect((await vault.accounts(ethers.constants.AddressZero)).assets).to.equal(0)
     })
 
+    it('simple deposits and redemptions (double withdrawal error check)', async () => {
+      expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
+      expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))
+
+      const smallDeposit = parse6decimal('10')
+      await vault.connect(user).update(user.address, smallDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('8'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('2'))
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      await updateOracle()
+      await vault.rebalance(user.address)
+
+      const checkpoint1 = await vault.checkpoints(1)
+      expect(checkpoint1.deposit).to.equal(smallDeposit)
+      expect(checkpoint1.orders).to.equal(1)
+      expect(checkpoint1.timestamp).to.equal((await market.pendingOrders(vault.address, 1)).timestamp)
+
+      // We're underneath the collateral minimum, so we shouldn't have opened any positions.
+      expect(await position()).to.equal(0)
+      expect(await btcPosition()).to.equal(0)
+      const largeDeposit = parse6decimal('10000')
+      await vault.connect(user).update(user.address, largeDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('8008'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('2002'))
+      expect((await vault.accounts(user.address)).shares).to.equal(smallDeposit)
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(smallDeposit)
+      expect(await vault.totalAssets()).to.equal(smallDeposit)
+      expect(await vault.convertToAssets(parse6decimal('10'))).to.equal(parse6decimal('10'))
+      expect(await vault.convertToShares(parse6decimal('10'))).to.equal(parse6decimal('10'))
+      await updateOracle()
+      await vault.rebalance(user.address)
+      const checkpoint2 = await vault.checkpoints(2)
+      expect(checkpoint2.deposit).to.equal(largeDeposit)
+      expect(checkpoint2.assets).to.equal(smallDeposit)
+      expect(checkpoint2.shares).to.equal(smallDeposit)
+      expect(checkpoint2.orders).to.equal(1)
+      expect(checkpoint2.timestamp).to.equal((await market.pendingOrders(vault.address, 2)).timestamp)
+
+      expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('10010'))
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(parse6decimal('10010'))
+      expect(await vault.totalAssets()).to.equal(parse6decimal('10010'))
+      expect(await vault.convertToAssets(parse6decimal('10010'))).to.equal(parse6decimal('10010'))
+      expect(await vault.convertToShares(parse6decimal('10010'))).to.equal(parse6decimal('10010'))
+
+      // Now we should have opened positions.
+      // The positions should be equal to (smallDeposit + largeDeposit) * leverage originalOraclePrice.
+      expect(await position()).to.equal(
+        smallDeposit.add(largeDeposit).mul(leverage).mul(4).div(5).div(originalOraclePrice),
+      )
+      expect(await btcPosition()).to.equal(
+        smallDeposit.add(largeDeposit).mul(leverage).div(5).div(btcOriginalOraclePrice),
+      )
+
+      const half = smallDeposit.add(largeDeposit).div(2).add(smallDeposit)
+      await vault.connect(user).update(user.address, 0, half, 0)
+
+      await updateOracle()
+      await expect(vault.connect(user2).update(user2.address, smallDeposit, 0, 0)).to.not.reverted // this will create min position in the market
+      await expect(vault.connect(user).update(user.address, 0, 0, half)).to.not.reverted // this will revert even though it's just claiming
+    })
+
     it('multiple users', async () => {
       expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
       expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))


### PR DESCRIPTION
Resolves: https://github.com/sherlock-audit/2024-02-perennial-v2-3-judging/issues/11.

Adds additional documentation on what is going on in this calculation and why we do not need to the second `.add(withdrawal)`.