### PR TITLE
Only charge taker fees to the maker side of the intent order

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -38,6 +38,7 @@ export interface Guarantee {
   takerPos: BigNumberish
   takerNeg: BigNumberish
   notional: BigNumberish
+  takerFee: BigNumberish
   referral: BigNumberish
 }
 
@@ -112,6 +113,7 @@ export function expectGuaranteeEq(a: Guarantee, b: Guarantee): void {
   expect(a.takerPos).to.equal(b.takerPos, 'Order:TakerPos')
   expect(a.takerNeg).to.equal(b.takerNeg, 'Order:TakerNeg')
   expect(a.notional).to.equal(b.notional, 'Order:Notional')
+  expect(a.takerFee).to.equal(b.takerFee, 'Order:TakerFee')
   expect(a.referral).to.equal(b.referral, 'Order:Referral')
 }
 
@@ -233,6 +235,7 @@ export const DEFAULT_GUARANTEE: Guarantee = {
   takerPos: 0,
   takerNeg: 0,
   notional: 0,
+  takerFee: 0,
   referral: 0,
 }
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -175,7 +175,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         // load update context
         UpdateContext memory updateContext = _loadUpdateContext(context, signer, orderReferrer, guaranteeReferralFee);
 
-        (UFixed6 orderReferralFee, UFixed6 guarenteeReferralFee) = chargeFee
+        (UFixed6 processedOrderReferralFee, UFixed6 processedGuaranteeReferralFee) = chargeFee
             ? _processReferralFee(context, updateContext, orderReferrer, guaranteeReferrer)
             : (UFixed6Lib.ZERO, UFixed6Lib.ZERO);
 
@@ -184,9 +184,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             context.currentTimestamp,
             updateContext.currentPositionLocal,
             amount,
-            orderReferralFee
+            processedOrderReferralFee
         );
-        Guarantee memory newGuarantee = GuaranteeLib.from(newOrder, price, guarenteeReferralFee, chargeFee);
+        Guarantee memory newGuarantee = GuaranteeLib.from(newOrder, price, processedGuaranteeReferralFee, chargeFee);
 
         // process update
         _update(context, updateContext, newOrder, newGuarantee, orderReferrer, guaranteeReferrer);
@@ -244,7 +244,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         newShort = _processPositionMagicValue(context, updateContext.currentPositionLocal.short, newShort);
 
         // Compute referral fees
-        (UFixed6 orderReferralFee, ) = _processReferralFee(context, updateContext, referrer, address(0));
+        (UFixed6 processedOrderReferralFee, ) = _processReferralFee(context, updateContext, referrer, address(0));
 
         // create new order & guarantee
         Order memory newOrder = OrderLib.from(
@@ -255,7 +255,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             newLong,
             newShort,
             protect,
-            orderReferralFee
+            processedOrderReferralFee
         );
         Guarantee memory newGuarantee; // no guarantee is created for a market order
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -132,20 +132,20 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             address(0),
             intent.amount.mul(Fixed6Lib.NEG_ONE),
             intent.price,
-            true,
             intent.originator,
             intent.solver,
-            intent.fee
+            intent.fee,
+            true
         ); // sender
         _updateIntent(
             intent.common.account,
             signer,
             intent.amount,
             intent.price,
-            false,
             intent.originator,
             intent.solver,
-            intent.fee
+            intent.fee,
+            false
         ); // signer
     }
 
@@ -154,19 +154,19 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @param signer The signer of the order
     /// @param amount The size and direction of the order being opened
     /// @param price The price to execute the order at
-    /// @param settlementFee Whether to charge the settlement fee
     /// @param orderReferrer The referrer of the order
     /// @param guaranteeReferrer The referrer of the guarantee
     /// @param guaranteeReferralFee The referral fee for the guarantee
