### PR TITLE
Remove Updated event

### DIFF
--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -630,7 +630,6 @@ describe('Orders', () => {
       .withArgs(user.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
       .to.emit(market, 'OrderCreated')
-      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -20024 }, { ...DEFAULT_GUARANTEE })
 
     const executorDSUNet = (await dsu.balanceOf(userC.address)).sub(executorBalanceBefore)
     const feeCharged = executorDSUNet.div(BigNumber.from(10).pow(12))

--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -5,7 +5,7 @@ import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs'
 import 'hardhat'
 
 import { expect } from 'chai'
-import { parse6decimal } from '../../../../common/testutil/types'
+import { parse6decimal, DEFAULT_ORDER, DEFAULT_GUARANTEE } from '../../../../common/testutil/types'
 import { IMultiInvoker, Market, MultiInvoker } from '../../../types/generated'
 import { Compare, Dir, openTriggerOrder } from '../../helpers/types'
 import {
@@ -440,21 +440,18 @@ describe('Orders', () => {
 
     const balanceBefore = await dsu.balanceOf(userB.address)
     const execute = buildExecOrder({ user: user.address, market: market.address, orderId: 1 })
+
     await expect(multiInvoker.connect(userC).invoke(execute))
       .to.emit(multiInvoker, 'OrderExecuted')
       .withArgs(user.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
-      .to.emit(market, 'Updated')
+      .to.emit(market, 'OrderCreated')
+      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 }, { ...DEFAULT_GUARANTEE })
+      .to.emit(market, 'OrderCreated')
       .withArgs(
-        multiInvoker.address,
         user.address,
-        anyValue,
-        anyValue,
-        anyValue,
-        anyValue,
-        -50e6,
-        false,
-        constants.AddressZero,
+        { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition },
+        { ...DEFAULT_GUARANTEE },
       )
       .to.emit(multiInvoker, 'InterfaceFeeCharged')
       .withArgs(user.address, market.address, { receiver: userB.address, amount: 50e6, unwrap: false })
@@ -493,17 +490,13 @@ describe('Orders', () => {
       .to.emit(multiInvoker, 'OrderExecuted')
       .withArgs(user.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
-      .to.emit(market, 'Updated')
+      .to.emit(market, 'OrderCreated')
+      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 }, { ...DEFAULT_GUARANTEE })
+      .to.emit(market, 'OrderCreated')
       .withArgs(
-        multiInvoker.address,
         user.address,
-        anyValue,
-        anyValue,
-        anyValue,
-        anyValue,
-        -50e6,
-        false,
-        constants.AddressZero,
+        { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition },
+        { ...DEFAULT_GUARANTEE },
       )
       .to.emit(multiInvoker, 'InterfaceFeeCharged')
       .withArgs(user.address, market.address, { receiver: userB.address, amount: 50e6, unwrap: true })
@@ -544,17 +537,13 @@ describe('Orders', () => {
       .to.emit(multiInvoker, 'OrderExecuted')
       .withArgs(user.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
-      .to.emit(market, 'Updated')
+      .to.emit(market, 'OrderCreated')
+      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 }, { ...DEFAULT_GUARANTEE })
+      .to.emit(market, 'OrderCreated')
       .withArgs(
-        multiInvoker.address,
         user.address,
-        anyValue,
-        anyValue,
-        anyValue,
-        anyValue,
-        -50e6,
-        false,
-        constants.AddressZero,
+        { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition },
+        { ...DEFAULT_GUARANTEE },
       )
       .to.emit(multiInvoker, 'InterfaceFeeCharged')
       .withArgs(user.address, market.address, { receiver: userB.address, amount: 50e6, unwrap: true })
@@ -597,17 +586,11 @@ describe('Orders', () => {
       .to.emit(multiInvoker, 'OrderExecuted')
       .withArgs(userB.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
-      .to.emit(market, 'Updated')
+      .to.emit(market, 'OrderCreated')
       .withArgs(
-        multiInvoker.address,
         userB.address,
-        anyValue,
-        anyValue,
-        anyValue,
-        anyValue,
-        collateral.div(-4),
-        false,
-        constants.AddressZero,
+        { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: collateral.div(-4) },
+        { ...DEFAULT_GUARANTEE },
       )
 
     expect(await usdc.balanceOf(userB.address)).to.eq(balanceBefore.add(collateral.div(4)))
@@ -641,22 +624,13 @@ describe('Orders', () => {
     const executorBalanceBefore = await dsu.balanceOf(userC.address)
     const balanceBefore = await usdc.balanceOf(user.address)
     const execute = buildExecOrder({ user: user.address, market: market.address, orderId: 1 })
+
     await expect(multiInvoker.connect(userC).invoke(execute))
       .to.emit(multiInvoker, 'OrderExecuted')
       .withArgs(user.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
-      .to.emit(market, 'Updated')
-      .withArgs(
-        multiInvoker.address,
-        user.address,
-        anyValue,
-        anyValue,
-        anyValue,
-        anyValue,
-        anyValue,
-        false,
-        constants.AddressZero,
-      )
+      .to.emit(market, 'OrderCreated')
+      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -19881 }, { ...DEFAULT_GUARANTEE })
 
     const executorDSUNet = (await dsu.balanceOf(userC.address)).sub(executorBalanceBefore)
     const feeCharged = executorDSUNet.div(BigNumber.from(10).pow(12))
@@ -908,9 +882,16 @@ describe('Orders', () => {
 
       await ethers.HRE.ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1000000'])
       const execute = buildExecOrder({ user: user.address, market: market.address, orderId: 1 })
+
       await expect(multiInvoker.connect(user).invoke(execute, { maxFeePerGas: 16777216 }))
-        .to.emit(market, 'Updated')
-        .withArgs(multiInvoker.address, user.address, 1631114005, 0, 0, 0, -10, false, constants.AddressZero)
+        .to.emit(market, 'OrderCreated')
+        .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -10 }, { ...DEFAULT_GUARANTEE })
+        .to.emit(market, 'OrderCreated')
+        .withArgs(
+          user.address,
+          { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition },
+          { ...DEFAULT_GUARANTEE },
+        )
     })
 
     it('Fails to store TRIGGER values out of slot bounds', async () => {

--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -630,7 +630,7 @@ describe('Orders', () => {
       .withArgs(user.address, market.address, 1)
       .to.emit(multiInvoker, 'KeeperCall')
       .to.emit(market, 'OrderCreated')
-      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -19881 }, { ...DEFAULT_GUARANTEE })
+      .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -20024 }, { ...DEFAULT_GUARANTEE })
 
     const executorDSUNet = (await dsu.balanceOf(userC.address)).sub(executorBalanceBefore)
     const feeCharged = executorDSUNet.div(BigNumber.from(10).pow(12))

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -233,8 +233,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         // store updated state
         _storeContext(context);
-
-        emit Updated(msg.sender, context.account, context.currentTimestamp, newMaker, newLong, newShort, collateral, protect, referrer);
     }
 
     /// @notice Updates the beneficiary, coordinator, and parameter set of the market
@@ -554,7 +552,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         if (newOrder.collateral.sign() == -1) token.push(msg.sender, UFixed18Lib.from(newOrder.collateral.abs()));
 
         // events
-        emit OrderCreated(context.account, newOrder);
+        emit OrderCreated(context.account, newOrder, newGuarantee);
     }
 
     /// @notice Processes the referral fee for the given order

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -59,7 +59,7 @@ interface IMarket is IInstance {
     }
 
     event Updated(address indexed sender, address indexed account, uint256 version, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer);
-    event OrderCreated(address indexed account, Order order);
+    event OrderCreated(address indexed account, Order order, Guarantee guarantee);
     event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
     event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
     event BeneficiaryUpdated(address newBeneficiary);

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -16,6 +16,7 @@ import {
   parse6decimal,
   expectCheckpointEq,
   DEFAULT_GLOBAL,
+  DEFAULT_GUARANTEE,
 } from '../../../../common/testutil/types'
 import { Market } from '../../../types/generated'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
@@ -114,8 +115,12 @@ describe('Fees', () => {
           .connect(user)
           ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
       )
-        .to.emit(market, 'Updated')
-        .withArgs(user.address, user.address, TIMESTAMP_1, POSITION, 0, 0, COLLATERAL, false, constants.AddressZero)
+        .to.emit(market, 'OrderCreated')
+        .withArgs(
+          user.address,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, makerPos: POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
+        )
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
@@ -202,8 +207,12 @@ describe('Fees', () => {
           .connect(user)
           ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
       )
-        .to.emit(market, 'Updated')
-        .withArgs(user.address, user.address, TIMESTAMP_1, POSITION, 0, 0, COLLATERAL, false, constants.AddressZero)
+        .to.emit(market, 'OrderCreated')
+        .withArgs(
+          user.address,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, makerPos: POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
+        )
 
       await nextWithConstantPrice()
       await settle(market, user)
@@ -305,17 +314,11 @@ describe('Fees', () => {
             false,
           ),
       )
-        .to.emit(market, 'Updated')
+        .to.emit(market, 'OrderCreated')
         .withArgs(
           userB.address,
-          userB.address,
-          TIMESTAMP_1,
-          0,
-          LONG_POSITION,
-          0,
-          COLLATERAL,
-          false,
-          constants.AddressZero,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: LONG_POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
         )
 
       await nextWithConstantPrice()
@@ -437,17 +440,11 @@ describe('Fees', () => {
             false,
           ),
       )
-        .to.emit(market, 'Updated')
+        .to.emit(market, 'OrderCreated')
         .withArgs(
           userB.address,
-          userB.address,
-          TIMESTAMP_2,
-          0,
-          LONG_POSITION,
-          0,
-          COLLATERAL,
-          false,
-          constants.AddressZero,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, longPos: LONG_POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
         )
 
       await nextWithConstantPrice()
@@ -602,17 +599,11 @@ describe('Fees', () => {
             false,
           ),
       )
-        .to.emit(market, 'Updated')
+        .to.emit(market, 'OrderCreated')
         .withArgs(
           userB.address,
-          userB.address,
-          TIMESTAMP_1,
-          0,
-          LONG_POSITION,
-          0,
-          COLLATERAL,
-          false,
-          constants.AddressZero,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: LONG_POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
         )
 
       await nextWithConstantPrice()
@@ -771,17 +762,11 @@ describe('Fees', () => {
             false,
           ),
       )
-        .to.emit(market, 'Updated')
+        .to.emit(market, 'OrderCreated')
         .withArgs(
           userB.address,
-          userB.address,
-          TIMESTAMP_1,
-          0,
-          0,
-          SHORT_POSITION,
-          COLLATERAL,
-          false,
-          constants.AddressZero,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, shortPos: SHORT_POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
         )
 
       await nextWithConstantPrice()
@@ -903,17 +888,11 @@ describe('Fees', () => {
             false,
           ),
       )
-        .to.emit(market, 'Updated')
+        .to.emit(market, 'OrderCreated')
         .withArgs(
           userB.address,
-          userB.address,
-          TIMESTAMP_2,
-          0,
-          0,
-          SHORT_POSITION,
-          COLLATERAL,
-          false,
-          constants.AddressZero,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, shortPos: SHORT_POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
         )
 
       await nextWithConstantPrice()
@@ -1068,17 +1047,11 @@ describe('Fees', () => {
             false,
           ),
       )
-        .to.emit(market, 'Updated')
+        .to.emit(market, 'OrderCreated')
         .withArgs(
           userB.address,
-          userB.address,
-          TIMESTAMP_1,
-          0,
-          0,
-          SHORT_POSITION,
-          COLLATERAL,
-          false,
-          constants.AddressZero,
+          { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, shortPos: SHORT_POSITION, collateral: COLLATERAL },
+          { ...DEFAULT_GUARANTEE },
         )
 
       await nextWithConstantPrice()

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -18,6 +18,7 @@ import {
   parse6decimal,
   expectCheckpointEq,
   DEFAULT_GLOBAL,
+  DEFAULT_GUARANTEE,
 } from '../../../../common/testutil/types'
 import { Market__factory } from '../../../types/generated'
 import { CHAINLINK_CUSTOM_CURRENCIES } from '@equilibria/perennial-v2-oracle/util/constants'
@@ -121,16 +122,18 @@ describe('Happy Path', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(user.address, user.address, TIMESTAMP_1, POSITION, 0, 0, COLLATERAL, false, constants.AddressZero)
       .to.emit(market, 'OrderCreated')
-      .withArgs(user.address, {
-        ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_1,
-        orders: 1,
-        collateral: COLLATERAL,
-        makerPos: POSITION,
-      })
+      .withArgs(
+        user.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_1,
+          orders: 1,
+          collateral: COLLATERAL,
+          makerPos: POSITION,
+        },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // Check user is in the correct state
     expectLocalEq(await market.locals(user.address), {
@@ -233,8 +236,12 @@ describe('Happy Path', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, 0, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(user.address, user.address, TIMESTAMP_1, POSITION, 0, 0, 0, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        user.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, makerPos: POSITION.div(2) },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // Check user is in the correct state
     expectLocalEq(await market.locals(user.address), {
@@ -338,15 +345,17 @@ describe('Happy Path', () => {
     await expect(
       market.connect(user)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(user.address, user.address, TIMESTAMP_2, 0, 0, 0, 0, false, constants.AddressZero)
       .to.emit(market, 'OrderCreated')
-      .withArgs(user.address, {
-        ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
-        orders: 1,
-        makerNeg: POSITION,
-      })
+      .withArgs(
+        user.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_2,
+          orders: 1,
+          makerNeg: POSITION,
+        },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // User state
     expectLocalEq(await market.locals(user.address), {
@@ -414,8 +423,12 @@ describe('Happy Path', () => {
     await expect(
       market.connect(user)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(user.address, user.address, TIMESTAMP_2, 0, 0, 0, 0, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        user.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION.div(2) },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // User state
     expectLocalEq(await market.locals(user.address), {
@@ -488,16 +501,18 @@ describe('Happy Path', () => {
         .connect(userB)
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, POSITION_B, 0, COLLATERAL, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, userB.address, TIMESTAMP_1, 0, POSITION_B, 0, COLLATERAL, false, constants.AddressZero)
       .to.emit(market, 'OrderCreated')
-      .withArgs(userB.address, {
-        ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_1,
-        orders: 1,
-        collateral: COLLATERAL,
-        longPos: POSITION_B,
-      })
+      .withArgs(
+        userB.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_1,
+          orders: 1,
+          collateral: COLLATERAL,
+          longPos: POSITION_B,
+        },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // User State
     expectLocalEq(await market.locals(user.address), {
@@ -639,8 +654,12 @@ describe('Happy Path', () => {
         .connect(userB)
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, POSITION_B, 0, 0, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, userB.address, TIMESTAMP_1, 0, POSITION_B, 0, 0, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: POSITION_B.div(2) },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // User State
     expectLocalEq(await market.locals(userB.address), {
@@ -758,15 +777,17 @@ describe('Happy Path', () => {
     await expect(
       market.connect(userB)['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, userB.address, TIMESTAMP_2, 0, 0, 0, 0, false, constants.AddressZero)
       .to.emit(market, 'OrderCreated')
-      .withArgs(userB.address, {
-        ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
-        orders: 1,
-        longNeg: POSITION_B,
-      })
+      .withArgs(
+        userB.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_2,
+          orders: 1,
+          longNeg: POSITION_B,
+        },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // User State
     expectLocalEq(await market.locals(userB.address), {
@@ -849,8 +870,12 @@ describe('Happy Path', () => {
     await expect(
       market.connect(userB)['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, userB.address, TIMESTAMP_2, 0, 0, 0, 0, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, longNeg: POSITION_B.div(2) },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // User State
     expectLocalEq(await market.locals(userB.address), {
@@ -946,8 +971,12 @@ describe('Happy Path', () => {
         .connect(userB)
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, POSITION_B, 0, COLLATERAL, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, userB.address, TIMESTAMP_1, 0, POSITION_B, 0, COLLATERAL, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: POSITION_B, collateral: COLLATERAL },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // 50 rounds (120% max)
     for (let i = 0; i < 50; i++) {
@@ -987,8 +1016,12 @@ describe('Happy Path', () => {
         .connect(userB)
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, POSITION_B, COLLATERAL, false),
     )
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, userB.address, TIMESTAMP_1, 0, 0, POSITION_B, COLLATERAL, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, shortPos: POSITION_B, collateral: COLLATERAL },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // 50 rounds (120% max)
     for (let i = 0; i < 50; i++) {
@@ -1093,8 +1126,12 @@ describe('Happy Path', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, -1, false),
     ) // 4 -> 5
-      .to.emit(market, 'Updated')
-      .withArgs(user.address, user.address, TIMESTAMP_5, POSITION, 0, 0, -1, false, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        user.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_5, orders: 1, makerPos: POSITION.div(2), collateral: -1 },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     // Check user is in the correct state
     expectLocalEq(await market.locals(user.address), {
@@ -1261,17 +1298,17 @@ describe('Happy Path', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, -1, false),
     )
-      .to.emit(market, 'Updated')
+      .to.emit(market, 'OrderCreated')
       .withArgs(
         user.address,
-        user.address,
-        await chainlink.oracle.current(),
-        POSITION,
-        0,
-        0,
-        -1,
-        false,
-        constants.AddressZero,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: await chainlink.oracle.current(),
+          orders: 1,
+          makerPos: POSITION,
+          collateral: -1,
+        },
+        { ...DEFAULT_GUARANTEE },
       )
 
     // Check user is in the correct state

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants, utils } from 'ethers'
 
 import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
-import { expectPositionEq, parse6decimal } from '../../../../common/testutil/types'
+import { expectPositionEq, parse6decimal, DEFAULT_ORDER, DEFAULT_GUARANTEE } from '../../../../common/testutil/types'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 
 export const TIMESTAMP_2 = 1631113819
@@ -34,8 +34,12 @@ describe('Liquidate', () => {
     await expect(
       market.connect(userB)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
     ) // liquidate
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, user.address, TIMESTAMP_2, 0, 0, 0, 0, true, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        user.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION, protection: 1 },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
     expect(await market.liquidators(user.address, 2)).to.eq(userB.address)
@@ -168,8 +172,12 @@ describe('Liquidate', () => {
     await expect(
       market.connect(userB)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
     ) // liquidate
-      .to.emit(market, 'Updated')
-      .withArgs(userB.address, user.address, TIMESTAMP_2, 0, 0, 0, 0, true, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        user.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION, protection: 1 },
+        { ...DEFAULT_GUARANTEE },
+      )
 
     await chainlink.next()
     await settle(market, user)
@@ -275,8 +283,12 @@ describe('Liquidate', () => {
     await expect(
       market.connect(userC)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
     ) // liquidate
-      .to.emit(market, 'Updated')
-      .withArgs(userC.address, user.address, TIMESTAMP_3, 0, 0, 0, 0, true, constants.AddressZero)
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        user.address,
+        { ...DEFAULT_ORDER, timestamp: TIMESTAMP_3, orders: 1, makerNeg: parse6decimal('5'), protection: 1 },
+        { ...DEFAULT_GUARANTEE },
+      )
     expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
     expect(await market.liquidators(user.address, 2)).to.eq(userC.address)
     expect(await dsu.balanceOf(market.address)).to.equal(utils.parseEther('1500'))

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -15961,17 +15961,17 @@ describe('Market', () => {
               .connect(operator)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
-              operator.address,
               user.address,
-              ORACLE_VERSION_2.timestamp,
-              POSITION,
-              0,
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -39,6 +39,7 @@ import {
   expectOrderEq,
   expectCheckpointEq,
   DEFAULT_GLOBAL,
+  DEFAULT_GUARANTEE,
 } from '../../../../common/testutil/types'
 import { IMarket, MarketParameterStruct, RiskParameterStruct } from '../../../types/generated/contracts/Market'
 
@@ -1273,7 +1274,11 @@ describe('Market', () => {
               constants.AddressZero,
             )
             .to.emit(market, 'OrderCreated')
-            .withArgs(user.address, { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL })
+            .withArgs(
+              user.address,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
+              { ...DEFAULT_GUARANTEE },
+            )
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
@@ -1330,11 +1335,15 @@ describe('Market', () => {
               constants.AddressZero,
             )
             .to.emit(market, 'OrderCreated')
-            .withArgs(user.address, {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              collateral: -COLLATERAL,
-            })
+            .withArgs(
+              user.address,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                collateral: -COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
+            )
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
@@ -1632,13 +1641,17 @@ describe('Market', () => {
                 constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                orders: 1,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                collateral: COLLATERAL,
-                makerPos: POSITION,
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  orders: 1,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  collateral: COLLATERAL,
+                  makerPos: POSITION,
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
@@ -2837,13 +2850,17 @@ describe('Market', () => {
                   constants.AddressZero,
                 )
                 .to.emit(market, 'OrderCreated')
-                .withArgs(user.address, {
-                  ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_2.timestamp,
-                  collateral: COLLATERAL,
-                  orders: 1,
-                  longPos: POSITION,
-                })
+                .withArgs(
+                  user.address,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    collateral: COLLATERAL,
+                    orders: 1,
+                    longPos: POSITION,
+                  },
+                  { ...DEFAULT_GUARANTEE },
+                )
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -6102,13 +6119,17 @@ describe('Market', () => {
                   constants.AddressZero,
                 )
                 .to.emit(market, 'OrderCreated')
-                .withArgs(user.address, {
-                  ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_2.timestamp,
-                  collateral: COLLATERAL,
-                  orders: 1,
-                  shortPos: POSITION,
-                })
+                .withArgs(
+                  user.address,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    collateral: COLLATERAL,
+                    orders: 1,
+                    shortPos: POSITION,
+                  },
+                  { ...DEFAULT_GUARANTEE },
+                )
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
@@ -16528,21 +16549,29 @@ describe('Market', () => {
               ),
           )
             .to.emit(market, 'OrderCreated')
-            .withArgs(user.address, {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              longPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
-            })
+            .withArgs(
+              user.address,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                takerReferral: POSITION.div(2).mul(2).div(10),
+              },
+              { ...DEFAULT_GUARANTEE },
+            )
             .to.emit(market, 'OrderCreated')
-            .withArgs(userC.address, {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              shortPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
-            })
+            .withArgs(
+              userC.address,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                takerReferral: POSITION.div(2).mul(2).div(10),
+              },
+              { ...DEFAULT_GUARANTEE },
+            )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
@@ -18621,21 +18650,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
@@ -18809,21 +18846,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
@@ -18997,21 +19042,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
@@ -19185,21 +19238,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
@@ -19388,21 +19449,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
             oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
@@ -19593,21 +19662,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
             oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
@@ -19798,21 +19875,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
             oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
@@ -20004,21 +20089,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
             oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
@@ -20216,21 +20309,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
             oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
@@ -20429,21 +20530,29 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
-              .withArgs(userC.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longNeg: POSITION.div(2),
-                takerReferral: POSITION.div(2).mul(2).div(10),
-              })
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
             oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -16182,12 +16182,16 @@ describe('Market', () => {
               ),
           )
             .to.emit(market, 'OrderCreated')
-            .withArgs(user.address, {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              longPos: POSITION.div(2),
-            })
+            .withArgs(
+              user.address,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+              },
+              { ...DEFAULT_GUARANTEE },
+            )
             .to.emit(market, 'OrderCreated')
             .withArgs(
               userC.address,
@@ -18292,12 +18296,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -18489,12 +18497,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -18686,12 +18698,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -18883,12 +18899,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -19095,12 +19115,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longNeg: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -19308,12 +19332,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortNeg: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -19521,12 +19549,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortPos: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -19736,12 +19768,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -19957,12 +19993,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                longNeg: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,
@@ -20178,12 +20218,16 @@ describe('Market', () => {
                 ),
             )
               .to.emit(market, 'OrderCreated')
-              .withArgs(user.address, {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                orders: 1,
-                shortNeg: POSITION.div(2),
-              })
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
+                },
+                { ...DEFAULT_GUARANTEE },
+              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 userC.address,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -877,17 +877,11 @@ describe('Market', () => {
             .connect(liquidator)
             ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
         )
-          .to.emit(market, 'Updated')
+          .to.emit(market, 'OrderCreated')
           .withArgs(
-            liquidator.address,
             userB.address,
-            ORACLE_VERSION_4.timestamp, // TIMESTAMP + 10800
-            0,
-            0,
-            0,
-            0,
-            true,
-            constants.AddressZero,
+            { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION, protection: 1 },
+            { ...DEFAULT_GUARANTEE },
           )
         oracleVersion = {
           ...oracleVersion,
@@ -1032,17 +1026,17 @@ describe('Market', () => {
             { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp },
             DEFAULT_LOCAL_ACCUMULATION_RESULT,
           )
-          .to.emit(market, 'Updated')
+          .to.emit(market, 'OrderCreated')
           .withArgs(
             user.address,
-            user.address,
-            ORACLE_VERSION_2.timestamp,
-            POSITION,
-            0,
-            0,
-            COLLATERAL,
-            false,
-            constants.AddressZero,
+            {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
+            },
+            { ...DEFAULT_GUARANTEE },
           )
 
         oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1142,17 +1136,17 @@ describe('Market', () => {
             { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp },
             DEFAULT_LOCAL_ACCUMULATION_RESULT,
           )
-          .to.emit(market, 'Updated')
+          .to.emit(market, 'OrderCreated')
           .withArgs(
             user.address,
-            user.address,
-            ORACLE_VERSION_2.timestamp,
-            POSITION,
-            0,
-            0,
-            COLLATERAL,
-            false,
-            constants.AddressZero,
+            {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
+            },
+            { ...DEFAULT_GUARANTEE },
           )
 
         oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1261,18 +1255,6 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false),
           )
-            .to.emit(market, 'Updated')
-            .withArgs(
-              user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              0,
-              0,
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
-            )
             .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
@@ -1322,18 +1304,6 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL.mul(-1), false),
           )
-            .to.emit(market, 'Updated')
-            .withArgs(
-              user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              0,
-              0,
-              0,
-              COLLATERAL.mul(-1),
-              false,
-              constants.AddressZero,
-            )
             .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
@@ -1383,17 +1353,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              0,
-              0,
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1444,17 +1408,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL.mul(-1), false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_3.timestamp,
-              0,
-              0,
-              0,
-              COLLATERAL.mul(-1),
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, collateral: COLLATERAL.mul(-1) },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1499,17 +1457,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              0,
-              0,
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1560,17 +1512,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL.mul(-1), false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_6.timestamp,
-              0,
-              0,
-              0,
-              COLLATERAL.mul(-1),
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_6.timestamp, collateral: COLLATERAL.mul(-1) },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1628,18 +1574,6 @@ describe('Market', () => {
                   false,
                 ),
             )
-              .to.emit(market, 'Updated')
-              .withArgs(
-                user.address,
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                POSITION,
-                0,
-                0,
-                COLLATERAL,
-                false,
-                constants.AddressZero,
-              )
               .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
@@ -1720,17 +1654,17 @@ describe('Market', () => {
                 { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp },
                 DEFAULT_LOCAL_ACCUMULATION_RESULT,
               )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                POSITION,
-                0,
-                0,
-                COLLATERAL,
-                false,
-                constants.AddressZero,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
+                },
+                { ...DEFAULT_GUARANTEE },
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1813,17 +1747,11 @@ describe('Market', () => {
                 .connect(user)
                 ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION.mul(2), 0, 0, 0, false),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                POSITION.mul(2),
-                0,
-                0,
-                0,
-                false,
-                constants.AddressZero,
+                { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, makerPos: POSITION },
+                { ...DEFAULT_GUARANTEE },
               )
 
             expectLocalEq(await market.locals(user.address), {
@@ -1872,17 +1800,11 @@ describe('Market', () => {
                 .connect(user)
                 ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION.mul(2), 0, 0, 0, false),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                POSITION.mul(2),
-                0,
-                0,
-                0,
-                false,
-                constants.AddressZero,
+                { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, makerPos: POSITION },
+                { ...DEFAULT_GUARANTEE },
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1944,17 +1866,11 @@ describe('Market', () => {
                 .connect(user)
                 ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION.mul(2), 0, 0, 0, false),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_3.timestamp,
-                POSITION.mul(2),
-                0,
-                0,
-                0,
-                false,
-                constants.AddressZero,
+                { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerPos: POSITION },
+                { ...DEFAULT_GUARANTEE },
               )
 
             expectLocalEq(await market.locals(user.address), {
@@ -2014,17 +1930,11 @@ describe('Market', () => {
                 .connect(user)
                 ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION.mul(2), 0, 0, 0, false),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_3.timestamp,
-                POSITION.mul(2),
-                0,
-                0,
-                0,
-                false,
-                constants.AddressZero,
+                { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerPos: POSITION },
+                { ...DEFAULT_GUARANTEE },
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2087,17 +1997,17 @@ describe('Market', () => {
                   false,
                 ),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                POSITION,
-                0,
-                0,
-                COLLATERAL,
-                false,
-                constants.AddressZero,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
+                },
+                { ...DEFAULT_GUARANTEE },
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2173,17 +2083,17 @@ describe('Market', () => {
                   false,
                 ),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_2.timestamp,
-                POSITION,
-                0,
-                0,
-                COLLATERAL,
-                false,
-                constants.AddressZero,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
+                },
+                { ...DEFAULT_GUARANTEE },
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2260,17 +2170,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -2322,17 +2226,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2388,17 +2286,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -2454,17 +2346,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2524,17 +2410,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -2594,17 +2474,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -2656,17 +2530,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2736,17 +2604,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2837,18 +2699,6 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
-                .withArgs(
-                  user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
-                )
                 .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
@@ -2917,17 +2767,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION,
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2993,17 +2843,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -3060,17 +2904,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3140,17 +2978,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -3218,17 +3050,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3320,17 +3146,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3440,17 +3266,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3573,17 +3399,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_3.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3713,17 +3539,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -3776,17 +3596,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3875,17 +3689,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -3942,17 +3750,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -4045,17 +3847,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_4.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 await settle(market, user)
@@ -4156,17 +3952,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_4.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -4276,17 +4066,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -4391,17 +4175,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -4915,17 +4693,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -5121,17 +4899,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -5368,17 +5146,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -5501,17 +5279,11 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_5.timestamp,
-                  0,
-                  0,
-                  0,
-                  shortfall.mul(-1),
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -5597,17 +5369,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    longNeg: POSITION.div(2),
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -5787,17 +5559,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    longNeg: POSITION.div(2),
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -5916,17 +5688,11 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_5.timestamp,
-                  0,
-                  0,
-                  0,
-                  shortfall.mul(-1),
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6106,18 +5872,6 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
-                .withArgs(
-                  user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  0,
-                  POSITION,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
-                )
                 .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
@@ -6187,17 +5941,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  0,
-                  POSITION,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    shortPos: POSITION,
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6263,17 +6017,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, POSITION, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  0,
-                  POSITION,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, shortPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6331,17 +6079,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, POSITION, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  0,
-                  POSITION,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, shortPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6411,17 +6153,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, POSITION, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  POSITION,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6489,17 +6225,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, POSITION, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  POSITION,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -6596,17 +6326,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  0,
-                  POSITION.div(2),
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    shortPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6720,17 +6450,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  0,
-                  POSITION.div(2),
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    shortPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6856,17 +6586,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  0,
-                  POSITION.div(2),
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_3.timestamp,
+                    orders: 1,
+                    shortPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -6995,17 +6725,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -7058,17 +6782,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7158,17 +6876,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -7225,17 +6937,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7329,17 +7035,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_4.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, shortNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 await settle(market, userB)
@@ -7440,17 +7140,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_4.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, shortNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -7562,17 +7256,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7679,17 +7367,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -8210,17 +7892,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -8424,17 +8106,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -8648,17 +8330,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -8773,17 +8455,11 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_5.timestamp,
-                  0,
-                  0,
-                  0,
-                  shortfall.mul(-1),
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -8869,17 +8545,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    shortNeg: POSITION.div(2),
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -9065,17 +8741,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    shortNeg: POSITION.div(2),
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9196,17 +8872,11 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_5.timestamp,
-                  0,
-                  0,
-                  0,
-                  shortfall.mul(-1),
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -9378,17 +9048,11 @@ describe('Market', () => {
                 .connect(user)
                 ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION.div(2), 0, 0, 0, false),
             )
-              .to.emit(market, 'Updated')
+              .to.emit(market, 'OrderCreated')
               .withArgs(
                 user.address,
-                user.address,
-                ORACLE_VERSION_3.timestamp,
-                POSITION.div(2),
-                0,
-                0,
-                0,
-                false,
-                constants.AddressZero,
+                { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION.div(2) },
+                { ...DEFAULT_GUARANTEE },
               )
 
             const marketParameter2 = { ...(await market.parameter()) }
@@ -9532,17 +9196,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION,
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9602,17 +9266,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION,
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -9679,17 +9343,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9748,17 +9406,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -9829,17 +9481,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9908,17 +9554,11 @@ describe('Market', () => {
                   .connect(user)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION, 0, 0, false),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_3.timestamp,
-                  0,
-                  POSITION,
-                  0,
-                  0,
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -10027,17 +9667,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10175,17 +9815,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10304,17 +9944,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10425,17 +10065,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10551,17 +10191,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10672,17 +10312,17 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
                   user.address,
-                  user.address,
-                  ORACLE_VERSION_2.timestamp,
-                  0,
-                  POSITION.div(2),
-                  0,
-                  COLLATERAL,
-                  false,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10839,17 +10479,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -10903,17 +10537,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -11017,17 +10645,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -11085,17 +10707,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -11203,17 +10819,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_4.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 await settle(market, user)
@@ -11323,17 +10933,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_4.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -11475,17 +11079,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -11580,17 +11178,11 @@ describe('Market', () => {
                     .connect(user)
                     ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
                 )
-                  .to.emit(market, 'Updated')
+                  .to.emit(market, 'OrderCreated')
                   .withArgs(
                     user.address,
-                    user.address,
-                    ORACLE_VERSION_3.timestamp,
-                    0,
-                    0,
-                    0,
-                    0,
-                    false,
-                    constants.AddressZero,
+                    { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
+                    { ...DEFAULT_GUARANTEE },
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -12142,17 +11734,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -12397,17 +11989,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp, // TIMESTAMP + 10800
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -12529,17 +12121,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -12769,17 +12361,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    makerNeg: POSITION,
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -12911,17 +12503,11 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   userB.address,
-                  ORACLE_VERSION_5.timestamp,
-                  0,
-                  0,
-                  0,
-                  shortfall.mul(-1),
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -13018,17 +12604,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    longNeg: POSITION.div(2),
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -13268,17 +12854,17 @@ describe('Market', () => {
                   .connect(liquidator)
                   ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_4.timestamp,
-                  0,
-                  0,
-                  0,
-                  0,
-                  true,
-                  constants.AddressZero,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_4.timestamp,
+                    orders: 1,
+                    longNeg: POSITION.div(2),
+                    protection: 1,
+                  },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               // rate_1 = rate_0 + (elapsed * skew / k)
@@ -13424,17 +13010,11 @@ describe('Market', () => {
                     false,
                   ),
               )
-                .to.emit(market, 'Updated')
+                .to.emit(market, 'OrderCreated')
                 .withArgs(
-                  liquidator.address,
                   user.address,
-                  ORACLE_VERSION_5.timestamp,
-                  0,
-                  0,
-                  0,
-                  shortfall.mul(-1),
-                  false,
-                  constants.AddressZero,
+                  { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
+                  { ...DEFAULT_GUARANTEE },
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -14008,17 +13588,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              0,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(2) },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -14049,8 +13623,12 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false),
           )
-            .to.emit(market, 'Updated')
-            .withArgs(user.address, user.address, ORACLE_VERSION_5.timestamp, 0, 0, 0, 0, false, constants.AddressZero)
+            .to.emit(market, 'OrderCreated')
+            .withArgs(
+              user.address,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, orders: 1, longNeg: POSITION.div(2) },
+              { ...DEFAULT_GUARANTEE },
+            )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
           oracle.at.whenCalledWith(ORACLE_VERSION_5.timestamp).returns(ORACLE_VERSION_5)
@@ -14523,17 +14101,17 @@ describe('Market', () => {
               .connect(liquidator)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
-              liquidator.address,
               user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              0,
-              0,
-              0,
-              true,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                longNeg: POSITION.div(2),
+                protection: 1,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -14699,17 +14277,17 @@ describe('Market', () => {
               .connect(liquidator)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, POSITION.div(4), 0, true),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
-              liquidator.address,
               user.address,
-              ORACLE_VERSION_5.timestamp,
-              0,
-              0,
-              POSITION.div(4),
-              0,
-              true,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_5.timestamp,
+                orders: 1,
+                shortNeg: POSITION.div(2),
+                protection: 1,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -14800,17 +14378,17 @@ describe('Market', () => {
               .connect(liquidator)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
-              liquidator.address,
               user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              0,
-              0,
-              0,
-              true,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                shortNeg: POSITION.div(2),
+                protection: 1,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at
@@ -14827,17 +14405,17 @@ describe('Market', () => {
               .connect(liquidator)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
-              liquidator.address,
               user.address,
-              ORACLE_VERSION_5.timestamp,
-              0,
-              0,
-              0,
-              0,
-              true,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_5.timestamp,
+                orders: 1,
+                shortNeg: POSITION.div(2),
+                protection: 1,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
           await settle(market, userB)
 
@@ -15050,17 +14628,17 @@ describe('Market', () => {
                 false,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_3.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15205,17 +14783,17 @@ describe('Market', () => {
                 false,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_3.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15227,17 +14805,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              0,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longPos: POSITION.div(2) },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4 })
@@ -15410,17 +14982,17 @@ describe('Market', () => {
                 false,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_3.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15432,17 +15004,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              0,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longPos: POSITION.div(2) },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4, valid: false })
@@ -15605,17 +15171,17 @@ describe('Market', () => {
                 false,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_3.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.status.returns([{ ...ORACLE_VERSION_2 }, ORACLE_VERSION_4.timestamp])
@@ -15626,17 +15192,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              0,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15800,17 +15360,17 @@ describe('Market', () => {
                 false,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_3.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.status.returns([{ ...ORACLE_VERSION_2 }, ORACLE_VERSION_4.timestamp])
@@ -15821,17 +15381,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_4.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              0,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15844,17 +15398,11 @@ describe('Market', () => {
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_5.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              0,
-              false,
-              constants.AddressZero,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, orders: 1, longPos: POSITION.div(2) },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_5.timestamp).returns({ ...ORACLE_VERSION_5 })
@@ -16021,17 +15569,17 @@ describe('Market', () => {
                 false,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -16408,17 +15956,17 @@ describe('Market', () => {
               .connect(operator)
               ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
-              operator.address,
               user.address,
-              ORACLE_VERSION_2.timestamp,
-              POSITION,
-              0,
-              0,
-              COLLATERAL,
-              false,
-              constants.AddressZero,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -18366,17 +17914,18 @@ describe('Market', () => {
                 liquidator.address,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              POSITION,
-              0,
-              0,
-              COLLATERAL,
-              false,
-              liquidator.address,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
+                makerReferral: POSITION.div(5),
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -18472,17 +18021,18 @@ describe('Market', () => {
                 liquidator.address,
               ),
           )
-            .to.emit(market, 'Updated')
+            .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,
-              user.address,
-              ORACLE_VERSION_2.timestamp,
-              0,
-              POSITION.div(2),
-              0,
-              COLLATERAL,
-              false,
-              liquidator.address,
+              {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
+                takerReferral: POSITION.div(10),
+              },
+              { ...DEFAULT_GUARANTEE },
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)


### PR DESCRIPTION
- Removes `Updated` event
- Adds `Guarantee` to the `OrderCreated` event

### Out of Scope
- We will add `referrer`, `liquidator`, and `solver` to `OrderCreated` in a future task due to in progress issues.