### PR TITLE
[Delegate MultiInvoker Audit Fix] Use 'settle' instead of noOp 'update' in MultiInvoker

### DIFF
--- a/packages/perennial-extensions/contracts/MultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/MultiInvoker.sol
@@ -460,7 +460,7 @@ contract MultiInvoker is IMultiInvoker, Kept {
     /// @param market Market to settle
     /// @param account Account to settle
     function _marketSettle(IMarket market, address account) private {
-        _marketWithdraw(market, account, UFixed6Lib.ZERO);
+        market.settle(account);
     }
 
     /// @notice Target market must be created by MarketFactory


### PR DESCRIPTION
Uses `settle` instead of `update` in the execute order function in the MultiInvoker

https://github.com/sherlock-audit/2024-05-kwenta-x-perennial-integration-update-judging/issues/34