+    /// @param chargeFee Whether to charge the fee
     function _updateIntent(
         address account,
         address signer,
         Fixed6 amount,
         Fixed6 price,
-        bool settlementFee,
         address orderReferrer,
         address guaranteeReferrer,
-        UFixed6 guaranteeReferralFee
+        UFixed6 guaranteeReferralFee,
+        bool chargeFee
     ) private {
         // settle market & account
         Context memory context = _loadContext(account);
@@ -175,8 +175,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         // load update context
         UpdateContext memory updateContext = _loadUpdateContext(context, signer, orderReferrer, guaranteeReferralFee);
 
-        (UFixed6 orderReferralFee, UFixed6 guarenteeReferralFee) =
-            _processReferralFee(context, updateContext, orderReferrer, guaranteeReferrer);
+        (UFixed6 orderReferralFee, UFixed6 guarenteeReferralFee) = chargeFee
+            ? _processReferralFee(context, updateContext, orderReferrer, guaranteeReferrer)
+            : (UFixed6Lib.ZERO, UFixed6Lib.ZERO);
 
         // create new order & guarantee
         Order memory newOrder = OrderLib.from(
@@ -185,7 +186,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             amount,
             orderReferralFee
         );
-        Guarantee memory newGuarantee = GuaranteeLib.from(newOrder, price, guarenteeReferralFee, settlementFee);
+        Guarantee memory newGuarantee = GuaranteeLib.from(newOrder, price, guarenteeReferralFee, chargeFee);
 
         // process update
         _update(context, updateContext, newOrder, newGuarantee, orderReferrer, guaranteeReferrer);

--- a/packages/perennial/contracts/libs/CheckpointLib.sol
+++ b/packages/perennial/contracts/libs/CheckpointLib.sol
@@ -85,26 +85,29 @@ library CheckpointLib {
         Guarantee memory guarantee,
         Version memory toVersion
     ) private pure returns (UFixed6 tradeFee, UFixed6 subtractiveFee, UFixed6 solverFee) {
+        UFixed6 takerTotal = order.takerTotal().sub(guarantee.takerFee);
+
         UFixed6 makerFee = Fixed6Lib.ZERO
             .sub(toVersion.makerFee.accumulated(Accumulator6(Fixed6Lib.ZERO), order.makerTotal()))
             .abs();
         UFixed6 takerFee = Fixed6Lib.ZERO
-            .sub(toVersion.takerFee.accumulated(Accumulator6(Fixed6Lib.ZERO), order.takerTotal()))
+            .sub(toVersion.takerFee.accumulated(Accumulator6(Fixed6Lib.ZERO), takerTotal))
             .abs();
 
         UFixed6 makerSubtractiveFee = order.makerTotal().isZero() ?
             UFixed6Lib.ZERO :
             makerFee.muldiv(order.makerReferral, order.makerTotal());
-        UFixed6 takerSubtractiveFee = order.takerTotal().isZero() ?
+        UFixed6 takerSubtractiveFee = takerTotal.isZero() ?
             UFixed6Lib.ZERO :
-            takerFee.muldiv(order.takerReferral, order.takerTotal());
+            takerFee.muldiv(order.takerReferral, takerTotal);
 
-        solverFee = order.takerTotal().isZero() ?
+        solverFee = takerTotal.isZero() ?
             UFixed6Lib.ZERO :
-            takerFee.muldiv(guarantee.referral, order.takerTotal());
+            takerFee.muldiv(guarantee.referral, takerTotal);
 
         tradeFee = makerFee.add(takerFee);
         subtractiveFee = makerSubtractiveFee.add(takerSubtractiveFee).sub(solverFee);
+
     }
 
     /// @notice Accumulate price offset for the next position

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -157,13 +157,14 @@ library VersionLib {
             UFixed6Lib.ZERO :
             makerFee.muldiv(context.order.makerReferral, context.order.makerTotal());
 
-        UFixed6 takerFee = context.order.takerTotal()
+        UFixed6 takerTotal = context.order.takerTotal().sub(context.guarantee.takerFee);
+        UFixed6 takerFee = takerTotal
             .mul(context.toOracleVersion.price.abs())
             .mul(context.marketParameter.takerFee);
-        next.takerFee.decrement(Fixed6Lib.from(takerFee), context.order.takerTotal());
-        UFixed6 takerSubtractiveFee = context.order.takerTotal().isZero() ?
+        next.takerFee.decrement(Fixed6Lib.from(takerFee), takerTotal);
+        UFixed6 takerSubtractiveFee = takerTotal.isZero() ?
             UFixed6Lib.ZERO :
-            takerFee.muldiv(context.order.takerReferral, context.order.takerTotal());
+            takerFee.muldiv(context.order.takerReferral, takerTotal);
 
         result.tradeFee = result.tradeFee.add(makerFee).add(takerFee).sub(makerSubtractiveFee).sub(takerSubtractiveFee);
         result.subtractiveFee = result.subtractiveFee.add(makerSubtractiveFee).add(takerSubtractiveFee);

--- a/packages/perennial/contracts/test/GuaranteeTester.sol
+++ b/packages/perennial/contracts/test/GuaranteeTester.sol
@@ -8,8 +8,8 @@ abstract contract GuaranteeTester {
 
     function store(Guarantee memory newGuarantee) public virtual;
 
-    function from(Order memory order, Fixed6 price, UFixed6 referralFee, bool settlementFee) external {
-        Guarantee memory newGuarantee = GuaranteeLib.from(order, price, referralFee, settlementFee);
+    function from(Order memory order, Fixed6 price, UFixed6 referralFee, bool chargeFee) external {
+        Guarantee memory newGuarantee = GuaranteeLib.from(order, price, referralFee, chargeFee);
         store(newGuarantee);
     }
 }

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -17,6 +17,9 @@ struct Guarantee {
     /// @dev The negative skew (close long / open short) guarantee size
     UFixed6 takerNeg;
 
+    /// @dev The magnitude of the guarentee that is applicable to the fee
+    UFixed6 takerFee;
+
     /// @dev The referral fee multiplied by the size applicable to the referral (local only)
     UFixed6 referral;
 }
@@ -39,27 +42,28 @@ library GuaranteeLib {
     /// @notice Invalidates the guarantee
     /// @param self The guarantee object to update
     function invalidate(Guarantee memory self) internal pure {
-        (self.takerPos, self.takerNeg, self.notional, self.referral) =
-            (UFixed6Lib.ZERO, UFixed6Lib.ZERO, Fixed6Lib.ZERO, UFixed6Lib.ZERO);
+        (self.takerPos, self.takerNeg, self.notional, self.takerFee, self.referral) =
+            (UFixed6Lib.ZERO, UFixed6Lib.ZERO, Fixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
     }
 
     /// @notice Creates a new guarantee from an order
     /// @param order The order to create the guarantee from
     /// @param priceOverride The price override
     /// @param referralFee The referral fee percentage
-    /// @param settlementFee Whether the order will still be charged the settlement fee
+    /// @param chargeFee Whether the order will still be charged the fee
     /// @return newGuarantee The resulting guarantee
     function from(
         Order memory order,
         Fixed6 priceOverride,
         UFixed6 referralFee,
-        bool settlementFee
+        bool chargeFee
     ) internal pure returns (Guarantee memory newGuarantee) {
         // maker orders and one intent order per fill will be required to pay the settlement fee
-        if (!order.takerTotal().isZero() && !settlementFee) newGuarantee.orders = order.orders;
+        if (!order.takerTotal().isZero() && !chargeFee) newGuarantee.orders = order.orders;
 
         (newGuarantee.takerPos, newGuarantee.takerNeg) =
             (order.longPos.add(order.shortNeg), order.longNeg.add(order.shortPos));
+        newGuarantee.takerFee = chargeFee ? UFixed6Lib.ZERO : order.takerTotal();
 
         newGuarantee.notional = taker(newGuarantee).mul(priceOverride);
         newGuarantee.referral = order.takerReferral.mul(referralFee);
@@ -84,10 +88,11 @@ library GuaranteeLib {
     /// @param guarantee The new guarantee
     function add(Guarantee memory self, Guarantee memory guarantee) internal pure {
         self.orders = self.orders + guarantee.orders;
-        (self.takerPos, self.takerNeg, self.notional, self.referral) = (
+        (self.notional, self.takerPos, self.takerNeg, self.takerFee, self.referral) = (
+            self.notional.add(guarantee.notional),
             self.takerPos.add(guarantee.takerPos),
             self.takerNeg.add(guarantee.takerNeg),
-            self.notional.add(guarantee.notional),
+            self.takerFee.add(guarantee.takerFee),
             self.referral.add(guarantee.referral)
         );
     }
@@ -100,6 +105,7 @@ library GuaranteeLib {
 ///         uint32 orders;
 ///         uint64 takerPos;
 ///         uint64 takerNeg;
+///         uint64 takerFee;
 ///     }
 ///
 library GuaranteeStorageGlobalLib {
@@ -110,6 +116,7 @@ library GuaranteeStorageGlobalLib {
             Fixed6Lib.ZERO,
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 64)) >> (256 - 64)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 64 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot0 << (256 - 32 - 64 - 64 - 64)) >> (256 - 64)),
             UFixed6Lib.ZERO
         );
     }
@@ -120,7 +127,8 @@ library GuaranteeStorageGlobalLib {
         uint256 encoded0 =
             uint256(newValue.orders << (256 - 32)) >> (256 - 32) |
             uint256(UFixed6.unwrap(newValue.takerPos) << (256 - 64)) >> (256 - 32 - 64) |
-            uint256(UFixed6.unwrap(newValue.takerNeg) << (256 - 64)) >> (256 - 32 - 64 - 64);
+            uint256(UFixed6.unwrap(newValue.takerNeg) << (256 - 64)) >> (256 - 32 - 64 - 64) |
+            uint256(UFixed6.unwrap(newValue.takerFee) << (256 - 64)) >> (256 - 32 - 64 - 64 - 64);
 
         assembly {
             sstore(self.slot, encoded0)
@@ -138,6 +146,7 @@ library GuaranteeStorageGlobalLib {
 ///         uint64 takerNeg;
 ///
 ///         /* slot 1 */
+///         uint64 takerFee;
 ///         uint64 referral;
 ///     }
 ///
@@ -149,7 +158,8 @@ library GuaranteeStorageLocalLib {
             Fixed6.wrap(int256(slot0 << (256 - 32 - 64)) >> (256 - 64)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 64 - 64)) >> (256 - 64)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 64 - 64 - 64)) >> (256 - 64)),
-            UFixed6.wrap(uint256(slot1 << (256 - 64)) >> (256 - 64))
+            UFixed6.wrap(uint256(slot1 << (256 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64)) >> (256 - 64))
         );
     }
 
@@ -166,7 +176,8 @@ library GuaranteeStorageLocalLib {
             uint256(UFixed6.unwrap(newValue.takerPos) << (256 - 64)) >> (256 - 32 - 64 - 64) |
             uint256(UFixed6.unwrap(newValue.takerNeg) << (256 - 64)) >> (256 - 32 - 64 - 64 - 64);
         uint256 encode1 =
-            uint256(UFixed6.unwrap(newValue.referral) << (256 - 64)) >> (256 - 64);
+            uint256(UFixed6.unwrap(newValue.takerFee) << (256 - 64)) >> (256 - 64) |
+            uint256(UFixed6.unwrap(newValue.referral) << (256 - 64)) >> (256 - 64 - 64);
 
         assembly {
             sstore(self.slot, encoded0)
@@ -183,5 +194,6 @@ library GuaranteeStorageLib {
         if (newValue.orders > type(uint32).max) revert GuaranteeStorageInvalidError();
         if (newValue.takerPos.gt(UFixed6.wrap(type(uint64).max))) revert GuaranteeStorageLib.GuaranteeStorageInvalidError();
         if (newValue.takerNeg.gt(UFixed6.wrap(type(uint64).max))) revert GuaranteeStorageLib.GuaranteeStorageInvalidError();
+        if (newValue.takerFee.gt(UFixed6.wrap(type(uint64).max))) revert GuaranteeStorageLib.GuaranteeStorageInvalidError();
     }
 }

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -17,7 +17,7 @@ struct Guarantee {
     /// @dev The negative skew (close long / open short) guarantee size
     UFixed6 takerNeg;
 
-    /// @dev The magnitude of the guarentee that is applicable to the fee
+    /// @dev The magnitude of the guarantee that is applicable to the fee
     UFixed6 takerFee;
 
     /// @dev The referral fee multiplied by the size applicable to the referral (local only)

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -16540,7 +16540,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             .to.emit(market, 'OrderCreated')
             .withArgs(userC.address, {
@@ -16565,7 +16564,7 @@ describe('Market', () => {
             ...DEFAULT_LOCAL,
             currentId: 2,
             latestId: 1,
-            collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(TAKER_FEE).sub(EXPECTED_PNL),
+            collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
           })
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
@@ -16620,13 +16619,13 @@ describe('Market', () => {
           })
           expectLocalEq(await market.locals(liquidator.address), {
             ...DEFAULT_LOCAL,
-            claimable: TAKER_FEE.mul(2).div(10),
+            claimable: TAKER_FEE.mul(2).div(10).div(2),
           })
           expectLocalEq(await market.locals(owner.address), {
             ...DEFAULT_LOCAL,
-            claimable: TAKER_FEE.mul(2).div(10),
+            claimable: TAKER_FEE.mul(2).div(10).div(2),
           })
-          const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+          const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
           expectGlobalEq(await market.global(), {
             currentId: 2,
             latestId: 1,
@@ -18645,7 +18644,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 orders: 1,
                 longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -18670,7 +18668,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(TAKER_FEE).sub(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -18725,13 +18723,13 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
-            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
               currentId: 2,
               latestId: 1,
@@ -18839,7 +18837,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 orders: 1,
                 shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -18864,7 +18861,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(TAKER_FEE).add(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -18919,13 +18916,13 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
-            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
               currentId: 2,
               latestId: 1,
@@ -19033,7 +19030,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 orders: 1,
                 longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -19058,7 +19054,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(TAKER_FEE).add(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -19113,13 +19109,13 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
-            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
               currentId: 2,
               latestId: 1,
@@ -19227,7 +19223,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 orders: 1,
                 shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -19252,7 +19247,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(TAKER_FEE).sub(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -19307,13 +19302,13 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
-            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
               currentId: 2,
               latestId: 1,
@@ -19436,7 +19431,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 orders: 1,
                 longNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -19463,7 +19457,6 @@ describe('Market', () => {
                 .sub(SETTLEMENT_FEE.div(2)) // open
                 .sub(EXPECTED_INTEREST_5_123)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123) // while open
-                .sub(TAKER_FEE)
                 .add(EXPECTED_PNL), // close
             })
             expectPositionEq(await market.positions(user.address), {
@@ -19518,15 +19511,15 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
-              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2)) // fill
+              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
               currentId: 3,
               latestId: 2,
@@ -19647,7 +19640,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 orders: 1,
                 shortNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -19674,7 +19666,6 @@ describe('Market', () => {
                 .sub(SETTLEMENT_FEE.div(2)) // open
                 .sub(EXPECTED_INTEREST_5_123)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123) // while open
-                .sub(TAKER_FEE)
                 .sub(EXPECTED_PNL), // close
             })
             expectPositionEq(await market.positions(user.address), {
@@ -19729,15 +19720,15 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
-              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2)) // fill
+              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
               currentId: 3,
               latestId: 2,
@@ -19858,7 +19849,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 orders: 1,
                 shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -19881,7 +19871,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 3,
               latestId: 2,
-              collateral: COLLATERAL.sub(TAKER_FEE).add(EXPECTED_PNL), // open
+              collateral: COLLATERAL.add(EXPECTED_PNL), // open
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -19941,15 +19931,15 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
-              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2)) // fill
+              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
               currentId: 3,
               latestId: 2,
@@ -20070,7 +20060,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 orders: 1,
                 longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -20093,7 +20082,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 3,
               latestId: 2,
-              collateral: COLLATERAL.sub(TAKER_FEE).sub(EXPECTED_PNL), // open
+              collateral: COLLATERAL.sub(EXPECTED_PNL), // open
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -20153,15 +20142,15 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             const totalFee = EXPECTED_INTEREST_FEE_5_123.add(EXPECTED_FUNDING_FEE_1_5_123)
               .add(TAKER_FEE) // setup
-              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2)) // fill
+              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
               currentId: 3,
               latestId: 2,
@@ -20288,7 +20277,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 orders: 1,
                 longNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -20314,7 +20302,6 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(3).add(1)) // open
                 .sub(EXPECTED_INTEREST_10_123_EFF.div(2)) // while open
-                .sub(TAKER_FEE)
                 .add(EXPECTED_PNL), // close
             })
             expectPositionEq(await market.positions(user.address), {
@@ -20372,15 +20359,15 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             const totalFee = TAKER_FEE.mul(2) // setup
               .add(EXPECTED_INTEREST_FEE_10_123_EFF) // while open
-              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2)) // fill
+              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
               currentId: 3,
               latestId: 2,
@@ -20507,7 +20494,6 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 orders: 1,
                 shortNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
               })
               .to.emit(market, 'OrderCreated')
               .withArgs(userC.address, {
@@ -20533,7 +20519,6 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(3).add(1)) // open
                 .sub(EXPECTED_INTEREST_10_123_EFF.div(2)) // while open
-                .sub(TAKER_FEE)
                 .sub(EXPECTED_PNL), // close
             })
             expectPositionEq(await market.positions(user.address), {
@@ -20591,15 +20576,15 @@ describe('Market', () => {
             })
             expectLocalEq(await market.locals(liquidator.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             expectLocalEq(await market.locals(owner.address), {
               ...DEFAULT_LOCAL,
-              claimable: TAKER_FEE.mul(2).div(10),
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
             })
             const totalFee = TAKER_FEE.mul(2) // setup
               .add(EXPECTED_INTEREST_FEE_10_123_EFF) // while open
-              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2)) // fill
+              .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
               currentId: 3,
               latestId: 2,

--- a/packages/perennial/test/unit/types/Guarantee.test.ts
+++ b/packages/perennial/test/unit/types/Guarantee.test.ts
@@ -29,6 +29,7 @@ describe('Guarantee', () => {
       takerPos: 3,
       takerNeg: 4,
       notional: 0,
+      takerFee: 5,
       referral: 0,
     }
 
@@ -47,9 +48,12 @@ describe('Guarantee', () => {
         await guaranteeGlobal.store(VALID_STORED_GUARANTEE)
 
         const value = await guaranteeGlobal.read()
+        expect(value.orders).to.equal(2)
         expect(value.takerPos).to.equal(3)
         expect(value.takerNeg).to.equal(4)
         expect(value.notional).to.equal(0)
+        expect(value.takerFee).to.equal(5)
+        expect(value.referral).to.equal(0)
       })
     })
   })
