### PR TITLE
[v2.2] Make updateRiskParameter migration-safe

### DIFF
--- a/packages/perennial-extensions/contracts/Coordinator.sol
+++ b/packages/perennial-extensions/contracts/Coordinator.sol
@@ -45,6 +45,6 @@ contract Coordinator is ICoordinator, Ownable {
     /// @param riskParameter The new risk parameter
     function updateRiskParameter(IMarket market, RiskParameter calldata riskParameter) external {
         if (msg.sender != coordinator) revert NotCoordinator();
-        market.updateRiskParameter(riskParameter);
+        market.updateRiskParameter(riskParameter, false);
     }
 }

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -319,7 +319,7 @@ export async function createMarket(
 
   const market = Market__factory.connect(marketAddress, owner)
 
-  await market.updateRiskParameter(riskParameter)
+  await market.updateRiskParameter(riskParameter, false)
   await market.updateParameter(beneficiaryB.address, constants.AddressZero, marketParameter)
 
   return market

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -380,7 +380,7 @@ testOracles.forEach(testOracle => {
         oracle: oracle.address,
       })
       await market.updateParameter(ethers.constants.AddressZero, ethers.constants.AddressZero, marketParameter)
-      await market.updateRiskParameter(riskParameter)
+      await market.updateRiskParameter(riskParameter, false)
 
       oracleSigner = await impersonateWithBalance(oracle.address, utils.parseEther('10'))
       factorySigner = await impersonateWithBalance(metaquantsOracleFactory.address, utils.parseEther('10'))

--- a/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -309,7 +309,7 @@ testOracles.forEach(testOracle => {
         oracle: oracle.address,
       })
       await market.updateParameter(ethers.constants.AddressZero, ethers.constants.AddressZero, marketParameter)
-      await market.updateRiskParameter(riskParameter)
+      await market.updateRiskParameter(riskParameter, false)
 
       market2 = Market__factory.connect(
         await marketFactory.callStatic.create({
@@ -323,7 +323,7 @@ testOracles.forEach(testOracle => {
         oracle: oracle2.address,
       })
       await market2.updateParameter(ethers.constants.AddressZero, ethers.constants.AddressZero, marketParameter)
-      await market2.updateRiskParameter(riskParameter)
+      await market2.updateRiskParameter(riskParameter, false)
 
       oracleSigner = await impersonateWithBalance(oracle.address, utils.parseEther('10'))
       factorySigner = await impersonateWithBalance(pythOracleFactory.address, utils.parseEther('10'))

--- a/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -359,7 +359,7 @@ testOracles.forEach(testOracle => {
         oracle: oracle.address,
       })
       await market.updateParameter(ethers.constants.AddressZero, ethers.constants.AddressZero, marketParameter)
-      await market.updateRiskParameter(riskParameter)
+      await market.updateRiskParameter(riskParameter, false)
 
       oracleSigner = await impersonateWithBalance(oracle.address, utils.parseEther('10'))
       factorySigner = await impersonateWithBalance(chainlinkOracleFactory.address, utils.parseEther('10'))

--- a/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
@@ -97,7 +97,7 @@ export async function deployProductOnMainnetFork({
   await factory.connect(owner).create(marketDefinition)
 
   const market = IMarket__factory.connect(productAddress, owner)
-  await market.connect(owner).updateRiskParameter(riskParameter)
+  await market.connect(owner).updateRiskParameter(riskParameter, false)
   await market.connect(owner).updateParameter(constants.AddressZero, constants.AddressZero, marketParameter)
 
   return market

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1416,21 +1416,27 @@ describe('Vault', () => {
 
     it('multiple users w/ makerFee', async () => {
       const riskParameters = { ...(await market.riskParameter()) }
-      await market.updateRiskParameter({
-        ...riskParameters,
-        makerFee: {
-          ...riskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await market.updateRiskParameter(
+        {
+          ...riskParameters,
+          makerFee: {
+            ...riskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
       const btcRiskParameters = { ...(await btcMarket.riskParameter()) }
-      await btcMarket.updateRiskParameter({
-        ...btcRiskParameters,
-        makerFee: {
-          ...btcRiskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await btcMarket.updateRiskParameter(
+        {
+          ...btcRiskParameters,
+          makerFee: {
+            ...btcRiskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
 
       expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
       expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))
@@ -1532,21 +1538,27 @@ describe('Vault', () => {
 
     it('multiple users w/ makerFee + settlement fee', async () => {
       const riskParameters = { ...(await market.riskParameter()) }
-      await market.updateRiskParameter({
-        ...riskParameters,
-        makerFee: {
-          ...riskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await market.updateRiskParameter(
+        {
+          ...riskParameters,
+          makerFee: {
+            ...riskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
       const btcRiskParameters = { ...(await btcMarket.riskParameter()) }
-      await btcMarket.updateRiskParameter({
-        ...btcRiskParameters,
-        makerFee: {
-          ...btcRiskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await btcMarket.updateRiskParameter(
+        {
+          ...btcRiskParameters,
+          makerFee: {
+            ...btcRiskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
 
       const settlementFee = parse6decimal('1.00')
       const marketParameter = { ...(await market.parameter()) }
@@ -1697,13 +1709,16 @@ describe('Vault', () => {
 
     it('simple deposits and redemptions w/ factory initial amount (with fees)', async () => {
       const riskParameters = { ...(await market.riskParameter()) }
-      await market.updateRiskParameter({
-        ...riskParameters,
-        makerFee: {
-          ...riskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await market.updateRiskParameter(
+        {
+          ...riskParameters,
+          makerFee: {
+            ...riskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
 
       const settlementFee = parse6decimal('1.00')
       const marketParameter = { ...(await market.parameter()) }
@@ -1743,21 +1758,27 @@ describe('Vault', () => {
 
     it('zero address settle w/ settlement fee', async () => {
       const riskParameters = { ...(await market.riskParameter()) }
-      await market.updateRiskParameter({
-        ...riskParameters,
-        makerFee: {
-          ...riskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await market.updateRiskParameter(
+        {
+          ...riskParameters,
+          makerFee: {
+            ...riskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
       const btcRiskParameters = { ...(await btcMarket.riskParameter()) }
-      await btcMarket.updateRiskParameter({
-        ...btcRiskParameters,
-        makerFee: {
-          ...btcRiskParameters.makerFee,
-          linearFee: parse6decimal('0.001'),
+      await btcMarket.updateRiskParameter(
+        {
+          ...btcRiskParameters,
+          makerFee: {
+            ...btcRiskParameters.makerFee,
+            linearFee: parse6decimal('0.001'),
+          },
         },
-      })
+        false,
+      )
 
       const settlementFee = parse6decimal('1.00')
       const marketParameter = { ...(await market.parameter()) }

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -173,24 +173,35 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
     /// @notice Updates the risk parameter set of the market
     /// @param newRiskParameter The new risk parameter set
-    function updateRiskParameter(RiskParameter memory newRiskParameter) external onlyCoordinator {
-
-        // credit impact update fee to the protocol account
+    function updateRiskParameter(RiskParameter memory newRiskParameter, bool isMigration) external onlyCoordinator {
+        // v2.2 migration note - storage layout backwards compatible
+        // only .exposure added, which correctly defaults to 0
         Global memory newGlobal = _global.read();
+
+        // v2.2 migration note - storage layout backwards compatible
+        // .long, .short, .maker preserved in place which are the only fields utilized here
         Position memory latestPosition = _position.read();
-        RiskParameter memory latestRiskParameter = _riskParameter.read();
-        OracleVersion memory latestVersion = oracle.at(latestPosition.timestamp);
 
+        RiskParameter memory latestRiskParameter;
+        if (isMigration) {
+            // v2.2 migration note - kick off adiabatic parameters with non-zero scale
+            // .adiabaticFee parameter of zero will correctly result in a latest exposure of zero no matter the skew
+            (latestRiskParameter.makerFee.scale, latestRiskParameter.takerFee.scale) = (UFixed6Lib.ONE, UFixed6Lib.ONE);
+        } else {
+            latestRiskParameter = _riskParameter.read();
+        }
+
+        // Accrue the PnL from the change in exposure of the adiabatic fee due to parameter change
         Fixed6 updateFee = latestRiskParameter.makerFee
-            .update(newRiskParameter.makerFee, latestPosition.maker, latestVersion.price.abs())
+            .update(newRiskParameter.makerFee, latestPosition.maker, newGlobal.latestPrice.abs())
             .add(latestRiskParameter.takerFee
-                .update(newRiskParameter.takerFee, latestPosition.skew(), latestVersion.price.abs()));
-
+                .update(newRiskParameter.takerFee, latestPosition.skew(), newGlobal.latestPrice.abs()));
         newGlobal.exposure = newGlobal.exposure.sub(updateFee);
-        _global.store(newGlobal);
 
         // update
+        _global.store(newGlobal);
         _riskParameter.validateAndStore(newRiskParameter, IMarketFactory(address(factory())).parameter());
+
         emit RiskParameterUpdated(newRiskParameter);
     }
 

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -147,6 +147,6 @@ interface IMarket is IInstance {
     function riskParameter() external view returns (RiskParameter memory);
     function updateOracle(IOracleProvider newOracle) external;
     function updateParameter(address newBeneficiary, address newCoordinator, MarketParameter memory newParameter) external;
-    function updateRiskParameter(RiskParameter memory newRiskParameter) external;
+    function updateRiskParameter(RiskParameter memory newRiskParameter, bool isMigration) external;
     function claimFee() external;
 }

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -185,7 +185,7 @@ describe('Fees', () => {
       riskParamsMakerFee.proportionalFee = BigNumber.from('0')
       riskParamsMakerFee.adiabaticFee = BigNumber.from('0')
       riskParams.makerFee = riskParamsMakerFee
-      await market.updateRiskParameter(riskParams)
+      await market.updateRiskParameter(riskParams, false)
 
       const POSITION = parse6decimal('10')
       const COLLATERAL = parse6decimal('1000')
@@ -204,7 +204,7 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await settle(market, user)
 
-      await market.updateRiskParameter(previousRiskParams)
+      await market.updateRiskParameter(previousRiskParams, false)
       await market.connect(user)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false)
 
       // Settle the market with a new oracle version
@@ -274,7 +274,7 @@ describe('Fees', () => {
       riskParamsMakerFee.proportionalFee = BigNumber.from('0')
       riskParamsMakerFee.adiabaticFee = BigNumber.from('0')
       riskParams.makerFee = riskParamsMakerFee
-      await market.updateRiskParameter(riskParams)
+      await market.updateRiskParameter(riskParams, false)
 
       const MAKER_POSITION = parse6decimal('10')
       const LONG_POSITION = parse6decimal('1')
@@ -382,7 +382,7 @@ describe('Fees', () => {
       riskParamsMakerFee.proportionalFee = BigNumber.from('0')
       riskParamsMakerFee.adiabaticFee = BigNumber.from('0')
       riskParams.makerFee = riskParamsMakerFee
-      await market.updateRiskParameter(riskParams)
+      await market.updateRiskParameter(riskParams, false)
 
       const MAKER_POSITION = parse6decimal('10')
       const LONG_POSITION = parse6decimal('1')
@@ -519,21 +519,24 @@ describe('Fees', () => {
     it('charges take fees on long close', async () => {
       const riskParams = await market.riskParameter()
       const marketParams = await market.parameter()
-      await market.updateRiskParameter({
-        ...riskParams,
-        makerFee: {
-          ...riskParams.makerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
+      await market.updateRiskParameter(
+        {
+          ...riskParams,
+          makerFee: {
+            ...riskParams.makerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          takerFee: {
+            ...riskParams.takerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
         },
-        takerFee: {
-          ...riskParams.takerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
-        },
-      })
+        false,
+      )
       await market.updateParameter(AddressZero, AddressZero, {
         ...marketParams,
         fundingFee: BigNumber.from('0'),
@@ -580,20 +583,23 @@ describe('Fees', () => {
       await updateNoOp(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
-      await market.updateRiskParameter({
-        ...riskParams,
-        makerFee: {
-          ...riskParams.makerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
+      await market.updateRiskParameter(
+        {
+          ...riskParams,
+          makerFee: {
+            ...riskParams.makerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          takerFee: {
+            ...riskParams.takerFee,
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
         },
-        takerFee: {
-          ...riskParams.takerFee,
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
-        },
-      })
+        false,
+      )
       await market
         .connect(userB)
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
@@ -694,7 +700,7 @@ describe('Fees', () => {
       riskParamsMakerFee.proportionalFee = BigNumber.from('0')
       riskParamsMakerFee.adiabaticFee = BigNumber.from('0')
       riskParams.makerFee = riskParamsMakerFee
-      await market.updateRiskParameter(riskParams)
+      await market.updateRiskParameter(riskParams, false)
 
       const MAKER_POSITION = parse6decimal('10')
       const SHORT_POSITION = parse6decimal('1')
@@ -802,7 +808,7 @@ describe('Fees', () => {
       riskParamsMakerFee.proportionalFee = BigNumber.from('0')
       riskParamsMakerFee.adiabaticFee = BigNumber.from('0')
       riskParams.makerFee = riskParamsMakerFee
-      await market.updateRiskParameter(riskParams)
+      await market.updateRiskParameter(riskParams, false)
 
       const MAKER_POSITION = parse6decimal('10')
       const SHORT_POSITION = parse6decimal('1')
@@ -939,21 +945,24 @@ describe('Fees', () => {
     it('charges take fees on short close', async () => {
       const riskParams = await market.riskParameter()
       const marketParams = await market.parameter()
-      await market.updateRiskParameter({
-        ...riskParams,
-        makerFee: {
-          ...riskParams.makerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
+      await market.updateRiskParameter(
+        {
+          ...riskParams,
+          makerFee: {
+            ...riskParams.makerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          takerFee: {
+            ...riskParams.takerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
         },
-        takerFee: {
-          ...riskParams.takerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
-        },
-      })
+        false,
+      )
       await market.updateParameter(AddressZero, AddressZero, {
         ...marketParams,
         fundingFee: BigNumber.from('0'),
@@ -1000,20 +1009,23 @@ describe('Fees', () => {
       await updateNoOp(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
-      await market.updateRiskParameter({
-        ...riskParams,
-        makerFee: {
-          ...riskParams.makerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
+      await market.updateRiskParameter(
+        {
+          ...riskParams,
+          makerFee: {
+            ...riskParams.makerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          takerFee: {
+            ...riskParams.takerFee,
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
         },
-        takerFee: {
-          ...riskParams.takerFee,
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
-        },
-      })
+        false,
+      )
       await market
         .connect(userB)
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
@@ -1115,21 +1127,24 @@ describe('Fees', () => {
 
       beforeEach(async () => {
         const riskParams = { ...(await market.riskParameter()) }
-        await market.updateRiskParameter({
-          ...riskParams,
-          makerFee: {
-            ...riskParams.makerFee,
-            linearFee: BigNumber.from('0'),
-            proportionalFee: BigNumber.from('0'),
-            adiabaticFee: BigNumber.from('0'),
+        await market.updateRiskParameter(
+          {
+            ...riskParams,
+            makerFee: {
+              ...riskParams.makerFee,
+              linearFee: BigNumber.from('0'),
+              proportionalFee: BigNumber.from('0'),
+              adiabaticFee: BigNumber.from('0'),
+            },
+            takerFee: {
+              ...riskParams.takerFee,
+              linearFee: BigNumber.from('0'),
+              proportionalFee: parse6decimal('0.01'),
+              adiabaticFee: BigNumber.from('0'),
+            },
           },
-          takerFee: {
-            ...riskParams.takerFee,
-            linearFee: BigNumber.from('0'),
-            proportionalFee: parse6decimal('0.01'),
-            adiabaticFee: BigNumber.from('0'),
-          },
-        })
+          false,
+        )
 
         const { user, userB, userC, dsu } = instanceVars
 
@@ -1219,21 +1234,24 @@ describe('Fees', () => {
 
       beforeEach(async () => {
         const riskParams = { ...(await market.riskParameter()) }
-        await market.updateRiskParameter({
-          ...riskParams,
-          makerFee: {
-            ...riskParams.makerFee,
-            linearFee: BigNumber.from('0'),
-            proportionalFee: BigNumber.from('0'),
-            adiabaticFee: BigNumber.from('0'),
+        await market.updateRiskParameter(
+          {
+            ...riskParams,
+            makerFee: {
+              ...riskParams.makerFee,
+              linearFee: BigNumber.from('0'),
+              proportionalFee: BigNumber.from('0'),
+              adiabaticFee: BigNumber.from('0'),
+            },
+            takerFee: {
+              ...riskParams.takerFee,
+              linearFee: BigNumber.from('0'),
+              proportionalFee: BigNumber.from('0'),
+              adiabaticFee: parse6decimal('0.02'),
+            },
           },
-          takerFee: {
-            ...riskParams.takerFee,
-            linearFee: BigNumber.from('0'),
-            proportionalFee: BigNumber.from('0'),
-            adiabaticFee: parse6decimal('0.02'),
-          },
-        })
+          false,
+        )
 
         const { user, userB, userC, dsu } = instanceVars
 
@@ -1317,14 +1335,17 @@ describe('Fees', () => {
 
         // Enable position fee to test refund
         const riskParams = await market.riskParameter()
-        await market.updateRiskParameter({
-          ...riskParams,
-          takerFee: {
-            ...riskParams.takerFee,
-            linearFee: parse6decimal('0.01'),
-            adiabaticFee: parse6decimal('0.02'),
+        await market.updateRiskParameter(
+          {
+            ...riskParams,
+            takerFee: {
+              ...riskParams.takerFee,
+              linearFee: parse6decimal('0.01'),
+              adiabaticFee: parse6decimal('0.02'),
+            },
           },
-        })
+          false,
+        )
         // Bring skew from -100% to 0% -> total impact change of -100%
         await market
           .connect(userC)
@@ -1363,14 +1384,17 @@ describe('Fees', () => {
 
         // Enable position fee to test refund
         const riskParams = await market.riskParameter()
-        await market.updateRiskParameter({
-          ...riskParams,
-          takerFee: {
-            ...riskParams.takerFee,
-            linearFee: parse6decimal('0.01'),
-            adiabaticFee: parse6decimal('0.04'),
+        await market.updateRiskParameter(
+          {
+            ...riskParams,
+            takerFee: {
+              ...riskParams.takerFee,
+              linearFee: parse6decimal('0.01'),
+              adiabaticFee: parse6decimal('0.04'),
+            },
           },
-        })
+          false,
+        )
         // Bring skew from -100% to 0% -> total impact change of -100%
         await market
           .connect(userC)
@@ -1399,21 +1423,24 @@ describe('Fees', () => {
       beforeEach(async () => {
         const riskParams = await market.riskParameter()
         const marketParams = await market.parameter()
-        await market.updateRiskParameter({
-          ...riskParams,
-          makerFee: {
-            ...riskParams.makerFee,
-            linearFee: BigNumber.from('0'),
-            proportionalFee: BigNumber.from('0'),
-            adiabaticFee: BigNumber.from('0'),
+        await market.updateRiskParameter(
+          {
+            ...riskParams,
+            makerFee: {
+              ...riskParams.makerFee,
+              linearFee: BigNumber.from('0'),
+              proportionalFee: BigNumber.from('0'),
+              adiabaticFee: BigNumber.from('0'),
+            },
+            takerFee: {
+              ...riskParams.takerFee,
+              linearFee: BigNumber.from('0'),
+              proportionalFee: BigNumber.from('0'),
+              adiabaticFee: BigNumber.from('0'),
+            },
           },
-          takerFee: {
-            ...riskParams.takerFee,
-            linearFee: BigNumber.from('0'),
-            proportionalFee: BigNumber.from('0'),
-            adiabaticFee: BigNumber.from('0'),
-          },
-        })
+          false,
+        )
 
         const { user, userB, userC, dsu } = instanceVars
 
@@ -1520,27 +1547,30 @@ describe('Fees', () => {
 
     beforeEach(async () => {
       const riskParams = await market.riskParameter()
-      await market.updateRiskParameter({
-        ...riskParams,
-        makerFee: {
-          ...riskParams.makerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
+      await market.updateRiskParameter(
+        {
+          ...riskParams,
+          makerFee: {
+            ...riskParams.makerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          takerFee: {
+            ...riskParams.takerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          utilizationCurve: {
+            minRate: parse6decimal('0.01'),
+            maxRate: parse6decimal('0.01'),
+            targetRate: parse6decimal('0.01'),
+            targetUtilization: parse6decimal('1'),
+          },
         },
-        takerFee: {
-          ...riskParams.takerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
-        },
-        utilizationCurve: {
-          minRate: parse6decimal('0.01'),
-          maxRate: parse6decimal('0.01'),
-          targetRate: parse6decimal('0.01'),
-          targetUtilization: parse6decimal('1'),
-        },
-      })
+        false,
+      )
 
       const { user, userB, userC, dsu } = instanceVars
 
@@ -1640,26 +1670,29 @@ describe('Fees', () => {
 
     beforeEach(async () => {
       const riskParams = await market.riskParameter()
-      await market.updateRiskParameter({
-        ...riskParams,
-        makerFee: {
-          ...riskParams.makerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
+      await market.updateRiskParameter(
+        {
+          ...riskParams,
+          makerFee: {
+            ...riskParams.makerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          takerFee: {
+            ...riskParams.takerFee,
+            linearFee: BigNumber.from('0'),
+            proportionalFee: BigNumber.from('0'),
+            adiabaticFee: BigNumber.from('0'),
+          },
+          pController: {
+            k: parse6decimal('10'),
+            min: parse6decimal('-1.20'),
+            max: parse6decimal('1.20'),
+          },
         },
-        takerFee: {
-          ...riskParams.takerFee,
-          linearFee: BigNumber.from('0'),
-          proportionalFee: BigNumber.from('0'),
-          adiabaticFee: BigNumber.from('0'),
-        },
-        pController: {
-          k: parse6decimal('10'),
-          min: parse6decimal('-1.20'),
-          max: parse6decimal('1.20'),
-        },
-      })
+        false,
+      )
 
       const { user, userB, userC, dsu } = instanceVars
 

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -107,7 +107,7 @@ describe('Happy Path', () => {
     const marketAddress = await marketFactory.callStatic.create(definition)
     await expect(marketFactory.create(definition)).to.emit(marketFactory, 'MarketCreated')
     const market = Market__factory.connect(marketAddress, owner)
-    await market.connect(owner).updateRiskParameter(riskParameter)
+    await market.connect(owner).updateRiskParameter(riskParameter, false)
     await market.connect(owner).updateParameter(beneficiaryB.address, AddressZero, parameter)
   })
 
@@ -506,7 +506,7 @@ describe('Happy Path', () => {
     const riskParameterTakerFee = { ...riskParameter.takerFee }
     riskParameterTakerFee.scale = parse6decimal('1')
     riskParameter.takerFee = riskParameterTakerFee
-    await market.updateRiskParameter(riskParameter)
+    await market.updateRiskParameter(riskParameter, false)
 
     await dsu.connect(user).approve(market.address, COLLATERAL.mul(1e12))
     await dsu.connect(userB).approve(market.address, COLLATERAL.mul(1e12))
@@ -661,7 +661,7 @@ describe('Happy Path', () => {
     const riskParameterTakerFee = { ...riskParameter.takerFee }
     riskParameterTakerFee.scale = parse6decimal('1')
     riskParameter.takerFee = riskParameterTakerFee
-    await market.updateRiskParameter(riskParameter)
+    await market.updateRiskParameter(riskParameter, false)
 
     await dsu.connect(user).approve(market.address, COLLATERAL.mul(1e12))
     await dsu.connect(userB).approve(market.address, COLLATERAL.mul(1e12))
@@ -988,7 +988,7 @@ describe('Happy Path', () => {
     const riskParameterTakerFee = { ...riskParameter.takerFee }
     riskParameterTakerFee.scale = parse6decimal('1')
     riskParameter.takerFee = riskParameterTakerFee
-    await market.updateRiskParameter(riskParameter)
+    await market.updateRiskParameter(riskParameter, false)
 
     await dsu.connect(user).approve(market.address, COLLATERAL.mul(1e12))
     await dsu.connect(userB).approve(market.address, COLLATERAL.mul(1e12))
@@ -1029,7 +1029,7 @@ describe('Happy Path', () => {
     const riskParameterTakerFee = { ...riskParameter.takerFee }
     riskParameterTakerFee.scale = parse6decimal('1')
     riskParameter.takerFee = riskParameterTakerFee
-    await market.updateRiskParameter(riskParameter)
+    await market.updateRiskParameter(riskParameter, false)
 
     await dsu.connect(user).approve(market.address, COLLATERAL.mul(1e12))
     await dsu.connect(userB).approve(market.address, COLLATERAL.mul(1e12))
@@ -1118,7 +1118,7 @@ describe('Happy Path', () => {
 
     const market = await createMarket(instanceVars)
     await market.updateParameter(beneficiaryB.address, AddressZero, parameter)
-    await market.updateRiskParameter(riskParameter)
+    await market.updateRiskParameter(riskParameter, false)
 
     await dsu.connect(user).approve(market.address, COLLATERAL.mul(2).mul(1e12))
     await dsu.connect(userB).approve(market.address, COLLATERAL.mul(2).mul(1e12))
@@ -1278,7 +1278,7 @@ describe('Happy Path', () => {
 
     const market = await createMarket(instanceVars)
     await market.updateParameter(beneficiaryB.address, AddressZero, parameter)
-    await market.updateRiskParameter(riskParameter)
+    await market.updateRiskParameter(riskParameter, false)
 
     await dsu.connect(user).approve(market.address, COLLATERAL.mul(2).mul(1e12))
     await dsu.connect(userB).approve(market.address, COLLATERAL.mul(2).mul(1e12))

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -258,7 +258,7 @@ export async function createMarket(
   await marketFactory.create(definition)
 
   const market = Market__factory.connect(marketAddress, owner)
-  await market.updateRiskParameter(riskParameter)
+  await market.updateRiskParameter(riskParameter, false)
   await market.updateParameter(beneficiaryB.address, constants.AddressZero, marketParameter)
 
   return market

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -563,7 +563,7 @@ describe('Market', () => {
   context('already initialized', async () => {
     beforeEach(async () => {
       await market.connect(factorySigner).initialize(marketDefinition)
-      await market.connect(owner).updateRiskParameter(riskParameter)
+      await market.connect(owner).updateRiskParameter(riskParameter, false)
     })
 
     describe('#updateOracle', async () => {
@@ -687,7 +687,7 @@ describe('Market', () => {
       }
 
       it('updates the parameters (owner)', async () => {
-        await expect(market.connect(owner).updateRiskParameter(defaultRiskParameter)).to.emit(
+        await expect(market.connect(owner).updateRiskParameter(defaultRiskParameter, false)).to.emit(
           market,
           'RiskParameterUpdated',
         )
@@ -722,7 +722,7 @@ describe('Market', () => {
 
       it('updates the parameters (coordinator)', async () => {
         await market.connect(owner).updateParameter(beneficiary.address, coordinator.address, await market.parameter())
-        await expect(market.connect(coordinator).updateRiskParameter(defaultRiskParameter)).to.emit(
+        await expect(market.connect(coordinator).updateRiskParameter(defaultRiskParameter, false)).to.emit(
           market,
           'RiskParameterUpdated',
         )
@@ -783,7 +783,7 @@ describe('Market', () => {
 
         // test the risk parameter update
         await market.connect(owner).updateParameter(beneficiary.address, coordinator.address, await market.parameter())
-        await expect(market.connect(coordinator).updateRiskParameter(defaultRiskParameter)).to.emit(
+        await expect(market.connect(coordinator).updateRiskParameter(defaultRiskParameter, false)).to.emit(
           market,
           'RiskParameterUpdated',
         )
@@ -978,7 +978,7 @@ describe('Market', () => {
         })
 
         // update risk parameters, introducing exposure
-        await expect(market.connect(owner).updateRiskParameter(defaultRiskParameter)).to.emit(
+        await expect(market.connect(owner).updateRiskParameter(defaultRiskParameter, false)).to.emit(
           market,
           'RiskParameterUpdated',
         )
@@ -1034,10 +1034,9 @@ describe('Market', () => {
       })
 
       it('reverts if not owner or coordinator', async () => {
-        await expect(market.connect(user).updateRiskParameter(defaultRiskParameter)).to.be.revertedWithCustomError(
-          market,
-          'MarketNotCoordinatorError',
-        )
+        await expect(
+          market.connect(user).updateRiskParameter(defaultRiskParameter, false),
+        ).to.be.revertedWithCustomError(market, 'MarketNotCoordinatorError')
       })
     })
 
@@ -2244,7 +2243,7 @@ describe('Market', () => {
             riskParameterMakerFee.linearFee = parse6decimal('0.005')
             riskParameterMakerFee.proportionalFee = parse6decimal('0.0025')
             riskParameter.makerFee = riskParameterMakerFee
-            await market.updateRiskParameter(riskParameter)
+            await market.updateRiskParameter(riskParameter, false)
 
             const marketParameter = { ...(await market.parameter()) }
             marketParameter.settlementFee = parse6decimal('0.50')
@@ -2841,7 +2840,7 @@ describe('Market', () => {
               riskParameterMakerFee.linearFee = parse6decimal('0.005')
               riskParameterMakerFee.proportionalFee = parse6decimal('0.0025')
               riskParameter.makerFee = riskParameterMakerFee
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               const marketParameter = { ...(await market.parameter()) }
               marketParameter.settlementFee = parse6decimal('0.50')
@@ -3565,7 +3564,7 @@ describe('Market', () => {
               riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
               riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
               riskParameter.takerFee = riskParameterTakerFee
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               const marketParameter = { ...(await market.parameter()) }
               marketParameter.settlementFee = parse6decimal('0.50')
@@ -3696,7 +3695,7 @@ describe('Market', () => {
               riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
               riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
               riskParameter.takerFee = riskParameterTakerFee
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               const marketParameter = { ...(await market.parameter()) }
               marketParameter.settlementFee = parse6decimal('0.50')
@@ -4295,7 +4294,7 @@ describe('Market', () => {
                 const riskParameterTakerFee = { ...riskParameter.takerFee }
                 riskParameterTakerFee.scale = POSITION.div(4)
                 riskParameter.takerFee = riskParameterTakerFee
-                await market.updateRiskParameter(riskParameter)
+                await market.updateRiskParameter(riskParameter, false)
 
                 await market
                   .connect(user)
@@ -4527,7 +4526,7 @@ describe('Market', () => {
                 riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
                 riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
                 riskParameter.takerFee = riskParameterTakerFee
-                await market.updateRiskParameter(riskParameter)
+                await market.updateRiskParameter(riskParameter, false)
 
                 const marketParameter = { ...(await market.parameter()) }
                 marketParameter.settlementFee = parse6decimal('0.50')
@@ -5495,7 +5494,7 @@ describe('Market', () => {
 
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.liquidationFee = parse6decimal('100')
-              await market.connect(owner).updateRiskParameter(riskParameter)
+              await market.connect(owner).updateRiskParameter(riskParameter, false)
 
               await settle(market, user)
               await settle(market, userB)
@@ -5908,7 +5907,7 @@ describe('Market', () => {
             it('with shortfall', async () => {
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.minMaintenance = parse6decimal('50')
-              await market.connect(owner).updateRiskParameter(riskParameter)
+              await market.connect(owner).updateRiskParameter(riskParameter, false)
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
               oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
@@ -6755,7 +6754,7 @@ describe('Market', () => {
             it('opens the position and settles later', async () => {
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.staleAfter = BigNumber.from(9600)
-              await market.connect(owner).updateRiskParameter(riskParameter)
+              await market.connect(owner).updateRiskParameter(riskParameter, false)
 
               await expect(
                 market
@@ -6868,7 +6867,7 @@ describe('Market', () => {
               riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
               riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
               riskParameter.takerFee = riskParameterTakerFee
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               const marketParameter = { ...(await market.parameter()) }
               marketParameter.settlementFee = parse6decimal('0.50')
@@ -7002,7 +7001,7 @@ describe('Market', () => {
               riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
               riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
               riskParameter.takerFee = riskParameterTakerFee
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               const marketParameter = { ...(await market.parameter()) }
               marketParameter.settlementFee = parse6decimal('0.50')
@@ -7607,7 +7606,7 @@ describe('Market', () => {
                 const riskParameterTakerFee = { ...riskParameter.takerFee }
                 riskParameterTakerFee.scale = POSITION.div(4)
                 riskParameter.takerFee = riskParameterTakerFee
-                await market.updateRiskParameter(riskParameter)
+                await market.updateRiskParameter(riskParameter, false)
 
                 await market
                   .connect(user)
@@ -7842,7 +7841,7 @@ describe('Market', () => {
                 riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
                 riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
                 riskParameter.takerFee = riskParameterTakerFee
-                await market.updateRiskParameter(riskParameter)
+                await market.updateRiskParameter(riskParameter, false)
 
                 const marketParameter = { ...(await market.parameter()) }
                 marketParameter.settlementFee = parse6decimal('0.50')
@@ -8340,7 +8339,7 @@ describe('Market', () => {
             beforeEach(async () => {
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.margin = parse6decimal('0.31')
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               dsu.transferFrom.whenCalledWith(userB.address, market.address, utils.parseEther('390')).returns(true)
               await market
@@ -9214,7 +9213,7 @@ describe('Market', () => {
             it('with shortfall', async () => {
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.minMaintenance = parse6decimal('50')
-              await market.connect(owner).updateRiskParameter(riskParameter)
+              await market.connect(owner).updateRiskParameter(riskParameter, false)
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
               oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
@@ -9543,7 +9542,7 @@ describe('Market', () => {
             riskParameterMakerFee.proportionalFee = parse6decimal('0.004')
             riskParameter.takerFee = riskParmeterTakerFee
             riskParameter.makerFee = riskParameterMakerFee
-            await market.updateRiskParameter(riskParameter)
+            await market.updateRiskParameter(riskParameter, false)
 
             const marketParameter = { ...(await market.parameter()) }
             marketParameter.settlementFee = parse6decimal('0.50')
@@ -9675,7 +9674,7 @@ describe('Market', () => {
           const riskParameterTakerFee = { ...riskParameter.takerFee }
           riskParameterTakerFee.scale = POSITION
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
         })
 
         context('position delta', async () => {
@@ -10351,7 +10350,7 @@ describe('Market', () => {
               riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
               riskParameterTakerFee.adiabaticFee = parse6decimal('0.004')
               riskParameter.takerFee = riskParameterTakerFee
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               const marketParameter = { ...(await market.parameter()) }
               marketParameter.settlementFee = parse6decimal('0.50')
@@ -11767,7 +11766,7 @@ describe('Market', () => {
                 riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
                 riskParameterTakerFee.adiabaticFee = parse6decimal('0.004')
                 riskParameter.takerFee = riskParameterTakerFee
-                await market.updateRiskParameter(riskParameter)
+                await market.updateRiskParameter(riskParameter, false)
 
                 const marketParameter = { ...(await market.parameter()) }
                 marketParameter.settlementFee = parse6decimal('0.50')
@@ -12581,7 +12580,7 @@ describe('Market', () => {
               await market
                 .connect(owner)
                 .updateParameter(beneficiary.address, coordinator.address, await market.parameter())
-              await expect(market.connect(coordinator).updateRiskParameter(adiabaticRiskParameter)).to.emit(
+              await expect(market.connect(coordinator).updateRiskParameter(adiabaticRiskParameter, false)).to.emit(
                 market,
                 'RiskParameterUpdated',
               )
@@ -13448,7 +13447,7 @@ describe('Market', () => {
             it('with shortfall', async () => {
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.minMaintenance = parse6decimal('50')
-              await market.connect(owner).updateRiskParameter(riskParameter)
+              await market.connect(owner).updateRiskParameter(riskParameter, false)
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
               oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
@@ -13827,7 +13826,7 @@ describe('Market', () => {
         it('reverts if over maker limit', async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.makerLimit = POSITION.div(2)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
           await expect(
             market
               .connect(user)
@@ -13838,7 +13837,7 @@ describe('Market', () => {
         it('reverts if under efficiency limit', async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.efficiencyLimit = parse6decimal('0.6')
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
           await market
@@ -14051,7 +14050,7 @@ describe('Market', () => {
 
         it('reverts if price is stale', async () => {
           const riskParameter = { ...(await market.riskParameter()), staleAfter: BigNumber.from(7200) }
-          await market.connect(owner).updateRiskParameter(riskParameter)
+          await market.connect(owner).updateRiskParameter(riskParameter, false)
 
           oracle.at.whenCalledWith(ORACLE_VERSION_1.timestamp).returns(ORACLE_VERSION_1)
           oracle.status.returns([ORACLE_VERSION_1, ORACLE_VERSION_3.timestamp - 1])
@@ -14083,7 +14082,7 @@ describe('Market', () => {
 
         it('reverts if sender is not account', async () => {
           const riskParameter = { ...(await market.riskParameter()), staleAfter: BigNumber.from(7200) }
-          await market.connect(owner).updateRiskParameter(riskParameter)
+          await market.connect(owner).updateRiskParameter(riskParameter, false)
 
           oracle.at.whenCalledWith(ORACLE_VERSION_1.timestamp).returns(ORACLE_VERSION_1)
           oracle.status.returns([ORACLE_VERSION_1, ORACLE_VERSION_3.timestamp - 1])
@@ -14163,7 +14162,7 @@ describe('Market', () => {
         it('reverts when the position is over-closed', async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.staleAfter = BigNumber.from(14400)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
           dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
@@ -14517,7 +14516,7 @@ describe('Market', () => {
 
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.5')
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               await expect(
                 market
@@ -14540,7 +14539,7 @@ describe('Market', () => {
 
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.3')
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               await expect(
                 market
@@ -14616,7 +14615,7 @@ describe('Market', () => {
 
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.5')
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               await expect(
                 market
@@ -14639,7 +14638,7 @@ describe('Market', () => {
 
               const riskParameter = { ...(await market.riskParameter()) }
               riskParameter.efficiencyLimit = parse6decimal('0.3')
-              await market.updateRiskParameter(riskParameter)
+              await market.updateRiskParameter(riskParameter, false)
 
               await expect(
                 market
@@ -14881,7 +14880,7 @@ describe('Market', () => {
         beforeEach(async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.staleAfter = BigNumber.from(14400)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
           await market
@@ -15617,7 +15616,7 @@ describe('Market', () => {
           riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -15766,7 +15765,7 @@ describe('Market', () => {
           riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -15974,7 +15973,7 @@ describe('Market', () => {
           riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -16170,7 +16169,7 @@ describe('Market', () => {
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
           riskParameter.staleAfter = BigNumber.from(9600)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -16360,7 +16359,7 @@ describe('Market', () => {
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
           riskParameter.staleAfter = BigNumber.from(9600)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -16850,7 +16849,7 @@ describe('Market', () => {
         it('flips funding when makerReceiveOnly', async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.makerReceiveOnly = true
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
           oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
@@ -17799,7 +17798,7 @@ describe('Market', () => {
         it('closes full position on MAX - 1 (pending)', async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.staleAfter = BigNumber.from(14400)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           await market
             .connect(userB)
@@ -17970,7 +17969,7 @@ describe('Market', () => {
         it('closes partial position on MAX - 1', async () => {
           const riskParameter = { ...(await market.riskParameter()) }
           riskParameter.staleAfter = BigNumber.from(14400)
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           await market
             .connect(userB)
@@ -18149,7 +18148,7 @@ describe('Market', () => {
           const riskParameterTakerFee = { ...riskParameter.takerFee }
           riskParameterTakerFee.scale = parse6decimal('15')
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
         })
@@ -18264,7 +18263,7 @@ describe('Market', () => {
             const riskParameterTakerFee = { ...riskParameter.takerFee }
             riskParameterTakerFee.scale = parse6decimal('1')
             riskParameter.takerFee = riskParameterTakerFee
-            await market.updateRiskParameter(riskParameter)
+            await market.updateRiskParameter(riskParameter, false)
 
             await market
               .connect(user)
@@ -18392,7 +18391,7 @@ describe('Market', () => {
             const riskParameterTakerFee = { ...riskParameter.takerFee }
             riskParameterTakerFee.scale = parse6decimal('1')
             riskParameter.takerFee = riskParameterTakerFee
-            await market.updateRiskParameter(riskParameter)
+            await market.updateRiskParameter(riskParameter, false)
 
             await market
               .connect(user)
@@ -18700,7 +18699,7 @@ describe('Market', () => {
           riskParameterMakerFee.linearFee = parse6decimal('0.005')
           riskParameterMakerFee.proportionalFee = parse6decimal('0.0025')
           riskParameter.makerFee = riskParameterMakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -18817,7 +18816,7 @@ describe('Market', () => {
           riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')
@@ -18968,7 +18967,7 @@ describe('Market', () => {
           riskParameterTakerFee.proportionalFee = parse6decimal('0.002')
           riskParameterTakerFee.adiabaticFee = parse6decimal('0.008')
           riskParameter.takerFee = riskParameterTakerFee
-          await market.updateRiskParameter(riskParameter)
+          await market.updateRiskParameter(riskParameter, false)
 
           const marketParameter = { ...(await market.parameter()) }
           marketParameter.settlementFee = parse6decimal('0.50')

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -38,6 +38,7 @@ import {
   expectCheckpointEq,
 } from '../../../../common/testutil/types'
 import { IMarket, MarketParameterStruct, RiskParameterStruct } from '../../../types/generated/contracts/Market'
+import { setStorageAt } from '@nomicfoundation/hardhat-network-helpers'
 
 const { ethers } = HRE
 use(smock.matchers)
@@ -1037,6 +1038,84 @@ describe('Market', () => {
         await expect(
           market.connect(user).updateRiskParameter(defaultRiskParameter, false),
         ).to.be.revertedWithCustomError(market, 'MarketNotCoordinatorError')
+      })
+
+      it('updates with isMigration=true and empty latest risk parameter', async () => {
+        // setup market with POSITION skew
+        await market.connect(owner).updateParameter(beneficiary.address, coordinator.address, marketParameter)
+
+        oracle.at.whenCalledWith(ORACLE_VERSION_0.timestamp).returns(ORACLE_VERSION_0)
+        oracle.at.whenCalledWith(ORACLE_VERSION_1.timestamp).returns(ORACLE_VERSION_1)
+
+        oracle.status.returns([ORACLE_VERSION_1, ORACLE_VERSION_2.timestamp])
+        oracle.request.whenCalledWith(user.address).returns()
+
+        dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+        await market
+          .connect(user)
+          ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false)
+        dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+        await market
+          .connect(userB)
+          ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, POSITION, 0, COLLATERAL, false)
+
+        oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
+        oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+        oracle.request.whenCalledWith(user.address).returns()
+
+        await settle(market, user)
+        await settle(market, userB)
+
+        // Manually set risk parameter to 0
+        await setStorageAt(market.address, 6, 0)
+        await setStorageAt(market.address, 7, 0)
+        await setStorageAt(market.address, 8, 0)
+
+        // test the migration risk parameter update
+        await market.connect(owner).updateParameter(beneficiary.address, coordinator.address, await market.parameter())
+        await expect(market.connect(coordinator).updateRiskParameter(defaultRiskParameter, true)).to.emit(
+          market,
+          'RiskParameterUpdated',
+        )
+
+        // Despite the market
+        expectGlobalEq(await market.global(), {
+          currentId: 2,
+          latestId: 1,
+          protocolFee: 0,
+          oracleFee: 0,
+          riskFee: 0,
+          donation: 0,
+          latestPrice: PRICE,
+          exposure: BigNumber.from(0).sub(parse6decimal('0.369')),
+        })
+
+        const riskParameter = await market.riskParameter()
+        expect(riskParameter.margin).to.equal(defaultRiskParameter.margin)
+        expect(riskParameter.maintenance).to.equal(defaultRiskParameter.maintenance)
+        expect(riskParameter.takerFee.linearFee).to.equal(defaultRiskParameter.takerFee.linearFee)
+        expect(riskParameter.takerFee.proportionalFee).to.equal(defaultRiskParameter.takerFee.proportionalFee)
+        expect(riskParameter.takerFee.adiabaticFee).to.equal(defaultRiskParameter.takerFee.adiabaticFee)
+        expect(riskParameter.takerFee.scale).to.equal(defaultRiskParameter.takerFee.scale)
+        expect(riskParameter.makerFee.linearFee).to.equal(defaultRiskParameter.makerFee.linearFee)
+        expect(riskParameter.makerFee.proportionalFee).to.equal(defaultRiskParameter.makerFee.proportionalFee)
+        expect(riskParameter.makerFee.adiabaticFee).to.equal(defaultRiskParameter.makerFee.adiabaticFee)
+        expect(riskParameter.makerFee.scale).to.equal(defaultRiskParameter.makerFee.scale)
+        expect(riskParameter.makerLimit).to.equal(defaultRiskParameter.makerLimit)
+        expect(riskParameter.efficiencyLimit).to.equal(defaultRiskParameter.efficiencyLimit)
+        expect(riskParameter.liquidationFee).to.equal(defaultRiskParameter.liquidationFee)
+        expect(riskParameter.utilizationCurve.minRate).to.equal(defaultRiskParameter.utilizationCurve.minRate)
+        expect(riskParameter.utilizationCurve.targetRate).to.equal(defaultRiskParameter.utilizationCurve.targetRate)
+        expect(riskParameter.utilizationCurve.maxRate).to.equal(defaultRiskParameter.utilizationCurve.maxRate)
+        expect(riskParameter.utilizationCurve.targetUtilization).to.equal(
+          defaultRiskParameter.utilizationCurve.targetUtilization,
+        )
+        expect(riskParameter.pController.k).to.equal(defaultRiskParameter.pController.k)
+        expect(riskParameter.pController.max).to.equal(defaultRiskParameter.pController.max)
+        expect(riskParameter.minMargin).to.equal(defaultRiskParameter.minMargin)
+        expect(riskParameter.minMaintenance).to.equal(defaultRiskParameter.minMaintenance)
+        expect(riskParameter.staleAfter).to.equal(defaultRiskParameter.staleAfter)
+        expect(riskParameter.makerReceiveOnly).to.equal(defaultRiskParameter.makerReceiveOnly)
       })
     })
 


### PR DESCRIPTION
Updates `updateRiskParameter()` to be compatible with our v2.2 migration flow by surfacing a `isMigration` flag which overrides the latestRiskParameter read with an empty read (w/ zero adiabatic fee), only setting the scale to avoid a divide-by-zero error.

Also updates the `Coordinator` for this new interface.

Cannot add a backwards compatible overload of the `updateRiskParameter` due to code size constraints.

### To Do
- [x] Update Market tests for new updateRiskParameter interface
- [x] Add test for migration case
- [x] Update Coordinator tests (mocks if needed)