### PR TITLE
[v2.2 Audit Fix] KeeperOracle flag to trap invalid oracle versions

### DIFF
--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -169,8 +169,6 @@ contract KeeperOracle is IKeeperOracle, Instance {
         if (!version.valid) revert KeeperOracleInvalidPriceError();
         if (version.timestamp <= _global.latestVersion || (next() != 0 && version.timestamp >= next()))
             revert KeeperOracleVersionOutsideRangeError();
-        if (version.price.gt(Fixed6.wrap(type(int64).max)) || version.price.lt(Fixed6.wrap(type(int64).min)))
-            revert KeeperOracleInvalidPriceError();
 
         _prices[version.timestamp].store(Price(version.price, true));
         return false;

--- a/packages/perennial-oracle/contracts/keeper/types/Price.sol
+++ b/packages/perennial-oracle/contracts/keeper/types/Price.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "@equilibria/root/number/types/UFixed6.sol";
+import "@equilibria/perennial-v2/contracts/types/OracleVersion.sol";
+
+struct Price {
+    Fixed6 price;
+    bool valid;
+}
+using PriceLib for Price global;
+struct StoredPrice {
+    int64 price;
+    bool valid;
+}
+struct PriceStorage { StoredPrice value; }
+using PriceStorageLib for PriceStorage global;
+
+/**
+ * @title PriceLib
+ * @notice Library for Price logic and data.
+ */
+library PriceLib {
+    // @notice Returns an oracle version based on the price snapshot and timestamp
+    // @param self The price snapshot object
+    // @param timestamp The timestamp of the price snapshot
+    // @return The corresponding oracle version
+    function toOracleVersion(Price memory self, uint256 timestamp) internal pure returns (OracleVersion memory) {
+        return OracleVersion(timestamp, self.price, self.valid);
+    }
+}
+
+library PriceStorageLib {
+    // sig: 0x2dbc6ed2
+    error PriceStorageInvalidError();
+
+    function read(PriceStorage storage self) internal view returns (Price memory) {
+        StoredPrice memory storedValue = self.value;
+        return Price(Fixed6.wrap(int256(storedValue.price)), storedValue.valid);
+    }
+
+    function store(PriceStorage storage self, Price memory newValue) internal {
+        if (newValue.price.gt(Fixed6.wrap(type(int64).max))) revert PriceStorageInvalidError();
+        if (newValue.price.lt(Fixed6.wrap(type(int64).min))) revert PriceStorageInvalidError();
+
+        self.value = StoredPrice(int64(Fixed6.unwrap(newValue.price)), newValue.valid);
+    }
+}

--- a/packages/perennial-oracle/contracts/test/PriceTester.sol
+++ b/packages/perennial-oracle/contracts/test/PriceTester.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../keeper/types/Price.sol";
+
+contract PriceTester {
+    PriceStorage public price;
+
+    function read() external view returns (Price memory) {
+        return price.read();
+    }
+
+    function store(Price memory newPrice) external {
+        return price.store(newPrice);
+    }
+}

--- a/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
@@ -170,13 +170,14 @@ describe('KeeperOracle', () => {
     // TODO: weaponize this transaction-to-blocktime facility into a utility function
     const requestedTime = (await ethers.provider.getBlock(tx.blockNumber!)).timestamp
 
-    // commit a requested price older than the timeout
+    // attempt to commit a requested price older than the timeout
     increase(KEEPER_ORACLE_TIMEOUT + 1)
     await commitPrice(requestedTime, parse6decimal('3333.444'))
 
-    const badPrice = await keeperOracle.at(requestedTime)
-    expect(badPrice.timestamp).to.equal(requestedTime)
-    expect(badPrice.price).to.equal(0)
-    expect(badPrice.valid).to.be.false
+    // ensure carryover price is received instead of invalid price
+    const invalidPrice = await keeperOracle.at(requestedTime)
+    expect(invalidPrice.timestamp).to.equal(requestedTime)
+    expect(invalidPrice.price).to.equal(parse6decimal('3333.777'))
+    expect(invalidPrice.valid).to.be.false
   })
 })