@@ -60,6 +64,7 @@ describe('Guarantee', () => {
       takerPos: 3,
       takerNeg: 4,
       notional: 14,
+      takerFee: 5,
       referral: 15,
     }
 
@@ -78,9 +83,12 @@ describe('Guarantee', () => {
         await guaranteeLocal.store(VALID_STORED_GUARANTEE)
 
         const value = await guaranteeLocal.read()
+        expect(value.orders).to.equal(2)
         expect(value.takerPos).to.equal(3)
         expect(value.takerNeg).to.equal(4)
         expect(value.notional).to.equal(14)
+        expect(value.takerFee).to.equal(5)
+        expect(value.referral).to.equal(15)
       })
 
       context('.notional', async () => {
@@ -155,11 +163,11 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
+          ...DEFAULT_GUARANTEE,
           orders: 1,
           takerPos: parse6decimal('10'),
-          takerNeg: 0,
           notional: parse6decimal('1230'),
-          referral: 0,
+          takerFee: parse6decimal('10'),
         })
       })
 
@@ -173,15 +181,15 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
+          ...DEFAULT_GUARANTEE,
           orders: 1,
-          takerPos: 0,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
-          referral: 0,
+          takerFee: parse6decimal('10'),
         })
       })
 
-      it('generates correct guarantee (long settlementFee)', async () => {
+      it('generates correct guarantee (long w/ fee)', async () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10') },
           parse6decimal('123'),
@@ -191,15 +199,13 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
-          orders: 0,
+          ...DEFAULT_GUARANTEE,
           takerPos: parse6decimal('10'),
-          takerNeg: 0,
           notional: parse6decimal('1230'),
-          referral: 0,
         })
       })
 
