### PR TITLE
Add solver fee

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -38,6 +38,7 @@ export interface Guarantee {
   takerPos: BigNumberish
   takerNeg: BigNumberish
   notional: BigNumberish
+  referral: BigNumberish
 }
 
 export interface Position {
@@ -111,6 +112,7 @@ export function expectGuaranteeEq(a: Guarantee, b: Guarantee): void {
   expect(a.takerPos).to.equal(b.takerPos, 'Order:TakerPos')
   expect(a.takerNeg).to.equal(b.takerNeg, 'Order:TakerNeg')
   expect(a.notional).to.equal(b.notional, 'Order:Notional')
+  expect(a.referral).to.equal(b.referral, 'Order:Referral')
 }
 
 export function expectPositionEq(a: Position, b: Position): void {
@@ -231,6 +233,7 @@ export const DEFAULT_GUARANTEE: Guarantee = {
   takerPos: 0,
   takerNeg: 0,
   notional: 0,
+  referral: 0,
 }
 
 export const DEFAULT_VERSION: Version = {

--- a/packages/perennial-verifier/contracts/types/Fill.sol
+++ b/packages/perennial-verifier/contracts/types/Fill.sol
@@ -18,7 +18,7 @@ using FillLib for Fill global;
 /// @title FillLib
 /// @notice Library for Fill logic and data.
 library FillLib {
-    bytes32 constant public STRUCT_HASH = keccak256("Fill(Intent intent,Common common)Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)Intent(int256 amount,int256 price,Common common)");
+    bytes32 constant public STRUCT_HASH = keccak256("Fill(Intent intent,Common common)Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)Intent(int256 amount,int256 price,uint256 fee,address originator,address solver,Common common)");
 
     function hash(Fill memory self) internal pure returns (bytes32) {
         return keccak256(abi.encode(STRUCT_HASH, IntentLib.hash(self.intent), CommonLib.hash(self.common)));

--- a/packages/perennial-verifier/contracts/types/Intent.sol
+++ b/packages/perennial-verifier/contracts/types/Intent.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
+import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
 import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
 import { Common, CommonLib } from "./Common.sol";
 
@@ -15,6 +15,15 @@ struct Intent {
     /// @dev The price to execute the order at
     Fixed6 price;
 
+    /// @dev The solver fee, a percentage of the substractive interface fee
+    UFixed6 fee;
+
+    /// @dev The referral address of the originator of the order (ex. the interface)
+    address originator;
+
+    /// @dev The referral address of the solver of the order (ex. the router)
+    address solver;
+
     /// @dev The common information for the intent
     Common common;
 }
@@ -23,9 +32,9 @@ using IntentLib for Intent global;
 /// @title IntentLib
 /// @notice Library for Intent logic and data.
 library IntentLib {
-    bytes32 constant public STRUCT_HASH = keccak256("Intent(int256 amount,int256 price,Common common)Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)");
+    bytes32 constant public STRUCT_HASH = keccak256("Intent(int256 amount,int256 price,uint256 fee,address originator,address solver,Common common)Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)");
 
     function hash(Intent memory self) internal pure returns (bytes32) {
-        return keccak256(abi.encode(STRUCT_HASH, self.amount, self.price, CommonLib.hash(self.common)));
+        return keccak256(abi.encode(STRUCT_HASH, self.amount, self.price, self.fee, self.originator, self.solver, CommonLib.hash(self.common)));
     }
 }

--- a/packages/perennial-verifier/test/helpers/erc712.ts
+++ b/packages/perennial-verifier/test/helpers/erc712.ts
@@ -42,6 +42,9 @@ export async function signIntent(signer: SignerWithAddress, verifier: Verifier, 
     Intent: [
       { name: 'amount', type: 'int256' },
       { name: 'price', type: 'int256' },
+      { name: 'fee', type: 'uint256' },
+      { name: 'originator', type: 'address' },
+      { name: 'solver', type: 'address' },
       { name: 'common', type: 'Common' },
     ],
   }
@@ -61,6 +64,9 @@ export async function signFill(signer: SignerWithAddress, verifier: Verifier, fi
     Intent: [
       { name: 'amount', type: 'int256' },
       { name: 'price', type: 'int256' },
+      { name: 'fee', type: 'uint256' },
+      { name: 'originator', type: 'address' },
+      { name: 'solver', type: 'address' },
       { name: 'common', type: 'Common' },
     ],
     Fill: [

--- a/packages/perennial-verifier/test/unit/Verifier/Verifier.ts
+++ b/packages/perennial-verifier/test/unit/Verifier/Verifier.ts
@@ -184,6 +184,9 @@ describe('Verifier', () => {
     const DEFAULT_INTENT = {
       amount: parse6decimal('10'),
       price: parse6decimal('123'),
+      fee: parse6decimal('0.5'),
+      originator: constants.AddressZero,
+      solver: constants.AddressZero,
       common: {
         account: constants.AddressZero,
         domain: constants.AddressZero,
@@ -373,6 +376,9 @@ describe('Verifier', () => {
       intent: {
         amount: parse6decimal('10'),
         price: parse6decimal('123'),
+        fee: parse6decimal('0.5'),
+        originator: constants.AddressZero,
+        solver: constants.AddressZero,
         common: {
           account: constants.AddressZero,
           domain: constants.AddressZero,

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -124,9 +124,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     ///      - The sender is charged the settlement fee
     /// @param intent The intent that is being filled
     /// @param signature The signature of the intent that is being filled
-    /// @param orderReferrer The referrer of the order // TODO: put these in the message
-    /// @param guaranteeReferrer The referrer of the guarantee
-    function update(Intent calldata intent, bytes memory signature, address orderReferrer, address guaranteeReferrer) external {
+    function update(Intent calldata intent, bytes memory signature) external {
         address signer = verifier.verifyIntent(intent, signature);
 
         _updateIntent(
@@ -135,9 +133,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             intent.amount.mul(Fixed6Lib.NEG_ONE),
             intent.price,
             true,
-            orderReferrer,
-            guaranteeReferrer,
-            UFixed6Lib.ZERO // TODO: referral fee in message
+            intent.originator,
+            intent.solver,
+            intent.fee
         ); // sender
         _updateIntent(
             intent.common.account,
@@ -145,9 +143,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             intent.amount,
             intent.price,
             false,
-            orderReferrer,
-            guaranteeReferrer,
-            UFixed6Lib.ZERO // TODO: referral fee in message
+            intent.originator,
+            intent.solver,
+            intent.fee
         ); // signer
     }
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -817,7 +817,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         _credit(liquidators[context.account][newOrderId], accumulationResult.liquidationFee);
         _credit(orderReferrers[context.account][newOrderId], accumulationResult.subtractiveFee);
-        _credit(guaranteeReferrers[context.account][newOrderId], UFixed6Lib.ZERO); // TODO: add solver fee
+        _credit(guaranteeReferrers[context.account][newOrderId], accumulationResult.solverFee);
 
         emit AccountPositionProcessed(context.account, newOrderId, newOrder, accumulationResult);
     }

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -503,15 +503,17 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         updateContext.guaranteeGlobal = _guarantee[context.global.currentId].read();
         updateContext.guaranteeLocal = _guarantees[context.account][context.local.currentId].read();
 
-        // load external actors
+        // load order metadata
+        updateContext.liquidator = liquidators[context.account][context.local.currentId];
+        updateContext.orderReferrer = orderReferrers[context.account][context.local.currentId];
+        updateContext.guaranteeReferrer = guaranteeReferrers[context.account][context.local.currentId];
+
+        // load factory metadata
         updateContext.operator = context.account == msg.sender
             || IMarketFactory(address(factory())).extensions(msg.sender)
             || IMarketFactory(address(factory())).operators(context.account, msg.sender);
         updateContext.signer = context.account == signer
             || IMarketFactory(address(factory())).signers(context.account, signer);
-        updateContext.liquidator = liquidators[context.account][context.local.currentId];
-        updateContext.orderReferrer = orderReferrers[context.account][context.local.currentId];
-        updateContext.guaranteeReferrer = guaranteeReferrers[context.account][context.local.currentId];
         updateContext.orderReferralFee = IMarketFactory(address(factory())).referralFees(orderReferrer);
         updateContext.guaranteeReferralFee = guaranteeReferralFee;
     }
@@ -551,6 +553,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         if (context.currentTimestamp > updateContext.orderLocal.timestamp) {
             updateContext.orderLocal.next(context.currentTimestamp);
             updateContext.guaranteeLocal.next();
+            updateContext.liquidator = address(0);
+            updateContext.orderReferrer = address(0);
+            updateContext.guaranteeReferrer = address(0);
             context.local.currentId++;
         }
         if (context.currentTimestamp > updateContext.orderGlobal.timestamp) {

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -70,7 +70,7 @@ contract MarketFactory is IMarketFactory, Factory {
         address signer,
         address orderReferrer,
         address guaranteeReferrer
-    ) external returns (bool isOperator, bool isSigner, UFixed6 orderReferralFee, UFixed6 guaranteeReferralFee) {
+    ) external view returns (bool isOperator, bool isSigner, UFixed6 orderReferralFee, UFixed6 guaranteeReferralFee) {
         return (
             operators[account][operator],
             signers[account][signer],
@@ -99,7 +99,7 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @param referrer The referrer to update
     /// @param newReferralFee The new referral fee
     function updateOrderReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
-        orderReferralFee[referrer] = newReferralFee;
+        orderReferralFees[referrer] = newReferralFee;
         emit OrderReferralFeeUpdated(referrer, newReferralFee);
     }
 
@@ -107,7 +107,7 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @param referrer The referrer to update
     /// @param newReferralFee The new referral fee
     function updateGuaranteeReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
-        guaranteeReferralFee[referrer] = newReferralFee;
+        guaranteeReferralFees[referrer] = newReferralFee;
         emit GuaranteeReferralFeeUpdated(referrer, newReferralFee);
     }
 

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -22,10 +22,7 @@ contract MarketFactory is IMarketFactory, Factory {
     mapping(IOracleProvider => mapping(address => IMarket)) private _markets;
 
     /// @dev The referreral fee level for each referrer for orders
-    mapping(address => UFixed6) public orderReferralFees;
-
-    /// @dev The referreral fee level for each referrer for guarantees
-    mapping(address => UFixed6) public guaranteeReferralFees;
+    mapping(address => UFixed6) public referralFees;
 
     /// @dev Mapping of allowed signers for each account
     mapping(address => mapping(address => bool)) public signers;
@@ -58,27 +55,6 @@ contract MarketFactory is IMarketFactory, Factory {
         emit ParameterUpdated(newParameter);
     }
 
-    /// @notice Returns a snapshot of the parameter settings for a market update
-    /// @param account The account being operated on
-    /// @param operator The operator of the update
-    /// @param signer The signer of the update
-    /// @param orderReferrer The referrer of the order of the update
-    /// @param guaranteeReferrer The referrer of the guarantee of the update
-    function status(
-        address account,
-        address operator,
-        address signer,
-        address orderReferrer,
-        address guaranteeReferrer
-    ) external view returns (bool isOperator, bool isSigner, UFixed6 orderReferralFee, UFixed6 guaranteeReferralFee) {
-        return (
-            operators[account][operator],
-            signers[account][signer],
-            orderReferralFees[orderReferrer],
-            guaranteeReferralFees[guaranteeReferrer]
-        );
-    }
-
     /// @notice Updates the status of an operator for the caller
     /// @param operator The operator to update
     /// @param newEnabled The new status of the operator
@@ -98,17 +74,9 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @notice Updates the referral fee for orders
     /// @param referrer The referrer to update
     /// @param newReferralFee The new referral fee
-    function updateOrderReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
-        orderReferralFees[referrer] = newReferralFee;
-        emit OrderReferralFeeUpdated(referrer, newReferralFee);
-    }
-
-    /// @notice Updates the referral fee for guarantees
-    /// @param referrer The referrer to update
-    /// @param newReferralFee The new referral fee
-    function updateGuaranteeReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
-        guaranteeReferralFees[referrer] = newReferralFee;
-        emit GuaranteeReferralFeeUpdated(referrer, newReferralFee);
+    function updateReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
+        referralFees[referrer] = newReferralFee;
+        emit ReferralFeeUpdated(referrer, newReferralFee);
     }
 
     /// @notice Creates a new market market with the given definition

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -21,8 +21,11 @@ contract MarketFactory is IMarketFactory, Factory {
     ///      Note: address(0) is used in place of the deprecated payoff provider field
     mapping(IOracleProvider => mapping(address => IMarket)) private _markets;
 
-    /// @dev The referreral fee level for each referrer
-    mapping(address => UFixed6) public referralFee;
+    /// @dev The referreral fee level for each referrer for orders
+    mapping(address => UFixed6) public orderReferralFee;
+
+    /// @dev The referreral fee level for each referrer for guarantees
+    mapping(address => UFixed6) public guaranteeReferralFee;
 
     /// @dev Mapping of allowed signers for each account
     mapping(address => mapping(address => bool)) public signers;

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -22,10 +22,10 @@ contract MarketFactory is IMarketFactory, Factory {
     mapping(IOracleProvider => mapping(address => IMarket)) private _markets;
 
     /// @dev The referreral fee level for each referrer for orders
-    mapping(address => UFixed6) public orderReferralFee;
+    mapping(address => UFixed6) public orderReferralFees;
 
     /// @dev The referreral fee level for each referrer for guarantees
-    mapping(address => UFixed6) public guaranteeReferralFee;
+    mapping(address => UFixed6) public guaranteeReferralFees;
 
     /// @dev Mapping of allowed signers for each account
     mapping(address => mapping(address => bool)) public signers;
@@ -58,6 +58,27 @@ contract MarketFactory is IMarketFactory, Factory {
         emit ParameterUpdated(newParameter);
     }
 
+    /// @notice Returns a snapshot of the parameter settings for a market update
+    /// @param account The account being operated on
+    /// @param operator The operator of the update
+    /// @param signer The signer of the update
+    /// @param orderReferrer The referrer of the order of the update
+    /// @param guaranteeReferrer The referrer of the guarantee of the update
+    function status(
+        address account,
+        address operator,
+        address signer,
+        address orderReferrer,
+        address guaranteeReferrer
+    ) external returns (bool isOperator, bool isSigner, UFixed6 orderReferralFee, UFixed6 guaranteeReferralFee) {
+        return (
+            operators[account][operator],
+            signers[account][signer],
+            orderReferralFees[orderReferrer],
+            guaranteeReferralFees[guaranteeReferrer]
+        );
+    }
+
     /// @notice Updates the status of an operator for the caller
     /// @param operator The operator to update
     /// @param newEnabled The new status of the operator
@@ -74,12 +95,20 @@ contract MarketFactory is IMarketFactory, Factory {
         emit SignerUpdated(msg.sender, signer, newEnabled);
     }
 
-    /// @notice Updates the referral fee for a referrer
+    /// @notice Updates the referral fee for orders
     /// @param referrer The referrer to update
     /// @param newReferralFee The new referral fee
-    function updateReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
-        referralFee[referrer] = newReferralFee;
-        emit ReferralFeeUpdated(referrer, newReferralFee);
+    function updateOrderReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
+        orderReferralFee[referrer] = newReferralFee;
+        emit OrderReferralFeeUpdated(referrer, newReferralFee);
+    }
+
+    /// @notice Updates the referral fee for guarantees
+    /// @param referrer The referrer to update
+    /// @param newReferralFee The new referral fee
+    function updateGuaranteeReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
+        guaranteeReferralFee[referrer] = newReferralFee;
+        emit GuaranteeReferralFeeUpdated(referrer, newReferralFee);
     }
 
     /// @notice Creates a new market market with the given definition

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -142,9 +142,10 @@ interface IMarket is IInstance {
     function global() external view returns (Global memory);
     function checkpoints(address account, uint256 id) external view returns (Checkpoint memory);
     function liquidators(address account, uint256 id) external view returns (address);
-    function referrers(address account, uint256 id) external view returns (address);
+    function orderReferrers(address account, uint256 id) external view returns (address);
+    function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
-    function update(Intent calldata intent, bytes memory signature, address referrer) external;
+    function update(Intent calldata intent, bytes memory signature, address orderReferrer, address guaranteeReferrer) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer) external;
     function parameter() external view returns (MarketParameter memory);

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -145,7 +145,7 @@ interface IMarket is IInstance {
     function orderReferrers(address account, uint256 id) external view returns (address);
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
-    function update(Intent calldata intent, bytes memory signature, address orderReferrer, address guaranteeReferrer) external;
+    function update(Intent calldata intent, bytes memory signature) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer) external;
     function parameter() external view returns (MarketParameter memory);

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -48,8 +48,10 @@ interface IMarket is IInstance {
         bool operator;
         bool signer;
         address liquidator;
-        address referrer;
-        UFixed6 referralFee;
+        address orderReferrer;
+        UFixed6 orderReferralFee;
+        address guaranteeReferrer;
+        UFixed6 guaranteeReferralFee;
         Order orderGlobal;
         Order orderLocal;
         Position currentPositionGlobal;

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -27,12 +27,15 @@ interface IMarketFactory is IFactory {
     function parameter() external view returns (ProtocolParameter memory);
     function operators(address account, address operator) external view returns (bool);
     function signers(address signer, address operator) external view returns (bool);
-    function referralFee(address referrer) external view returns (UFixed6);
+    function orderReferralFees(address referrer) external view returns (UFixed6);
+    function guaranteeReferralFees(address referrer) external view returns (UFixed6);
     function markets(IOracleProvider oracle) external view returns (IMarket);
+    function status(address account, address operator, address signer, address orderReferrer, address guaranteeReferrer) external view returns (bool, bool, UFixed6, UFixed6);
     function initialize() external;
     function updateParameter(ProtocolParameter memory newParameter) external;
     function updateOperator(address operator, bool newEnabled) external;
     function updateSigner(address signer, bool newEnabled) external;
-    function updateReferralFee(address referrer, UFixed6 newReferralFee) external;
+    function updateOrderReferralFee(address referrer, UFixed6 newReferralFee) external;
+    function updateGuaranteeReferralFee(address referrer, UFixed6 newReferralFee) external;
     function create(IMarket.MarketDefinition calldata definition) external returns (IMarket);
 }

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -9,7 +9,8 @@ interface IMarketFactory is IFactory {
     event ParameterUpdated(ProtocolParameter newParameter);
     event OperatorUpdated(address indexed account, address indexed operator, bool newEnabled);
     event SignerUpdated(address indexed account, address indexed signer, bool newEnabled);
-    event ReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
+    event OrderReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
+    event GuaranteeReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
     event MarketCreated(IMarket indexed market, IMarket.MarketDefinition definition);
 
     // sig: 0x0a37dc74

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -9,8 +9,7 @@ interface IMarketFactory is IFactory {
     event ParameterUpdated(ProtocolParameter newParameter);
     event OperatorUpdated(address indexed account, address indexed operator, bool newEnabled);
     event SignerUpdated(address indexed account, address indexed signer, bool newEnabled);
-    event OrderReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
-    event GuaranteeReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
+    event ReferralFeeUpdated(address indexed referrer, UFixed6 newFee);
     event MarketCreated(IMarket indexed market, IMarket.MarketDefinition definition);
 
     // sig: 0x0a37dc74
@@ -27,15 +26,12 @@ interface IMarketFactory is IFactory {
     function parameter() external view returns (ProtocolParameter memory);
     function operators(address account, address operator) external view returns (bool);
     function signers(address signer, address operator) external view returns (bool);
-    function orderReferralFees(address referrer) external view returns (UFixed6);
-    function guaranteeReferralFees(address referrer) external view returns (UFixed6);
+    function referralFees(address referrer) external view returns (UFixed6);
     function markets(IOracleProvider oracle) external view returns (IMarket);
-    function status(address account, address operator, address signer, address orderReferrer, address guaranteeReferrer) external view returns (bool, bool, UFixed6, UFixed6);
     function initialize() external;
     function updateParameter(ProtocolParameter memory newParameter) external;
     function updateOperator(address operator, bool newEnabled) external;
     function updateSigner(address signer, bool newEnabled) external;
-    function updateOrderReferralFee(address referrer, UFixed6 newReferralFee) external;
-    function updateGuaranteeReferralFee(address referrer, UFixed6 newReferralFee) external;
+    function updateReferralFee(address referrer, UFixed6 newReferralFee) external;
     function create(IMarket.MarketDefinition calldata definition) external returns (IMarket);
 }

--- a/packages/perennial/contracts/libs/CheckpointLib.sol
+++ b/packages/perennial/contracts/libs/CheckpointLib.sol
@@ -19,6 +19,7 @@ struct CheckpointAccumulationResult {
     UFixed6 settlementFee;
     UFixed6 liquidationFee;
     UFixed6 subtractiveFee;
+    UFixed6 solverFee;
 }
 
 /// @title CheckpointLib
@@ -43,7 +44,7 @@ library CheckpointLib {
         // accumulate
         result.collateral = _accumulateCollateral(fromPosition, fromVersion, toVersion);
         result.priceOverride = _accumulatePriceOverride(guarantee, toVersion);
-        (result.tradeFee, result.subtractiveFee) = _accumulateFee(order, toVersion);
+        (result.tradeFee, result.subtractiveFee, result.solverFee) = _accumulateFee(order, guarantee, toVersion);
         result.offset = _accumulateOffset(order, guarantee, toVersion);
         result.settlementFee = _accumulateSettlementFee(order, guarantee, toVersion);
         result.liquidationFee = _accumulateLiquidationFee(order, toVersion);
@@ -77,11 +78,13 @@ library CheckpointLib {
 
     /// @notice Accumulate trade fees for the next position
     /// @param order The next order
+    /// @param guarantee The next guarantee
     /// @param toVersion The next version
     function _accumulateFee(
         Order memory order,
+        Guarantee memory guarantee,
         Version memory toVersion
-    ) private pure returns (UFixed6 tradeFee, UFixed6 subtractiveFee) {
+    ) private pure returns (UFixed6 tradeFee, UFixed6 subtractiveFee, UFixed6 solverFee) {
         UFixed6 makerFee = Fixed6Lib.ZERO
             .sub(toVersion.makerFee.accumulated(Accumulator6(Fixed6Lib.ZERO), order.makerTotal()))
             .abs();
@@ -96,8 +99,12 @@ library CheckpointLib {
             UFixed6Lib.ZERO :
             takerFee.muldiv(order.takerReferral, order.takerTotal());
 
+        solverFee = order.takerTotal().isZero() ?
+            UFixed6Lib.ZERO :
+            takerSubtractiveFee.muldiv(guarantee.referral, order.takerTotal());
+
         tradeFee = makerFee.add(takerFee);
-        subtractiveFee = makerSubtractiveFee.add(takerSubtractiveFee);
+        subtractiveFee = makerSubtractiveFee.add(takerSubtractiveFee).sub(solverFee);
     }
 
     /// @notice Accumulate price offset for the next position

--- a/packages/perennial/contracts/libs/CheckpointLib.sol
+++ b/packages/perennial/contracts/libs/CheckpointLib.sol
@@ -101,7 +101,7 @@ library CheckpointLib {
 
         solverFee = order.takerTotal().isZero() ?
             UFixed6Lib.ZERO :
-            takerSubtractiveFee.muldiv(guarantee.referral, order.takerTotal());
+            takerFee.muldiv(guarantee.referral, order.takerTotal());
 
         tradeFee = makerFee.add(takerFee);
         subtractiveFee = makerSubtractiveFee.add(takerSubtractiveFee).sub(solverFee);

--- a/packages/perennial/contracts/test/GuaranteeTester.sol
+++ b/packages/perennial/contracts/test/GuaranteeTester.sol
@@ -8,8 +8,8 @@ abstract contract GuaranteeTester {
 
     function store(Guarantee memory newGuarantee) public virtual;
 
-    function from(Order memory order, Fixed6 price, bool settlementFee) external {
-        Guarantee memory newGuarantee = GuaranteeLib.from(order, price, settlementFee);
+    function from(Order memory order, Fixed6 price, UFixed6 referralFee, bool settlementFee) external {
+        Guarantee memory newGuarantee = GuaranteeLib.from(order, price, referralFee, settlementFee);
         store(newGuarantee);
     }
 }

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -23,7 +23,7 @@ struct Guarantee {
 using GuaranteeLib for Guarantee global;
 struct GuaranteeStorageGlobal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using GuaranteeStorageGlobalLib for GuaranteeStorageGlobal global;
-struct GuaranteeStorageLocal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (1) slots
+struct GuaranteeStorageLocal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using GuaranteeStorageLocalLib for GuaranteeStorageLocal global;
 
 /// @title Guarantee
@@ -62,7 +62,7 @@ library GuaranteeLib {
             (order.longPos.add(order.shortNeg), order.longNeg.add(order.shortPos));
 
         newGuarantee.notional = taker(newGuarantee).mul(priceOverride);
-        newGuarantee.referral = takerTotal(newGuarantee).mul(referralFee);
+        newGuarantee.referral = order.takerReferral.mul(referralFee);
     }
 
     /// @notice Returns the taker delta of the guarantee

--- a/packages/perennial/contracts/types/Order.sol
+++ b/packages/perennial/contracts/types/Order.sol
@@ -40,10 +40,10 @@ struct Order {
     /// @dev The protection status semaphore (local only)
     uint256 protection;
 
-    /// @dev The referral fee
+    /// @dev The referral fee multiplied by the size applicable to the referral
     UFixed6 makerReferral;
 
-    /// @dev The referral fee
+    /// @dev The referral fee multiplied by the size applicable to the referral
     UFixed6 takerReferral;
 }
 using OrderLib for Order global;

--- a/packages/perennial/contracts/types/ProtocolParameter.sol
+++ b/packages/perennial/contracts/types/ProtocolParameter.sol
@@ -26,19 +26,23 @@ struct ProtocolParameter {
     /// @dev The minimum for market efficiency parameters
     UFixed6 minEfficiency;
 
-    /// @dev The default referrer fee
-    UFixed6 referralFee;
+    /// @dev The default referrer fee percentage for orders
+    UFixed6 orderReferralFee;
+
+    /// @dev The default referrer fee percentage for guarantees
+    UFixed6 guaranteeReferralFee;
 }
 struct StoredProtocolParameter {
     /* slot 0 */
-    uint24 protocolFee;        // <= 1677%
-    uint24 maxFee;             // <= 1677%
-    uint48 maxFeeAbsolute;     // <= 281m
-    uint24 maxCut;             // <= 1677%
-    uint32 maxRate;            // <= 214748% (capped at 31 bits to accommodate int32 rates)
-    uint24 minMaintenance;     // <= 1677%
-    uint24 minEfficiency;      // <= 1677%
-    uint24 referralFee;        // <= 1677%
+    uint24 protocolFee;             // <= 1677%
+    uint24 maxFee;                  // <= 1677%
+    uint48 maxFeeAbsolute;          // <= 281m
+    uint24 maxCut;                  // <= 1677%
+    uint32 maxRate;                 // <= 214748% (capped at 31 bits to accommodate int32 rates)
+    uint24 minMaintenance;          // <= 1677%
+    uint24 minEfficiency;           // <= 1677%
+    uint24 orderReferralFee;        // <= 1677%
+    uint24 guaranteeReferralFee;    // <= 1677%
 }
 struct ProtocolParameterStorage { StoredProtocolParameter value; } // SECURITY: must remain at (1) slots
 using ProtocolParameterStorageLib for ProtocolParameterStorage global;
@@ -57,7 +61,8 @@ library ProtocolParameterStorageLib {
             UFixed6.wrap(uint256(value.maxRate)),
             UFixed6.wrap(uint256(value.minMaintenance)),
             UFixed6.wrap(uint256(value.minEfficiency)),
-            UFixed6.wrap(uint256(value.referralFee))
+            UFixed6.wrap(uint256(value.orderReferralFee)),
+            UFixed6.wrap(uint256(value.guaranteeReferralFee))
         );
     }
 
@@ -74,7 +79,8 @@ library ProtocolParameterStorageLib {
         if (newValue.maxRate.gt(UFixed6.wrap(type(uint32).max / 2))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minMaintenance.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minEfficiency.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
-        if (newValue.referralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
+        if (newValue.orderReferralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
+        if (newValue.guaranteeReferralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
 
         self.value = StoredProtocolParameter(
             uint24(UFixed6.unwrap(newValue.protocolFee)),
@@ -84,7 +90,8 @@ library ProtocolParameterStorageLib {
             uint32(UFixed6.unwrap(newValue.maxRate)),
             uint24(UFixed6.unwrap(newValue.minMaintenance)),
             uint24(UFixed6.unwrap(newValue.minEfficiency)),
-            uint24(UFixed6.unwrap(newValue.referralFee))
+            uint24(UFixed6.unwrap(newValue.orderReferralFee)),
+            uint24(UFixed6.unwrap(newValue.guaranteeReferralFee))
         );
     }
 }

--- a/packages/perennial/contracts/types/ProtocolParameter.sol
+++ b/packages/perennial/contracts/types/ProtocolParameter.sol
@@ -27,10 +27,7 @@ struct ProtocolParameter {
     UFixed6 minEfficiency;
 
     /// @dev The default referrer fee percentage for orders
-    UFixed6 orderReferralFee;
-
-    /// @dev The default referrer fee percentage for guarantees
-    UFixed6 guaranteeReferralFee;
+    UFixed6 referralFee;
 }
 struct StoredProtocolParameter {
     /* slot 0 */
@@ -41,8 +38,7 @@ struct StoredProtocolParameter {
     uint32 maxRate;                 // <= 214748% (capped at 31 bits to accommodate int32 rates)
     uint24 minMaintenance;          // <= 1677%
     uint24 minEfficiency;           // <= 1677%
-    uint24 orderReferralFee;        // <= 1677%
-    uint24 guaranteeReferralFee;    // <= 1677%
+    uint24 referralFee;             // <= 1677%
 }
 struct ProtocolParameterStorage { StoredProtocolParameter value; } // SECURITY: must remain at (1) slots
 using ProtocolParameterStorageLib for ProtocolParameterStorage global;
@@ -61,8 +57,7 @@ library ProtocolParameterStorageLib {
             UFixed6.wrap(uint256(value.maxRate)),
             UFixed6.wrap(uint256(value.minMaintenance)),
             UFixed6.wrap(uint256(value.minEfficiency)),
-            UFixed6.wrap(uint256(value.orderReferralFee)),
-            UFixed6.wrap(uint256(value.guaranteeReferralFee))
+            UFixed6.wrap(uint256(value.referralFee))
         );
     }
 
@@ -79,8 +74,7 @@ library ProtocolParameterStorageLib {
         if (newValue.maxRate.gt(UFixed6.wrap(type(uint32).max / 2))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minMaintenance.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minEfficiency.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
-        if (newValue.orderReferralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
-        if (newValue.guaranteeReferralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
+        if (newValue.referralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
 
         self.value = StoredProtocolParameter(
             uint24(UFixed6.unwrap(newValue.protocolFee)),
@@ -90,8 +84,7 @@ library ProtocolParameterStorageLib {
             uint32(UFixed6.unwrap(newValue.maxRate)),
             uint24(UFixed6.unwrap(newValue.minMaintenance)),
             uint24(UFixed6.unwrap(newValue.minEfficiency)),
-            uint24(UFixed6.unwrap(newValue.orderReferralFee)),
-            uint24(UFixed6.unwrap(newValue.guaranteeReferralFee))
+            uint24(UFixed6.unwrap(newValue.referralFee))
         );
     }
 }

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -377,7 +377,7 @@ async function deposit(market: Market, amount: BigNumber, account: SignerWithAdd
     )
 }
 
-describe('Market', () => {
+describe.skip('Market', () => {
   let protocolTreasury: SignerWithAddress
   let owner: SignerWithAddress
   let beneficiary: SignerWithAddress
@@ -16521,10 +16521,11 @@ describe('Market', () => {
           await expect(
             market
               .connect(userC)
-              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                 intent,
                 DEFAULT_SIGNATURE,
                 liquidator.address,
+                constants.AddressZero,
               ),
           )
             .to.emit(market, 'OrderCreated')
@@ -18614,10 +18615,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -18802,10 +18804,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -18990,10 +18993,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19178,10 +19182,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19381,10 +19386,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19586,10 +19592,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19791,10 +19798,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19997,10 +20005,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -20209,10 +20218,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -20422,10 +20432,11 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                   intent,
                   DEFAULT_SIGNATURE,
                   liquidator.address,
+                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -20602,10 +20613,11 @@ describe('Market', () => {
           await expect(
             market
               .connect(userC)
-              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address)'](
+              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
                 intent,
                 DEFAULT_SIGNATURE,
                 liquidator.address,
+                constants.AddressZero,
               ),
           ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
         })

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -16500,9 +16500,9 @@ describe('Market', () => {
           const intent: IntentStruct = {
             amount: POSITION.div(2),
             price: parse6decimal('125'),
-            fee: 0,
-            originator: constants.AddressZero,
-            solver: constants.AddressZero,
+            fee: parse6decimal('0.5'),
+            originator: liquidator.address,
+            solver: owner.address,
             common: {
               account: user.address,
               domain: market.address,
@@ -16620,7 +16620,11 @@ describe('Market', () => {
           })
           expectLocalEq(await market.locals(liquidator.address), {
             ...DEFAULT_LOCAL,
-            claimable: TAKER_FEE.mul(2).div(10).mul(2),
+            claimable: TAKER_FEE.mul(2).div(10),
+          })
+          expectLocalEq(await market.locals(owner.address), {
+            ...DEFAULT_LOCAL,
+            claimable: TAKER_FEE.mul(2).div(10),
           })
           const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
           expectGlobalEq(await market.global(), {
@@ -16656,9 +16660,12 @@ describe('Market', () => {
         })
 
         it('reverts when not operator', async () => {
-          const intent = {
+          const intent: IntentStruct = {
             amount: POSITION.div(2),
             price: parse6decimal('125'),
+            fee: parse6decimal('0.5'),
+            originator: liquidator.address,
+            solver: owner.address,
             common: {
               account: user.address,
               domain: market.address,
@@ -16684,8 +16691,11 @@ describe('Market', () => {
 
           await expect(
             market
-              .connect(operator)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
+              .connect(userC)
+              ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
+                intent,
+                DEFAULT_SIGNATURE,
+              ),
           ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
         })
       })
@@ -18596,9 +18606,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -18715,7 +18725,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
             expectGlobalEq(await market.global(), {
@@ -18786,9 +18800,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -18905,7 +18919,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
             expectGlobalEq(await market.global(), {
@@ -18976,9 +18994,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('121'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19095,7 +19113,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
             expectGlobalEq(await market.global(), {
@@ -19166,9 +19188,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('121'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19285,7 +19307,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
             expectGlobalEq(await market.global(), {
@@ -19347,9 +19373,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19492,7 +19518,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
@@ -19554,9 +19584,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19699,7 +19729,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
@@ -19761,9 +19795,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19907,7 +19941,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
@@ -19969,9 +20007,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -20115,7 +20153,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
@@ -20177,9 +20219,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -20330,7 +20372,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = TAKER_FEE.mul(2) // setup
               .add(EXPECTED_INTEREST_FEE_10_123_EFF) // while open
@@ -20392,9 +20438,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
-              fee: 0,
-              originator: constants.AddressZero,
-              solver: constants.AddressZero,
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -20545,7 +20591,11 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10).mul(2),
+              claimable: TAKER_FEE.mul(2).div(10),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10),
             })
             const totalFee = TAKER_FEE.mul(2) // setup
               .add(EXPECTED_INTEREST_FEE_10_123_EFF) // while open
@@ -20605,7 +20655,7 @@ describe('Market', () => {
             amount: POSITION.div(2),
             price: parse6decimal('125'),
             fee: 0,
-            originator: constants.AddressZero,
+            originator: liquidator.address,
             solver: constants.AddressZero,
             common: {
               account: user.address,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -40,7 +40,12 @@ import {
   expectCheckpointEq,
   DEFAULT_GLOBAL,
 } from '../../../../common/testutil/types'
-import { IMarket, MarketParameterStruct, RiskParameterStruct } from '../../../types/generated/contracts/Market'
+import {
+  IMarket,
+  IntentStruct,
+  MarketParameterStruct,
+  RiskParameterStruct,
+} from '../../../types/generated/contracts/Market'
 
 const { ethers } = HRE
 use(smock.matchers)
@@ -16492,9 +16497,12 @@ describe('Market', () => {
           const TAKER_FEE = parse6decimal('6.15') // position * (0.01) * price
           const SETTLEMENT_FEE = parse6decimal('0.50')
 
-          const intent = {
+          const intent: IntentStruct = {
             amount: POSITION.div(2),
             price: parse6decimal('125'),
+            fee: 0,
+            originator: constants.AddressZero,
+            solver: constants.AddressZero,
             common: {
               account: user.address,
               domain: market.address,
@@ -16521,11 +16529,9 @@ describe('Market', () => {
           await expect(
             market
               .connect(userC)
-              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+              ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                 intent,
                 DEFAULT_SIGNATURE,
-                liquidator.address,
-                constants.AddressZero,
               ),
           )
             .to.emit(market, 'OrderCreated')
@@ -18590,6 +18596,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -18615,11 +18624,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -18779,6 +18786,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -18804,11 +18814,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -18968,6 +18976,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('121'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -18993,11 +19004,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19157,6 +19166,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('121'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19182,11 +19194,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19337,6 +19347,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19386,11 +19399,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19543,6 +19554,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19592,11 +19606,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19749,6 +19761,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -19798,11 +19813,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -19956,6 +19969,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -20005,11 +20021,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -20163,6 +20177,9 @@ describe('Market', () => {
             const intent = {
               amount: -POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -20218,11 +20235,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -20377,6 +20392,9 @@ describe('Market', () => {
             const intent = {
               amount: POSITION.div(2),
               price: parse6decimal('125'),
+              fee: 0,
+              originator: constants.AddressZero,
+              solver: constants.AddressZero,
               common: {
                 account: user.address,
                 domain: market.address,
@@ -20432,11 +20450,9 @@ describe('Market', () => {
             await expect(
               market
                 .connect(userC)
-                ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+                ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                   intent,
                   DEFAULT_SIGNATURE,
-                  liquidator.address,
-                  constants.AddressZero,
                 ),
             )
               .to.emit(market, 'OrderCreated')
@@ -20588,6 +20604,9 @@ describe('Market', () => {
           const intent = {
             amount: POSITION.div(2),
             price: parse6decimal('125'),
+            fee: 0,
+            originator: constants.AddressZero,
+            solver: constants.AddressZero,
             common: {
               account: user.address,
               domain: market.address,
@@ -20613,11 +20632,9 @@ describe('Market', () => {
           await expect(
             market
               .connect(userC)
-              ['update((int256,int256,(address,address,uint256,uint256,uint256)),bytes,address,address)'](
+              ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
                 intent,
                 DEFAULT_SIGNATURE,
-                liquidator.address,
-                constants.AddressZero,
               ),
           ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
         })

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -377,7 +377,7 @@ async function deposit(market: Market, amount: BigNumber, account: SignerWithAdd
     )
 }
 
-describe.skip('Market', () => {
+describe('Market', () => {
   let protocolTreasury: SignerWithAddress
   let owner: SignerWithAddress
   let beneficiary: SignerWithAddress

--- a/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
@@ -233,7 +233,7 @@ describe('MarketFactory', () => {
         .to.emit(factory, 'ReferralFeeUpdated')
         .withArgs(user.address, parse6decimal('0.3'))
 
-      expect(await factory.referralFee(user.address)).to.equal(parse6decimal('0.3'))
+      expect(await factory.referralFees(user.address)).to.equal(parse6decimal('0.3'))
     })
 
     it('reverts if not owner', async () => {

--- a/packages/perennial/test/unit/types/Guarantee.test.ts
+++ b/packages/perennial/test/unit/types/Guarantee.test.ts
@@ -29,6 +29,7 @@ describe('Guarantee', () => {
       takerPos: 3,
       takerNeg: 4,
       notional: 0,
+      referral: 0,
     }
 
     let guaranteeGlobal: GuaranteeGlobalTester
@@ -59,6 +60,7 @@ describe('Guarantee', () => {
       takerPos: 3,
       takerNeg: 4,
       notional: 14,
+      referral: 15,
     }
 
     let guaranteeLocal: GuaranteeLocalTester
@@ -119,6 +121,27 @@ describe('Guarantee', () => {
           ).to.be.revertedWithCustomError(guaranteeLocal, 'GuaranteeStorageInvalidError')
         })
       })
+
+      context('.referral', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await guaranteeLocal.store({
+            ...DEFAULT_GUARANTEE,
+            referral: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await guaranteeLocal.read()
+          expect(value.referral).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if referral out of range', async () => {
+          await expect(
+            guaranteeLocal.store({
+              ...DEFAULT_GUARANTEE,
+              referral: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(guaranteeLocal, 'GuaranteeStorageInvalidError')
+        })
+      })
     })
 
     describe('#from', () => {
@@ -126,6 +149,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           false,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -135,6 +159,7 @@ describe('Guarantee', () => {
           takerPos: parse6decimal('10'),
           takerNeg: 0,
           notional: parse6decimal('1230'),
+          referral: 0,
         })
       })
 
@@ -142,6 +167,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, longNeg: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           false,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -151,6 +177,7 @@ describe('Guarantee', () => {
           takerPos: 0,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
+          referral: 0,
         })
       })
 
@@ -158,6 +185,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           true,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -167,6 +195,25 @@ describe('Guarantee', () => {
           takerPos: parse6decimal('10'),
           takerNeg: 0,
           notional: parse6decimal('1230'),
+          referral: 0,
+        })
+      })
+
+      it('generates correct guarantee (long referral)', async () => {
+        await guaranteeLocal.from(
+          { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10'), takerReferral: parse6decimal('2') },
+          parse6decimal('123'),
+          parse6decimal('0.5'),
+          true,
+        )
+        const newGuarantee = await guaranteeLocal.read()
+
+        expectGuaranteeEq(newGuarantee, {
+          orders: 0,
+          takerPos: parse6decimal('10'),
+          takerNeg: 0,
+          notional: parse6decimal('1230'),
+          referral: parse6decimal('1'),
         })
       })
 
@@ -174,6 +221,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, shortPos: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           false,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -183,6 +231,7 @@ describe('Guarantee', () => {
           takerPos: 0,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
+          referral: 0,
         })
       })
 
@@ -190,6 +239,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, shortNeg: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           false,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -199,6 +249,7 @@ describe('Guarantee', () => {
           takerPos: parse6decimal('10'),
           takerNeg: 0,
           notional: parse6decimal('1230'),
+          referral: 0,
         })
       })
 
@@ -206,6 +257,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, shortPos: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           true,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -215,6 +267,25 @@ describe('Guarantee', () => {
           takerPos: 0,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
+          referral: 0,
+        })
+      })
+
+      it('generates correct guarantee (short referral)', async () => {
+        await guaranteeLocal.from(
+          { ...DEFAULT_ORDER, orders: 1, shortPos: parse6decimal('10'), takerReferral: parse6decimal('2') },
+          parse6decimal('123'),
+          parse6decimal('0.5'),
+          true,
+        )
+        const newGuarantee = await guaranteeLocal.read()
+
+        expectGuaranteeEq(newGuarantee, {
+          orders: 0,
+          takerPos: 0,
+          takerNeg: parse6decimal('10'),
+          notional: parse6decimal('-1230'),
+          referral: parse6decimal('1'),
         })
       })
 
@@ -222,6 +293,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, makerPos: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           false,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -231,6 +303,7 @@ describe('Guarantee', () => {
           takerPos: 0,
           takerNeg: 0,
           notional: 0,
+          referral: 0,
         })
       })
 
@@ -238,6 +311,7 @@ describe('Guarantee', () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, makerNeg: parse6decimal('10') },
           parse6decimal('123'),
+          0,
           false,
         )
         const newGuarantee = await guaranteeLocal.read()
@@ -247,6 +321,7 @@ describe('Guarantee', () => {
           takerPos: 0,
           takerNeg: 0,
           notional: 0,
+          referral: 0,
         })
       })
     })

--- a/packages/perennial/test/unit/types/Local.test.ts
+++ b/packages/perennial/test/unit/types/Local.test.ts
@@ -165,7 +165,7 @@ describe('Local', () => {
   describe('#update', () => {
     it('correctly updates fees', async () => {
       await local.store({ ...DEFAULT_LOCAL, collateral: 1000 })
-      await local['update(uint256,(int256,int256,uint256,int256,uint256,uint256,uint256))'](11, {
+      await local['update(uint256,(int256,int256,uint256,int256,uint256,uint256,uint256,uint256))'](11, {
         collateral: 567,
         priceOverride: -222,
         tradeFee: 123,
@@ -173,6 +173,7 @@ describe('Local', () => {
         settlementFee: 456,
         liquidationFee: 256,
         subtractiveFee: 0,
+        solverFee: 0,
       })
 
       const storedLocal = await local.read()

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -1153,7 +1153,6 @@ describe('Version', () => {
             makerFee: {
               linearFee: parse6decimal('0.02'),
               proportionalFee: parse6decimal('0.10'),
-              adiabaticFee: parse6decimal('0.20'),
               scale: parse6decimal('100'),
             },
             takerFee: {
@@ -1257,7 +1256,6 @@ describe('Version', () => {
             makerFee: {
               linearFee: parse6decimal('0.02'),
               proportionalFee: parse6decimal('0.10'),
-              adiabaticFee: parse6decimal('0.20'),
               scale: parse6decimal('100'),
             },
             takerFee: {
@@ -1359,7 +1357,6 @@ describe('Version', () => {
             makerFee: {
               linearFee: parse6decimal('0.02'),
               proportionalFee: parse6decimal('0.10'),
-              adiabaticFee: parse6decimal('0.20'),
               scale: parse6decimal('100'),
             },
             takerFee: {
@@ -1917,7 +1914,6 @@ describe('Version', () => {
                 makerFee: {
                   linearFee: 0,
                   proportionalFee: 0,
-                  adiabaticFee: 0,
                   scale: parse6decimal('100'),
                 },
                 takerFee: {
@@ -1975,7 +1971,6 @@ describe('Version', () => {
                 makerFee: {
                   linearFee: 0,
                   proportionalFee: 0,
-                  adiabaticFee: 0,
                   scale: parse6decimal('100'),
                 },
                 takerFee: {
@@ -2033,7 +2028,6 @@ describe('Version', () => {
                 makerFee: {
                   linearFee: 0,
                   proportionalFee: 0,
-                  adiabaticFee: 0,
                   scale: parse6decimal('100'),
                 },
                 takerFee: {
@@ -2093,7 +2087,6 @@ describe('Version', () => {
                 makerFee: {
                   linearFee: 0,
                   proportionalFee: 0,
-                  adiabaticFee: 0,
                   scale: parse6decimal('100'),
                 },
                 takerFee: {
@@ -2151,7 +2144,6 @@ describe('Version', () => {
                 makerFee: {
                   linearFee: 0,
                   proportionalFee: 0,
-                  adiabaticFee: 0,
                   scale: parse6decimal('100'),
                 },
                 takerFee: {
@@ -2209,7 +2201,6 @@ describe('Version', () => {
                 makerFee: {
                   linearFee: 0,
                   proportionalFee: 0,
-                  adiabaticFee: 0,
                   scale: parse6decimal('100'),
                 },
                 takerFee: {


### PR DESCRIPTION
Adds a `solver` fee to intents.

Updates the `Intent` message to contain three new fields:
- `originator` the originator of the order (ex. the interface)
  - receives the subtractive fee less the solver fee
- `solver` the solver of the guarentee (ex. router API)
   - receives the solver fee
- `fee` portion of the subtractive fee to instead give to the solver.

All referral information is now read from the intent instead of passed in as a parameter to `update()`. 