### PR TITLE
Add updateOperatorWithSignature

### DIFF
--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -161,7 +161,11 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
     owner,
   ).deploy(verifierProxy.address)
 
-  const factoryImpl = await new MarketFactory__factory(owner).deploy(oracleFactory.address, marketImpl.address)
+  const factoryImpl = await new MarketFactory__factory(owner).deploy(
+    oracleFactory.address,
+    verifierImpl.address,
+    marketImpl.address,
+  )
 
   const factoryProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
     factoryImpl.address,

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -307,7 +307,11 @@ testOracles.forEach(testOracle => {
         },
         owner,
       ).deploy(verifierImpl.address)
-      marketFactory = await new MarketFactory__factory(owner).deploy(oracleFactory.address, marketImpl.address)
+      marketFactory = await new MarketFactory__factory(owner).deploy(
+        oracleFactory.address,
+        verifierImpl.address,
+        marketImpl.address,
+      )
       await marketFactory.initialize()
       await marketFactory.updateParameter({
         protocolFee: parse6decimal('0.50'),

--- a/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -236,7 +236,11 @@ testOracles.forEach(testOracle => {
         },
         owner,
       ).deploy(verifierImpl.address)
-      marketFactory = await new MarketFactory__factory(owner).deploy(oracleFactory.address, marketImpl.address)
+      marketFactory = await new MarketFactory__factory(owner).deploy(
+        oracleFactory.address,
+        verifierImpl.address,
+        marketImpl.address,
+      )
       await marketFactory.initialize()
       await marketFactory.updateParameter({
         protocolFee: parse6decimal('0.50'),

--- a/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -286,7 +286,11 @@ testOracles.forEach(testOracle => {
         },
         owner,
       ).deploy(verifierImpl.address)
-      marketFactory = await new MarketFactory__factory(owner).deploy(oracleFactory.address, marketImpl.address)
+      marketFactory = await new MarketFactory__factory(owner).deploy(
+        oracleFactory.address,
+        verifierImpl.address,
+        marketImpl.address,
+      )
       await marketFactory.initialize()
       await marketFactory.updateParameter({
         protocolFee: parse6decimal('0.50'),

--- a/packages/perennial-verifier/contracts/Verifier.sol
+++ b/packages/perennial-verifier/contracts/Verifier.sol
@@ -7,6 +7,7 @@ import { Common, CommonLib } from "./types/Common.sol";
 import { Intent, IntentLib } from "./types/Intent.sol";
 import { Fill, FillLib } from "./types/Fill.sol";
 import { GroupCancellation, GroupCancellationLib } from "./types/GroupCancellation.sol";
+import { OperatorUpdate, OperatorUpdateLib } from "./types/OperatorUpdate.sol";
 import { IVerifier } from "./interfaces/IVerifier.sol";
 
 /// @title Verifier
@@ -73,6 +74,18 @@ contract Verifier is IVerifier, EIP712 {
         validateAndCancel(groupCancellation.common, signature) returns (address)
     {
         return ECDSA.recover(_hashTypedDataV4(GroupCancellationLib.hash(groupCancellation)), signature);
+    }
+
+    /// @notice Verifies the signature of a operator approval type
+    /// @dev Cancels the nonce after verifying the signature
+    /// @param operatorUpdate The operator approval message to verify
+    /// @param signature The signature of the account for the operator approval
+    /// @return The address corresponding to the signature
+    function verifyOperatorUpdate(OperatorUpdate calldata operatorUpdate, bytes calldata signature)
+        external
+        validateAndCancel(operatorUpdate.common, signature) returns (address)
+    {
+        return ECDSA.recover(_hashTypedDataV4(OperatorUpdateLib.hash(operatorUpdate)), signature);
     }
 
     /// @notice Cancels a nonce

--- a/packages/perennial-verifier/contracts/interfaces/IVerifier.sol
+++ b/packages/perennial-verifier/contracts/interfaces/IVerifier.sol
@@ -5,6 +5,7 @@ import { Common } from "../types/Common.sol";
 import { Intent } from "../types/Intent.sol";
 import { Fill } from "../types/Fill.sol";
 import { GroupCancellation } from "../types/GroupCancellation.sol";
+import { OperatorUpdate } from "../types/OperatorUpdate.sol";
 
 interface IVerifier {
     // sig: 0xfec563a0
@@ -27,6 +28,7 @@ interface IVerifier {
     function verifyIntent(Intent calldata intent, bytes calldata signature) external returns (address);
     function verifyFill(Fill calldata fill, bytes calldata signature) external returns (address);
     function verifyGroupCancellation(GroupCancellation calldata groupCancellation, bytes calldata signature) external returns (address);
+    function verifyOperatorUpdate(OperatorUpdate calldata operatorUpdate, bytes calldata signature) external returns (address);
     function cancelNonce(uint256 nonce) external;
     function cancelNonceWithSignature(Common calldata common, bytes calldata signature) external;
     function cancelGroup(uint256 group) external;

--- a/packages/perennial-verifier/contracts/types/OperatorUpdate.sol
+++ b/packages/perennial-verifier/contracts/types/OperatorUpdate.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
+import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
+import { Common, CommonLib } from "./Common.sol";
+
+struct OperatorUpdate {
+    /// @dev The operator to approve for the signing account
+    address operator;
+
+    /// @dev The new status of the operator
+    bool approved;
+
+    /// @dev The common information for the intent
+    Common common;
+}
+using OperatorUpdateLib for OperatorUpdate global;
+
+/// @title OperatorUpdateLib
+/// @notice Library for OperatorUpdate logic and data.
+library OperatorUpdateLib {
+    bytes32 constant public STRUCT_HASH = keccak256("OperatorUpdate(address operator,bool approved,Common common)Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)");
+
+    function hash(OperatorUpdate memory self) internal pure returns (bytes32) {
+        return keccak256(abi.encode(STRUCT_HASH, self.operator, self.approved,CommonLib.hash(self.common)));
+    }
+}

--- a/packages/perennial-verifier/contracts/types/OperatorUpdate.sol
+++ b/packages/perennial-verifier/contracts/types/OperatorUpdate.sol
@@ -23,6 +23,6 @@ library OperatorUpdateLib {
     bytes32 constant public STRUCT_HASH = keccak256("OperatorUpdate(address operator,bool approved,Common common)Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)");
 
     function hash(OperatorUpdate memory self) internal pure returns (bytes32) {
-        return keccak256(abi.encode(STRUCT_HASH, self.operator, self.approved,CommonLib.hash(self.common)));
+        return keccak256(abi.encode(STRUCT_HASH, self.operator, self.approved, CommonLib.hash(self.common)));
     }
 }

--- a/packages/perennial-verifier/test/helpers/erc712.ts
+++ b/packages/perennial-verifier/test/helpers/erc712.ts
@@ -6,9 +6,10 @@ import {
   IntentStruct,
   OperatorUpdateStruct,
 } from '../../types/generated/contracts/Verifier'
-import { Verifier } from '../../types/generated'
+import { IVerifier, Verifier } from '../../types/generated'
+import { FakeContract } from '@defi-wonderland/smock'
 
-export function erc721Domain(verifier: Verifier) {
+export function erc721Domain(verifier: Verifier | FakeContract<IVerifier>) {
   return {
     name: 'Perennial',
     version: '1.0.0',
@@ -17,7 +18,11 @@ export function erc721Domain(verifier: Verifier) {
   }
 }
 
-export async function signCommon(signer: SignerWithAddress, verifier: Verifier, common: CommonStruct): Promise<string> {
+export async function signCommon(
+  signer: SignerWithAddress,
+  verifier: Verifier | FakeContract<IVerifier>,
+  common: CommonStruct,
+): Promise<string> {
   const types = {
     Common: [
       { name: 'account', type: 'address' },
@@ -31,7 +36,11 @@ export async function signCommon(signer: SignerWithAddress, verifier: Verifier, 
   return await signer._signTypedData(erc721Domain(verifier), types, common)
 }
 
-export async function signIntent(signer: SignerWithAddress, verifier: Verifier, intent: IntentStruct): Promise<string> {
+export async function signIntent(
+  signer: SignerWithAddress,
+  verifier: Verifier | FakeContract<IVerifier>,
+  intent: IntentStruct,
+): Promise<string> {
   const types = {
     Common: [
       { name: 'account', type: 'address' },
@@ -50,7 +59,11 @@ export async function signIntent(signer: SignerWithAddress, verifier: Verifier, 
   return await signer._signTypedData(erc721Domain(verifier), types, intent)
 }
 
-export async function signFill(signer: SignerWithAddress, verifier: Verifier, fill: FillStruct): Promise<string> {
+export async function signFill(
+  signer: SignerWithAddress,
+  verifier: Verifier | FakeContract<IVerifier>,
+  fill: FillStruct,
+): Promise<string> {
   const types = {
     Common: [
       { name: 'account', type: 'address' },
@@ -75,7 +88,7 @@ export async function signFill(signer: SignerWithAddress, verifier: Verifier, fi
 
 export async function signGroupCancellation(
   signer: SignerWithAddress,
-  verifier: Verifier,
+  verifier: Verifier | FakeContract<IVerifier>,
   groupCancellation: GroupCancellationStruct,
 ): Promise<string> {
   const types = {
@@ -97,7 +110,7 @@ export async function signGroupCancellation(
 
 export async function signOperatorUpdate(
   signer: SignerWithAddress,
-  verifier: Verifier,
+  verifier: Verifier | FakeContract<IVerifier>,
   operatorUpdate: OperatorUpdateStruct,
 ): Promise<string> {
   const types = {

--- a/packages/perennial-verifier/test/helpers/erc712.ts
+++ b/packages/perennial-verifier/test/helpers/erc712.ts
@@ -4,6 +4,7 @@ import {
   FillStruct,
   GroupCancellationStruct,
   IntentStruct,
+  OperatorUpdateStruct,
 } from '../../types/generated/contracts/Verifier'
 import { Verifier } from '../../types/generated'
 
@@ -92,4 +93,27 @@ export async function signGroupCancellation(
   }
 
   return await signer._signTypedData(erc721Domain(verifier), types, groupCancellation)
+}
+
+export async function signOperatorUpdate(
+  signer: SignerWithAddress,
+  verifier: Verifier,
+  operatorUpdate: OperatorUpdateStruct,
+): Promise<string> {
+  const types = {
+    Common: [
+      { name: 'account', type: 'address' },
+      { name: 'domain', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'group', type: 'uint256' },
+      { name: 'expiry', type: 'uint256' },
+    ],
+    OperatorUpdate: [
+      { name: 'operator', type: 'address' },
+      { name: 'approved', type: 'bool' },
+      { name: 'common', type: 'Common' },
+    ],
+  }
+
+  return await signer._signTypedData(erc721Domain(verifier), types, operatorUpdate)
 }

--- a/packages/perennial-verifier/test/unit/Verifier/Verifier.ts
+++ b/packages/perennial-verifier/test/unit/Verifier/Verifier.ts
@@ -8,7 +8,7 @@ import HRE from 'hardhat'
 
 import { Verifier, Verifier__factory } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
-import { signIntent, signFill, signCommon, signGroupCancellation } from '../../helpers/erc712'
+import { signIntent, signFill, signCommon, signGroupCancellation, signOperatorUpdate } from '../../helpers/erc712'
 
 const { ethers } = HRE
 use(smock.matchers)
@@ -747,6 +747,204 @@ describe('Verifier', () => {
       await expect(
         verifier.connect(caller).verifyGroupCancellation(groupCancellation, signature),
       ).to.revertedWithCustomError(verifier, 'VerifierInvalidGroupError')
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+  })
+
+  describe('#verifyOperatorUpdate', () => {
+    const DEFAULT_OPERATOR_UPDATE = {
+      operator: constants.AddressZero,
+      approved: false,
+      common: {
+        account: constants.AddressZero,
+        domain: constants.AddressZero,
+        nonce: 0,
+        group: 0,
+        expiry: constants.MaxUint256,
+      },
+    }
+
+    it('should verify default group cancellation', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        operator: owner.address,
+        approval: true,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      const result = await verifier.connect(caller).callStatic.verifyOperatorUpdate(operatorUpdate, signature)
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(result).to.eq(caller.address)
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should verify group cancellation w/ expiry', async () => {
+      const now = await time.latest()
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: {
+          ...DEFAULT_OPERATOR_UPDATE.common,
+          account: caller.address,
+          domain: caller.address,
+          expiry: now + 2,
+        },
+      } // callstatic & call each take one second
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      const result = await verifier.connect(caller).callStatic.verifyOperatorUpdate(operatorUpdate, signature)
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(result).to.eq(caller.address)
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should reject group cancellation w/ invalid expiry', async () => {
+      const now = await time.latest()
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address, expiry: now },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidExpiryError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject group cancellation w/ invalid expiry (zero)', async () => {
+      const now = await time.latest()
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address, expiry: 0 },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidExpiryError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should verify group cancellation w/ domain', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: market.address },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      const result = await verifier.connect(market).callStatic.verifyOperatorUpdate(operatorUpdate, signature)
+      await expect(verifier.connect(market).verifyOperatorUpdate(operatorUpdate, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(result).to.eq(caller.address)
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should reject group cancellation w/ invalid domain', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: market.address },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidDomainError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject group cancellation w/ invalid domain (zero)', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidDomainError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject group cancellation w/ invalid signature (too small)', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address },
+      }
+      const signature =
+        '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidSignatureError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject group cancellation w/ invalid signature (too large)', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address },
+      }
+      const signature =
+        '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123'
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidSignatureError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject group cancellation w/ invalid nonce', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address, nonce: 17 },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      await verifier.connect(caller).cancelNonce(17)
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidNonceError',
+      )
+
+      expect(await verifier.nonces(caller.address, 17)).to.eq(true)
+    })
+
+    it('should reject group cancellation w/ invalid nonce', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address, group: 17 },
+      }
+      const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)
+
+      await verifier.connect(caller).cancelGroup(17)
+
+      await expect(verifier.connect(caller).verifyOperatorUpdate(operatorUpdate, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidGroupError',
+      )
 
       expect(await verifier.nonces(caller.address, 0)).to.eq(false)
     })

--- a/packages/perennial-verifier/test/unit/Verifier/Verifier.ts
+++ b/packages/perennial-verifier/test/unit/Verifier/Verifier.ts
@@ -769,7 +769,7 @@ describe('Verifier', () => {
       const operatorUpdate = {
         ...DEFAULT_OPERATOR_UPDATE,
         operator: owner.address,
-        approval: true,
+        approved: true,
         common: { ...DEFAULT_OPERATOR_UPDATE.common, account: caller.address, domain: caller.address },
       }
       const signature = await signOperatorUpdate(caller, verifier, operatorUpdate)

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.24;
 
+import "@equilibria/perennial-v2-verifier/contracts/interfaces/IVerifier.sol";
 import "@equilibria/root/attribute/Factory.sol";
 import "./interfaces/IOracleProvider.sol";
 import "./interfaces/IMarketFactory.sol";
@@ -10,6 +11,9 @@ import "./interfaces/IMarketFactory.sol";
 contract MarketFactory is IMarketFactory, Factory {
     /// @dev The oracle factory
     IFactory public immutable oracleFactory;
+
+    /// @dev The verifier contract
+    IVerifier public immutable verifier;
 
     /// @dev The global protocol parameters
     ProtocolParameterStorage private _parameter;
@@ -26,9 +30,11 @@ contract MarketFactory is IMarketFactory, Factory {
 
     /// @notice Constructs the contract
     /// @param oracleFactory_ The oracle factory
+    /// @param verifier_ The verifier contract
     /// @param implementation_ The initial market implementation contract
-    constructor(IFactory oracleFactory_, address implementation_) Factory(implementation_) {
+    constructor(IFactory oracleFactory_, IVerifier verifier_, address implementation_) Factory(implementation_) {
         oracleFactory = oracleFactory_;
+        verifier = verifier_;
     }
 
     /// @notice Initializes the contract state
@@ -56,8 +62,26 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @param operator The operator to update
     /// @param newEnabled The new status of the operator
     function updateOperator(address operator, bool newEnabled) external {
-        operators[msg.sender][operator] = newEnabled;
-        emit OperatorUpdated(msg.sender, operator, newEnabled);
+        _updateOperator(msg.sender, operator, newEnabled);
+    }
+
+    /// @notice Updates the status of an operator for the signer verified via a signed message
+    /// @param operatorUpdate The operator update message to process
+    /// @param signature The signature of the operator update message
+    function updateOperatorWithSignature(OperatorUpdate calldata operatorUpdate, bytes calldata signature) external {
+        address signer = verifier.verifyOperatorUpdate(operatorUpdate, signature);
+        if (signer != operatorUpdate.common.account) revert MarketFactoryInvalidSignerError();
+
+        _updateOperator(operatorUpdate.common.account, operatorUpdate.operator, operatorUpdate.approved);
+    }
+
+    /// @notice Updates the status of an operator for the account
+    /// @param account The account to update the operator for
+    /// @param operator The operator to update
+    /// @param newEnabled The new status of the operator
+    function _updateOperator(address account, address operator, bool newEnabled) private {
+        operators[account][operator] = newEnabled;
+        emit OperatorUpdated(account, operator, newEnabled);
     }
 
     /// @notice Updates the referral fee for a referrer

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -17,6 +17,8 @@ interface IMarketFactory is IFactory {
     error FactoryInvalidOracleError();
     // sig: 0x213e2260
     error FactoryAlreadyRegisteredError();
+    // sig: 0x6928a80f
+    error MarketFactoryInvalidSignerError();
 
     // sig: 0x4dc1bc59
     error ProtocolParameterStorageInvalidError();

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "@equilibria/root/attribute/interfaces/IFactory.sol";
+import "@equilibria/perennial-v2-verifier/contracts/types/OperatorUpdate.sol";
 import "../types/ProtocolParameter.sol";
 import "./IMarket.sol";
 
@@ -33,6 +34,7 @@ interface IMarketFactory is IFactory {
     function initialize() external;
     function updateParameter(ProtocolParameter memory newParameter) external;
     function updateOperator(address operator, bool newEnabled) external;
+    function updateOperatorWithSignature(OperatorUpdate calldata operatorUpdate, bytes calldata signature) external;
     function updateSigner(address signer, bool newEnabled) external;
     function updateReferralFee(address referrer, UFixed6 newReferralFee) external;
     function create(IMarket.MarketDefinition calldata definition) external returns (IMarket);

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -126,7 +126,11 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
     owner,
   ).deploy(verifierProxy.address)
 
-  const factoryImpl = await new MarketFactory__factory(owner).deploy(oracleFactory.address, marketImpl.address)
+  const factoryImpl = await new MarketFactory__factory(owner).deploy(
+    oracleFactory.address,
+    verifierImpl.address,
+    marketImpl.address,
+  )
 
   const factoryProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
     factoryImpl.address,

--- a/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { constants } from 'ethers'
+import { signOperatorUpdate } from '../../../../perennial-verifier/test/helpers/erc712'
 
 const { ethers } = HRE
 
@@ -71,7 +72,11 @@ describe('MarketFactory', () => {
       },
       owner,
     ).deploy(verifier.address)
-    factory = await new MarketFactory__factory(owner).deploy(oracleFactory.address, marketImpl.address)
+    factory = await new MarketFactory__factory(owner).deploy(
+      oracleFactory.address,
+      verifier.address,
+      marketImpl.address,
+    )
     await factory.initialize()
   })
 
@@ -256,6 +261,70 @@ describe('MarketFactory', () => {
         .withArgs(user.address, owner.address, false)
 
       expect(await factory.operators(user.address, owner.address)).to.equal(false)
+    })
+  })
+
+  describe('#updateOperatorWithSignature', async () => {
+    const DEFAULT_OPERATOR_UPDATE = {
+      operator: constants.AddressZero,
+      approved: false,
+      common: {
+        account: constants.AddressZero,
+        domain: constants.AddressZero,
+        nonce: 0,
+        group: 0,
+        expiry: constants.MaxUint256,
+      },
+    }
+
+    it('updates the operator status', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        operator: owner.address,
+        approved: true,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: user.address, domain: factory.address },
+      }
+      const signature = await signOperatorUpdate(user, verifier, operatorUpdate)
+
+      verifier.verifyOperatorUpdate.returns(user.address)
+
+      await expect(factory.connect(owner).updateOperatorWithSignature(operatorUpdate, signature))
+        .to.emit(factory, 'OperatorUpdated')
+        .withArgs(user.address, owner.address, true)
+
+      expect(await factory.operators(user.address, owner.address)).to.equal(true)
+
+      const operatorUpdate2 = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        operator: owner.address,
+        approval: false,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: user.address, domain: factory.address, nonce: 1 },
+      }
+      const signature2 = await signOperatorUpdate(user, verifier, operatorUpdate2)
+
+      verifier.verifyOperatorUpdate.returns(user.address)
+
+      await expect(factory.connect(owner).updateOperatorWithSignature(operatorUpdate2, signature2))
+        .to.emit(factory, 'OperatorUpdated')
+        .withArgs(user.address, owner.address, false)
+
+      expect(await factory.operators(user.address, owner.address)).to.equal(false)
+    })
+
+    it('reverts if signer does not match', async () => {
+      const operatorUpdate = {
+        ...DEFAULT_OPERATOR_UPDATE,
+        operator: owner.address,
+        approved: true,
+        common: { ...DEFAULT_OPERATOR_UPDATE.common, account: user.address, domain: factory.address },
+      }
+      const signature = await signOperatorUpdate(user, verifier, operatorUpdate)
+
+      verifier.verifyOperatorUpdate.returns(owner.address)
+
+      await expect(
+        factory.connect(owner).updateOperatorWithSignature(operatorUpdate, signature),
+      ).to.revertedWithCustomError(factory, 'MarketFactoryInvalidSignerError')
     })
   })
 })


### PR DESCRIPTION
Adds a second version of `MarketFactory.updateOperator()` that takes a signed message from the account instead of assuming the sender is the account.