-      it('generates correct guarantee (long referral)', async () => {
+      it('generates correct guarantee (long w/ referral + fee)', async () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10'), takerReferral: parse6decimal('2') },
           parse6decimal('123'),
@@ -209,10 +215,28 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
-          orders: 0,
+          ...DEFAULT_GUARANTEE,
           takerPos: parse6decimal('10'),
-          takerNeg: 0,
           notional: parse6decimal('1230'),
+          referral: parse6decimal('1'),
+        })
+      })
+
+      it('generates correct guarantee (long w/ referral)', async () => {
+        await guaranteeLocal.from(
+          { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10'), takerReferral: parse6decimal('2') },
+          parse6decimal('123'),
+          parse6decimal('0.5'),
+          false,
+        )
+        const newGuarantee = await guaranteeLocal.read()
+
+        expectGuaranteeEq(newGuarantee, {
+          ...DEFAULT_GUARANTEE,
+          orders: 1,
+          takerPos: parse6decimal('10'),
+          notional: parse6decimal('1230'),
+          takerFee: parse6decimal('10'),
           referral: parse6decimal('1'),
         })
       })
@@ -227,11 +251,11 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
+          ...DEFAULT_GUARANTEE,
           orders: 1,
-          takerPos: 0,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
-          referral: 0,
+          takerFee: parse6decimal('10'),
         })
       })
 
