### PR TITLE
Add delegated signing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
       - v2.1
       - v2.2
       - v2.3
+  workflow_dispatch:
 
 env:
   CI: true

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -471,8 +471,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         updateContext.guaranteeLocal = _guarantees[account][context.local.currentId].read();
 
         // load external actors
-        updateContext.operator = IMarketFactory(address(factory())).operators(account, msg.sender);
-        updateContext.signer = signer;
+        updateContext.operator = account == msg.sender || IMarketFactory(address(factory())).operators(account, msg.sender);
+        updateContext.signer = account == signer || IMarketFactory(address(factory())).signers(account, signer);
         updateContext.liquidator = liquidators[account][context.local.currentId];
         updateContext.referrer = referrers[account][context.local.currentId];
         updateContext.referralFee = IMarketFactory(address(factory())).referralFee(referrer);
@@ -546,7 +546,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         if (!newOrder.isEmpty()) oracle.request(IMarket(this), account);
 
         // after
-        InvariantLib.validate(context, updateContext,msg.sender,  account, newOrder);
+        InvariantLib.validate(context, updateContext, newOrder);
 
         // store
         _storeUpdateContext(context, updateContext, account);

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -24,6 +24,9 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @dev The referreral fee level for each referrer
     mapping(address => UFixed6) public referralFee;
 
+    /// @dev Mapping of allowed signers for each account
+    mapping(address => mapping(address => bool)) public signers;
+
     /// @notice Constructs the contract
     /// @param oracleFactory_ The oracle factory
     /// @param implementation_ The initial market implementation contract
