### PR TITLE
[v2.1.1 Audit Fix] KeeperOracle to settle using market.settle instead of no-op update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - v2.1
+      - v2.1.1
 
 env:
   CI: true

--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -174,7 +174,7 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @param market The market to settle
     /// @param account The account to settle
     function _settle(IMarket market, address account) private {
-        market.update(account, UFixed6Lib.MAX, UFixed6Lib.MAX, UFixed6Lib.MAX, Fixed6Lib.ZERO, false);
+        market.settle(account);
     }
 
     /// @dev Only allow authorized callers


### PR DESCRIPTION
One-liner, as this does not impact unit tests.  Will need to plan redeployment of `KeeperOracle`s accordingly.