--- a/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
@@ -10,6 +10,8 @@ import {
   Oracle__factory,
   OracleFactory__factory,
   AggregatorV3Interface,
+  IMarket,
+  IMarketFactory,
 } from '../../../types/generated'
 import { utils, BigNumber } from 'ethers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -17,26 +19,24 @@ import { fail } from 'assert'
 import { FakeContract, smock } from '@defi-wonderland/smock'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { expect } from 'chai'
-import { currentBlockTimestamp } from '../../../../common/testutil/time'
+import { currentBlockTimestamp, increase, increaseTo } from '../../../../common/testutil/time'
 import { impersonateWithBalance } from '../../../../common/testutil/impersonate'
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 
 const PYTH_ETH_USD_PRICE_FEED = '0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace'
+const KEEPER_ORACLE_TIMEOUT = 60
 
 describe('KeeperOracle', () => {
   let owner: SignerWithAddress
   let user: SignerWithAddress
+  let oracleSigner: SignerWithAddress
   let keeperOracle: KeeperOracle
   let keeperOracleFactory: KeeperFactory
+  let market: FakeContract<IMarket>
+  let marketFactory: FakeContract<IMarketFactory>
 
-  let pyth: FakeContract<AbstractPyth>
-  let dsu: FakeContract<IERC20Metadata>
-
-  beforeEach(async () => {
+  const keeperOracleFixture = async () => {
     ;[owner, user] = await ethers.getSigners()
-    // Base fee isn't working properly in coverage, so we need to set it manually
-    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
-
-    // TODO: move most of this stuff to a fixture to reuse chain state for multiple tests
 
     // mock external components
     const pyth = await smock.fake<AbstractPyth>('AbstractPyth')
@@ -45,13 +45,20 @@ describe('KeeperOracle', () => {
     const dsu = await smock.fake<IERC20Metadata>('IERC20Metadata')
     dsu.transfer.returns(true)
 
+    // mock the market
+    market = await smock.fake<IMarket>('IMarket')
+    marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
+    market.factory.returns(marketFactory.address)
+    marketFactory.instances.whenCalledWith(market.address).returns(true)
+
     // deploy prerequisites
     const oracleImpl = await new Oracle__factory(owner).deploy()
     const oracleFactory = await new OracleFactory__factory(owner).deploy(oracleImpl.address)
     await oracleFactory.initialize(dsu.address)
     await oracleFactory.updateMaxClaim(parse6decimal('10'))
 
-    const keeperOracleImpl = await new KeeperOracle__factory(owner).deploy(60)
+    // deploy the implementation contract and a factory letting us create an instance
+    const keeperOracleImpl = await new KeeperOracle__factory(owner).deploy(KEEPER_ORACLE_TIMEOUT)
     keeperOracleFactory = await new PythFactory__factory(owner).deploy(
       pyth.address,
       keeperOracleImpl.address,
@@ -75,6 +82,7 @@ describe('KeeperOracle', () => {
     await oracleFactory.register(keeperOracleFactory.address)
     await keeperOracleFactory.authorize(oracleFactory.address)
 
+    // create our KeeperOracle instance
     keeperOracle = KeeperOracle__factory.connect(
       await keeperOracleFactory.callStatic.create(PYTH_ETH_USD_PRICE_FEED, PYTH_ETH_USD_PRICE_FEED, {
         provider: ethers.constants.AddressZero,
@@ -86,6 +94,36 @@ describe('KeeperOracle', () => {
       provider: ethers.constants.AddressZero,
       decimals: 0,
     })
+
+    // needed for making oracle requests
+    const oracle = Oracle__factory.connect(
+      await oracleFactory.callStatic.create(PYTH_ETH_USD_PRICE_FEED, keeperOracleFactory.address),
+      owner,
+    )
+    await oracleFactory.create(PYTH_ETH_USD_PRICE_FEED, keeperOracleFactory.address)
+    oracleSigner = await impersonateWithBalance(oracle.address, utils.parseEther('10'))
+  }
+
+  async function commitPrice(timestamp: number, price: BigNumber) {
+    const oracleVersion = {
+      timestamp: timestamp,
+      price: price,
+      valid: true,
+    }
+    const keeperFactorySigner = await impersonateWithBalance(keeperOracleFactory.address, utils.parseEther('10'))
+    await expect(
+      keeperOracle.connect(keeperFactorySigner).commit(oracleVersion, {
+        maxFeePerGas: 100000000,
+      }),
+    ).to.emit(keeperOracle, 'OracleProviderVersionFulfilled')
+  }
+
+  beforeEach(async () => {
+    // snapshot initial chain state for multiple tests
+    await loadFixture(keeperOracleFixture)
+
+    // Base fee isn't working properly in coverage, so we need to set it manually
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
   })
 
   it('can commit new prices', async () => {
@@ -97,17 +135,7 @@ describe('KeeperOracle', () => {
 
     // commit a new version
     const newTimestamp = (await currentBlockTimestamp()) - 5
-    const newVersion = {
-      timestamp: newTimestamp,
-      price: parse6decimal('3456.789'),
-      valid: true,
-    }
-    const keeperFactorySigner = await impersonateWithBalance(keeperOracleFactory.address, utils.parseEther('10'))
-    await expect(
-      keeperOracle.connect(keeperFactorySigner).commit(newVersion, {
-        maxFeePerGas: 100000000,
-      }),
-    ).to.emit(keeperOracle, 'OracleProviderVersionFulfilled')
+    await commitPrice(newTimestamp, parse6decimal('3456.789'))
 
     // validate the commit worked
     version = await keeperOracle.latest()
@@ -116,7 +144,39 @@ describe('KeeperOracle', () => {
     expect(version.valid).to.be.true
   })
 
-  it.skip('discards expired prices', async () => {
-    fail('not yet implemented')
+  it('reverts committing 0 timestamp', async () => {
+    const badOracleVersion = {
+      timestamp: 0,
+      price: parse6decimal('63.48'),
+      valid: true,
+    }
+    const keeperFactorySigner = await impersonateWithBalance(keeperOracleFactory.address, utils.parseEther('10'))
+    await expect(
+      keeperOracle.connect(keeperFactorySigner).commit(badOracleVersion, {
+        maxFeePerGas: 100000000,
+      }),
+    ).to.be.revertedWithCustomError(keeperOracle, 'KeeperOracleVersionOutsideRangeError')
+  })
+
+  it('discards expired prices', async () => {
+    // establish an initial valid version
+    const startTime = await currentBlockTimestamp()
+    const initialTimestamp = startTime - 4
+    await commitPrice(initialTimestamp, parse6decimal('3333.777'))
+
+    // request a version
+    increase(10)
+    const tx = await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+    // TODO: weaponize this transaction-to-blocktime facility into a utility function
+    const requestedTime = (await ethers.provider.getBlock(tx.blockNumber!)).timestamp
+
+    // commit a requested price older than the timeout
+    increase(KEEPER_ORACLE_TIMEOUT + 1)
+    await commitPrice(requestedTime, parse6decimal('3333.444'))
+
+    const badPrice = await keeperOracle.at(requestedTime)
+    expect(badPrice.timestamp).to.equal(requestedTime)
+    expect(badPrice.price).to.equal(0)
+    expect(badPrice.valid).to.be.false
   })
 })

--- a/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
@@ -1,0 +1,122 @@
+import HRE, { ethers } from 'hardhat'
+
+import {
+  KeeperOracle__factory,
+  KeeperOracle,
+  KeeperFactory,
+  PythFactory__factory,
+  AbstractPyth,
+  IERC20Metadata,
+  Oracle__factory,
+  OracleFactory__factory,
+  AggregatorV3Interface,
+} from '../../../types/generated'
+import { utils, BigNumber } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { fail } from 'assert'
+import { FakeContract, smock } from '@defi-wonderland/smock'
+import { parse6decimal } from '../../../../common/testutil/types'
+import { expect } from 'chai'
+import { currentBlockTimestamp } from '../../../../common/testutil/time'
+import { impersonateWithBalance } from '../../../../common/testutil/impersonate'
+
+const PYTH_ETH_USD_PRICE_FEED = '0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace'
+
+describe('KeeperOracle', () => {
+  let owner: SignerWithAddress
+  let user: SignerWithAddress
+  let keeperOracle: KeeperOracle
+  let keeperOracleFactory: KeeperFactory
+
+  let pyth: FakeContract<AbstractPyth>
+  let dsu: FakeContract<IERC20Metadata>
+
+  beforeEach(async () => {
+    ;[owner, user] = await ethers.getSigners()
+    // Base fee isn't working properly in coverage, so we need to set it manually
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
+
+    // TODO: move most of this stuff to a fixture to reuse chain state for multiple tests
+
+    // mock external components
+    const pyth = await smock.fake<AbstractPyth>('AbstractPyth')
+    pyth.priceFeedExists.returns(true)
+    const chainlinkFeed = await smock.fake<AggregatorV3Interface>('AggregatorV3Interface')
+    const dsu = await smock.fake<IERC20Metadata>('IERC20Metadata')
+    dsu.transfer.returns(true)
+
+    // deploy prerequisites
+    const oracleImpl = await new Oracle__factory(owner).deploy()
+    const oracleFactory = await new OracleFactory__factory(owner).deploy(oracleImpl.address)
+    await oracleFactory.initialize(dsu.address)
+    await oracleFactory.updateMaxClaim(parse6decimal('10'))
+
+    const keeperOracleImpl = await new KeeperOracle__factory(owner).deploy(60)
+    keeperOracleFactory = await new PythFactory__factory(owner).deploy(
+      pyth.address,
+      keeperOracleImpl.address,
+      4,
+      10,
+      {
+        multiplierBase: 0,
+        bufferBase: 1_000_000,
+        multiplierCalldata: 0,
+        bufferCalldata: 500_000,
+      },
+      {
+        multiplierBase: ethers.utils.parseEther('1.02'),
+        bufferBase: 2_000_000,
+        multiplierCalldata: ethers.utils.parseEther('1.03'),
+        bufferCalldata: 1_500_000,
+      },
+      5_000,
+    )
+    await keeperOracleFactory.initialize(oracleFactory.address, chainlinkFeed.address, dsu.address)
+    await oracleFactory.register(keeperOracleFactory.address)
+    await keeperOracleFactory.authorize(oracleFactory.address)
+
+    keeperOracle = KeeperOracle__factory.connect(
+      await keeperOracleFactory.callStatic.create(PYTH_ETH_USD_PRICE_FEED, PYTH_ETH_USD_PRICE_FEED, {
+        provider: ethers.constants.AddressZero,
+        decimals: 0,
+      }),
+      owner,
+    )
+    await keeperOracleFactory.create(PYTH_ETH_USD_PRICE_FEED, PYTH_ETH_USD_PRICE_FEED, {
+      provider: ethers.constants.AddressZero,
+      decimals: 0,
+    })
+  })
+
+  it('can commit new prices', async () => {
+    // validate initial (empty) state
+    let version = await keeperOracle.latest()
+    expect(version.timestamp).to.equal(0)
+    expect(version.price).to.equal(0)
+    expect(version.valid).to.be.false
+
+    // commit a new version
+    const newTimestamp = (await currentBlockTimestamp()) - 5
+    const newVersion = {
+      timestamp: newTimestamp,
+      price: parse6decimal('3456.789'),
+      valid: true,
+    }
+    const keeperFactorySigner = await impersonateWithBalance(keeperOracleFactory.address, utils.parseEther('10'))
+    await expect(
+      keeperOracle.connect(keeperFactorySigner).commit(newVersion, {
+        maxFeePerGas: 100000000,
+      }),
+    ).to.emit(keeperOracle, 'OracleProviderVersionFulfilled')
+
+    // validate the commit worked
+    version = await keeperOracle.latest()
+    expect(version.timestamp).to.equal(newTimestamp)
+    expect(version.price).to.equal(parse6decimal('3456.789'))
+    expect(version.valid).to.be.true
+  })
+
+  it.skip('discards expired prices', async () => {
+    fail('not yet implemented')
+  })
+})

--- a/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
@@ -93,11 +93,6 @@ describe('PythOracleFactory', () => {
     market.factory.returns(marketFactory.address)
     marketFactory.instances.whenCalledWith(market.address).returns(true)
 
-    market = await smock.fake<IMarket>('IMarket')
-    marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
-    market.factory.returns(marketFactory.address)
-    marketFactory.instances.whenCalledWith(market.address).returns(true)
-
     const oracleImpl = await new Oracle__factory(owner).deploy()
     oracleFactory = await new OracleFactory__factory(owner).deploy(oracleImpl.address)
     await oracleFactory.initialize(dsu.address)

--- a/packages/perennial-oracle/test/unit/types/Price.test.ts
+++ b/packages/perennial-oracle/test/unit/types/Price.test.ts
@@ -46,12 +46,18 @@ describe('Price', () => {
 
     it('reverts if price out of range', async () => {
       const STORAGE_SIZE = 64
+
       const overflowPrice: PriceStruct = {
         price: BigNumber.from(2).pow(STORAGE_SIZE).add(1),
         valid: true,
       }
-
       await expect(price.store(overflowPrice)).to.be.revertedWithCustomError(price, 'PriceStorageInvalidError')
+
+      const underflowPrice: PriceStruct = {
+        price: BigNumber.from(2).pow(STORAGE_SIZE).add(1).mul(-1),
+        valid: false,
+      }
+      await expect(price.store(underflowPrice)).to.be.revertedWithCustomError(price, 'PriceStorageInvalidError')
     })
   })
 })

--- a/packages/perennial-oracle/test/unit/types/Price.test.ts
+++ b/packages/perennial-oracle/test/unit/types/Price.test.ts
@@ -1,0 +1,57 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import { PriceTester, PriceTester__factory } from '../../../types/generated'
+import { PriceStruct } from '../../../types/generated/contracts/test/PriceTester'
+import { BigNumber } from 'ethers'
+import { parse6decimal } from '../../../../common/testutil/types'
+
+const { ethers } = HRE
+
+describe('Price', () => {
+  let owner: SignerWithAddress
+  let price: PriceTester
+
+  beforeEach(async () => {
+    ;[owner] = await ethers.getSigners()
+
+    price = await new PriceTester__factory(owner).deploy()
+  })
+
+  describe('#storeAndRead', () => {
+    it('stores and reads a valid price', async () => {
+      const validPrice: PriceStruct = {
+        price: parse6decimal('63.48'),
+        valid: true,
+      }
+      await price.store(validPrice)
+
+      const readPrice = await price.read()
+      expect(readPrice.price).to.equal(validPrice.price)
+      expect(readPrice.valid).to.equal(validPrice.valid)
+    })
+
+    it('stores and reads an invalid price', async () => {
+      const invalidPrice: PriceStruct = {
+        price: 0,
+        valid: false,
+      }
+      await price.store(invalidPrice)
+
+      const readPrice = await price.read()
+      expect(readPrice.price).to.equal(invalidPrice.price)
+      expect(readPrice.valid).to.equal(invalidPrice.valid)
+    })
+
+    it('reverts if price out of range', async () => {
+      const STORAGE_SIZE = 64
+      const overflowPrice: PriceStruct = {
+        price: BigNumber.from(2).pow(STORAGE_SIZE).add(1),
+        valid: true,
+      }
+
+      await expect(price.store(overflowPrice)).to.be.revertedWithCustomError(price, 'PriceStorageInvalidError')
+    })
+  })
+})

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -543,7 +543,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         Order memory nextOrder;
 
-        // settle
+        // settle - process orders whose requested prices are now available from oracle
         while (
             context.global.currentId != context.global.latestId &&
             (nextOrder = _pendingOrder[context.global.latestId + 1].read()).ready(context.latestOracleVersion)
@@ -554,7 +554,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             (nextOrder = _pendingOrders[account][context.local.latestId + 1].read()).ready(context.latestOracleVersion)
         ) _processOrderLocal(context, settlementContext, account, context.local.latestId + 1, nextOrder);
 
-        // sync
+        // sync - advance position timestamps with the latest oracle version
         if (context.latestOracleVersion.timestamp > context.latestPosition.global.timestamp) {
             nextOrder = _pendingOrder[context.global.latestId].read();
             nextOrder.next(context.latestOracleVersion.timestamp);


### PR DESCRIPTION
## Changes
- Establish unit tests for covering `KeeperOracle` without focusing on a specific (Pyth/Chainlink) implementation.
- Reproduce [audit issue](https://github.com/sherlock-audit/2024-02-perennial-v2-3-judging/issues/6) handling of expired prices.
- Resolve by storing a validity flag alongside price.
- Clean up redundant initialization logic in `PythOracleFactory.test.ts` (unrelated).

## Deployment Plan
`KeeperFactory` and `KeeperOracle` and  instances will need to be redeployed.  Suspect this was already part of the 2.1 -> 2.2 migration plan.