@@ -245,15 +269,15 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
+          ...DEFAULT_GUARANTEE,
           orders: 1,
           takerPos: parse6decimal('10'),
-          takerNeg: 0,
           notional: parse6decimal('1230'),
-          referral: 0,
+          takerFee: parse6decimal('10'),
         })
       })
 
-      it('generates correct guarantee (short settlementFee)', async () => {
+      it('generates correct guarantee (short w/ fee)', async () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, shortPos: parse6decimal('10') },
           parse6decimal('123'),
@@ -263,15 +287,13 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
-          orders: 0,
-          takerPos: 0,
+          ...DEFAULT_GUARANTEE,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
-          referral: 0,
         })
       })
 
-      it('generates correct guarantee (short referral)', async () => {
+      it('generates correct guarantee (short w/ referral + fee)', async () => {
         await guaranteeLocal.from(
           { ...DEFAULT_ORDER, orders: 1, shortPos: parse6decimal('10'), takerReferral: parse6decimal('2') },
           parse6decimal('123'),
@@ -281,10 +303,28 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
-          orders: 0,
-          takerPos: 0,
+          ...DEFAULT_GUARANTEE,
           takerNeg: parse6decimal('10'),
           notional: parse6decimal('-1230'),
+          referral: parse6decimal('1'),
+        })
+      })
+
+      it('generates correct guarantee (short w/ referral)', async () => {
+        await guaranteeLocal.from(
+          { ...DEFAULT_ORDER, orders: 1, shortPos: parse6decimal('10'), takerReferral: parse6decimal('2') },
+          parse6decimal('123'),
+          parse6decimal('0.5'),
+          false,
+        )
+        const newGuarantee = await guaranteeLocal.read()
+
+        expectGuaranteeEq(newGuarantee, {
+          ...DEFAULT_GUARANTEE,
+          orders: 1,
+          takerNeg: parse6decimal('10'),
+          notional: parse6decimal('-1230'),
+          takerFee: parse6decimal('10'),
           referral: parse6decimal('1'),
         })
       })
@@ -299,11 +339,7 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
-          orders: 0,
-          takerPos: 0,
-          takerNeg: 0,
-          notional: 0,
-          referral: 0,
+          ...DEFAULT_GUARANTEE,
         })
       })
 