@@ -58,6 +61,14 @@ contract MarketFactory is IMarketFactory, Factory {
     function updateOperator(address operator, bool newEnabled) external {
         operators[msg.sender][operator] = newEnabled;
         emit OperatorUpdated(msg.sender, operator, newEnabled);
+    }
+
+    /// @notice Updates the status of a signer for the caller
+    /// @param signer The signer to update
+    /// @param newEnabled The new status of the opersignerator
+    function updateSigner(address signer, bool newEnabled) external {
+        signers[msg.sender][signer] = newEnabled;
+        emit SignerUpdated(msg.sender, signer, newEnabled);
     }
 
     /// @notice Updates the referral fee for a referrer

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -45,7 +45,7 @@ interface IMarket is IInstance {
 
     struct UpdateContext {
         bool operator;
-        address signer;
+        bool signer;
         address liquidator;
         address referrer;
         UFixed6 referralFee;

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -8,6 +8,7 @@ import "./IMarket.sol";
 interface IMarketFactory is IFactory {
     event ParameterUpdated(ProtocolParameter newParameter);
     event OperatorUpdated(address indexed account, address indexed operator, bool newEnabled);
+    event SignerUpdated(address indexed account, address indexed signer, bool newEnabled);
     event ReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
     event MarketCreated(IMarket indexed market, IMarket.MarketDefinition definition);
 
@@ -24,11 +25,13 @@ interface IMarketFactory is IFactory {
     function oracleFactory() external view returns (IFactory);
     function parameter() external view returns (ProtocolParameter memory);
     function operators(address account, address operator) external view returns (bool);
+    function signers(address signer, address operator) external view returns (bool);
     function referralFee(address referrer) external view returns (UFixed6);
     function markets(IOracleProvider oracle) external view returns (IMarket);
     function initialize() external;
     function updateParameter(ProtocolParameter memory newParameter) external;
     function updateOperator(address operator, bool newEnabled) external;
+    function updateSigner(address signer, bool newEnabled) external;
     function updateReferralFee(address referrer, UFixed6 newReferralFee) external;
     function create(IMarket.MarketDefinition calldata definition) external returns (IMarket);
 }

--- a/packages/perennial/contracts/libs/InvariantLib.sol
+++ b/packages/perennial/contracts/libs/InvariantLib.sol
@@ -17,14 +17,10 @@ library InvariantLib {
     /// @notice Verifies the invariant of the market
     /// @param context The context to use
     /// @param updateContext The update context to use
-    /// @param sender The sender of the transaction
-    /// @param account The account to verify the invariant for
     /// @param newOrder The order to verify the invariant for
     function validate(
         IMarket.Context memory context,
         IMarket.UpdateContext memory updateContext,
-        address sender,
-        address account,
         Order memory newOrder
     ) external pure {
         if (context.pendingLocal.neg().gt(context.latestPositionLocal.magnitude())) revert IMarket.MarketOverCloseError();
@@ -65,8 +61,7 @@ library InvariantLib {
         if (newOrder.protected()) return; // The following invariants do not apply to protected position updates (liquidations)
 
         if (
-            sender != account &&                                                // sender is operating on own account
-            updateContext.signer != account &&                                  // sender is relaying the account's signed intention
+            !updateContext.signer &&                                            // sender is relaying the account's signed intention
             !updateContext.operator &&                                          // sender is operator approved for account
             !(newOrder.isEmpty() && newOrder.collateral.gte(Fixed6Lib.ZERO))    // sender is depositing zero or more into account, without position change
         ) revert IMarket.MarketOperatorNotAllowedError();

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -16461,6 +16461,237 @@ describe('Market', () => {
         })
       })
 
+      context('signer', async () => {
+        beforeEach(async () => {
+          dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+        })
+
+        it('opens the position when signer', async () => {
+          factory.parameter.returns({
+            maxPendingIds: 5,
+            protocolFee: parse6decimal('0.50'),
+            maxFee: parse6decimal('0.01'),
+            maxFeeAbsolute: parse6decimal('1000'),
+            maxCut: parse6decimal('0.50'),
+            maxRate: parse6decimal('10.00'),
+            minMaintenance: parse6decimal('0.01'),
+            minEfficiency: parse6decimal('0.1'),
+            referralFee: parse6decimal('0.20'),
+          })
+
+          const marketParameter = { ...(await market.parameter()) }
+          marketParameter.settlementFee = parse6decimal('0.50')
+          marketParameter.takerFee = parse6decimal('0.01')
+          await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
+
+          const riskParameter = { ...(await market.riskParameter()) }
+          await market.updateRiskParameter({
+            ...riskParameter,
+            takerFee: {
+              ...riskParameter.takerFee,
+              linearFee: parse6decimal('0.001'),
+              proportionalFee: parse6decimal('0.002'),
+              adiabaticFee: parse6decimal('0.004'),
+            },
+          })
+
+          const EXPECTED_PNL = parse6decimal('10') // position * (125-123)
+          const TAKER_FEE = parse6decimal('6.15') // position * (0.01) * price
+          const SETTLEMENT_FEE = parse6decimal('0.50')
+
+          const intent = {
+            amount: POSITION.div(2),
+            price: parse6decimal('125'),
+            common: {
+              account: user.address,
+              domain: market.address,
+              nonce: 0,
+              group: 0,
+              expiry: 0,
+            },
+          }
+
+          await market
+            .connect(userB)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+          await market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+          await market
+            .connect(userC)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+          verifier.verifyIntent.returns(liquidator.address)
+          factory.signers.whenCalledWith(user.address, liquidator.address).returns(true)
+
+          await expect(
+            market
+              .connect(userC)
+              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                intent,
+                DEFAULT_SIGNATURE,
+                liquidator.address,
+              ),
+          )
+            .to.emit(market, 'OrderCreated')
+            .withArgs(user.address, {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+            })
+            .to.emit(market, 'OrderCreated')
+            .withArgs(userC.address, {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+            })
+
+          oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
+
+          oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
+          oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
+          oracle.request.whenCalledWith(user.address).returns()
+
+          await settle(market, user)
+          await settle(market, userB)
+          await settle(market, userC)
+
+          expectLocalEq(await market.locals(user.address), {
+            ...DEFAULT_LOCAL,
+            currentId: 2,
+            latestId: 1,
+            collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(TAKER_FEE).sub(EXPECTED_PNL),
+          })
+          expectPositionEq(await market.positions(user.address), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            long: POSITION.div(2),
+          })
+          expectOrderEq(await market.pendingOrders(user.address, 2), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_4.timestamp,
+          })
+          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
+            ...DEFAULT_CHECKPOINT,
+          })
+          expectLocalEq(await market.locals(userB.address), {
+            ...DEFAULT_LOCAL,
+            currentId: 2,
+            latestId: 1,
+            collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
+          })
+          expectPositionEq(await market.positions(userB.address), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            maker: POSITION,
+          })
+          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_4.timestamp,
+          })
+          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
+            ...DEFAULT_CHECKPOINT,
+          })
+          expectLocalEq(await market.locals(userC.address), {
+            ...DEFAULT_LOCAL,
+            currentId: 2,
+            latestId: 1,
+            collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
+              .sub(TAKER_FEE)
+              .add(EXPECTED_PNL)
+              .sub(SETTLEMENT_FEE.div(2)),
+          })
+          expectPositionEq(await market.positions(userC.address), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            short: POSITION.div(2),
+          })
+          expectOrderEq(await market.pendingOrders(userC.address, 2), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_4.timestamp,
+          })
+          expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
+            ...DEFAULT_CHECKPOINT,
+          })
+          expectLocalEq(await market.locals(liquidator.address), {
+            ...DEFAULT_LOCAL,
+            claimable: TAKER_FEE.mul(2).div(10).mul(2),
+          })
+          const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+          expectGlobalEq(await market.global(), {
+            currentId: 2,
+            latestId: 1,
+            protocolFee: totalFee.div(2), // loss of precision
+            oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
+            riskFee: totalFee.div(2).div(10), // loss of precision
+            donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+            exposure: 0,
+          })
+          expectPositionEq(await market.position(), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            maker: POSITION,
+            long: POSITION.div(2),
+            short: POSITION.div(2),
+          })
+          expectOrderEq(await market.pendingOrder(2), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_4.timestamp,
+          })
+          expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
+            ...DEFAULT_VERSION,
+            makerValue: {
+              _value: EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF.div(10),
+            },
+            longValue: { _value: EXPECTED_INTEREST_10_123_EFF.div(2).div(5).mul(-1) },
+            shortValue: { _value: EXPECTED_INTEREST_10_123_EFF.div(2).div(5).mul(-1) },
+            price: PRICE,
+            liquidationFee: { _value: -riskParameter.liquidationFee },
+          })
+        })
+
+        it('reverts when not operator', async () => {
+          const intent = {
+            amount: POSITION.div(2),
+            price: parse6decimal('125'),
+            common: {
+              account: user.address,
+              domain: market.address,
+              nonce: 0,
+              group: 0,
+              expiry: 0,
+            },
+          }
+
+          await market
+            .connect(userB)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+          await market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+          await market
+            .connect(userC)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+          verifier.verifyIntent.returns(liquidator.address)
+          factory.signers.whenCalledWith(user.address, liquidator.address).returns(false)
+
+          await expect(
+            market
+              .connect(operator)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
+          ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
+        })
+      })
+
       context('magic values', async () => {
         beforeEach(async () => {
           dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)

--- a/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
@@ -258,4 +258,20 @@ describe('MarketFactory', () => {
       expect(await factory.operators(user.address, owner.address)).to.equal(false)
     })
   })
+
+  describe('#updateSigner', async () => {
+    it('updates the signer status', async () => {
+      await expect(factory.connect(user).updateSigner(owner.address, true))
+        .to.emit(factory, 'SignerUpdated')
+        .withArgs(user.address, owner.address, true)
+
+      expect(await factory.signers(user.address, owner.address)).to.equal(true)
+
+      await expect(factory.connect(user).updateSigner(owner.address, false))
+        .to.emit(factory, 'SignerUpdated')
+        .withArgs(user.address, owner.address, false)
+
+      expect(await factory.signers(user.address, owner.address)).to.equal(false)
+    })
+  })
 })


### PR DESCRIPTION
Adds `signer` role in parallel to `operator` that a user can assign to their account. Like operators, there can be many signers on one account, and signers can be revoked at any time.

A signer is able to sign messages on behalf of the user.