@@ -317,11 +353,7 @@ describe('Guarantee', () => {
         const newGuarantee = await guaranteeLocal.read()
 
         expectGuaranteeEq(newGuarantee, {
-          orders: 0,
-          takerPos: 0,
-          takerNeg: 0,
-          notional: 0,
-          referral: 0,
+          ...DEFAULT_GUARANTEE,
         })
       })
     })
@@ -406,6 +438,27 @@ describe('Guarantee', () => {
             guarantee.store({
               ...DEFAULT_GUARANTEE,
               takerNeg: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(guarantee, 'GuaranteeStorageInvalidError')
+        })
+      })
+
+      context('.takerFee', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await guarantee.store({
+            ...DEFAULT_GUARANTEE,
+            takerFee: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await guarantee.read()
+          expect(value.takerFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if takerFee out of range', async () => {
+          await expect(
+            guarantee.store({
+              ...DEFAULT_GUARANTEE,
+              takerFee: BigNumber.from(2).pow(STORAGE_SIZE),
             }),
           ).to.be.revertedWithCustomError(guarantee, 'GuaranteeStorageInvalidError')
         })

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -111,7 +111,7 @@ describe('Version', () => {
     global: GlobalStruct,
     fromPosition: PositionStruct,
     order: OrderStruct,
-    guarantee: Guarantee,
+    guarantee: GuaranteeStruct,
     fromOracleVersion: OracleVersionStruct,
     toOracleVersion: OracleVersionStruct,
     marketParameter: MarketParameterStruct,


### PR DESCRIPTION
Updates the intent fill logic to only charge the `takerFee` (and it's associated sub-fees) to the maker side of the intent order pair during a fill.