### PR TITLE
Add interface / solver fee limits

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -125,6 +125,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @param intent The intent that is being filled
     /// @param signature The signature of the intent that is being filled
     function update(Intent calldata intent, bytes memory signature) external {
+        if (intent.fee.gt(UFixed6Lib.ONE)) revert MarketInvalidIntentFeeError();
+
         address signer = verifier.verifyIntent(intent, signature);
 
         _updateIntent(

--- a/packages/perennial/contracts/MarketFactory.sol
+++ b/packages/perennial/contracts/MarketFactory.sol
@@ -129,6 +129,8 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @param referrer The referrer to update
     /// @param newReferralFee The new referral fee
     function updateReferralFee(address referrer, UFixed6 newReferralFee) external onlyOwner {
+        if (newReferralFee.gt(UFixed6Lib.ONE)) revert MarketFactoryInvalidReferralFeeError();
+
         referralFees[referrer] = newReferralFee;
         emit ReferralFeeUpdated(referrer, newReferralFee);
     }

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -111,6 +111,8 @@ interface IMarket is IInstance {
     error MarketInvalidReferrerError();
     // sig: 0x5c5cb438
     error MarketSettleOnlyError();
+    // sig: 0x1e9d2296
+    error MarketInvalidIntentFeeError();
 
     // sig: 0x2142bc27
     error GlobalStorageInvalidError();

--- a/packages/perennial/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial/contracts/interfaces/IMarketFactory.sol
@@ -23,6 +23,8 @@ interface IMarketFactory is IFactory {
     error FactoryAlreadyRegisteredError();
     // sig: 0x6928a80f
     error MarketFactoryInvalidSignerError();
+    // sig: 0x199d4b3e
+    error MarketFactoryInvalidReferralFeeError();
 
     // sig: 0x4dc1bc59
     error ProtocolParameterStorageInvalidError();

--- a/packages/perennial/contracts/types/ProtocolParameter.sol
+++ b/packages/perennial/contracts/types/ProtocolParameter.sol
@@ -64,6 +64,7 @@ library ProtocolParameterStorageLib {
     function validate(ProtocolParameter memory self) internal pure {
         if (self.protocolFee.gt(self.maxCut)) revert ProtocolParameterStorageInvalidError();
         if (self.maxCut.gt(UFixed6Lib.ONE)) revert ProtocolParameterStorageInvalidError();
+        if (self.referralFee.gt(UFixed6Lib.ONE)) revert ProtocolParameterStorageInvalidError();
     }
 
     function validateAndStore(ProtocolParameterStorage storage self, ProtocolParameter memory newValue) internal {
@@ -74,7 +75,6 @@ library ProtocolParameterStorageLib {
         if (newValue.maxRate.gt(UFixed6.wrap(type(uint32).max / 2))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minMaintenance.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minEfficiency.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
-        if (newValue.referralFee.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
 
         self.value = StoredProtocolParameter(
             uint24(UFixed6.unwrap(newValue.protocolFee)),

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -20751,6 +20751,62 @@ describe('Market', () => {
               ),
           ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
         })
+
+        it('reverts if fee is too high', async () => {
+          factory.parameter.returns({
+            maxPendingIds: 5,
+            protocolFee: parse6decimal('0.50'),
+            maxFee: parse6decimal('0.01'),
+            maxFeeAbsolute: parse6decimal('1000'),
+            maxCut: parse6decimal('0.50'),
+            maxRate: parse6decimal('10.00'),
+            minMaintenance: parse6decimal('0.01'),
+            minEfficiency: parse6decimal('0.1'),
+            referralFee: parse6decimal('0.20'),
+          })
+
+          const marketParameter = { ...(await market.parameter()) }
+          marketParameter.settlementFee = parse6decimal('0.50')
+          marketParameter.takerFee = parse6decimal('0.01')
+          await market.updateParameter(beneficiary.address, coordinator.address, marketParameter)
+
+          const intent = {
+            amount: POSITION.div(2),
+            price: parse6decimal('125'),
+            fee: parse6decimal('1.5'),
+            originator: liquidator.address,
+            solver: constants.AddressZero,
+            common: {
+              account: user.address,
+              domain: market.address,
+              nonce: 0,
+              group: 0,
+              expiry: 0,
+            },
+          }
+
+          await market
+            .connect(userB)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+          await market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+          await market
+            .connect(userC)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+          verifier.verifyIntent.returns(user.address)
+
+          await expect(
+            market
+              .connect(userC)
+              ['update((int256,int256,uint256,address,address,(address,address,uint256,uint256,uint256)),bytes)'](
+                intent,
+                DEFAULT_SIGNATURE,
+              ),
+          ).to.be.revertedWithCustomError(market, 'MarketInvalidIntentFeeError')
+        })
       })
     })
 

--- a/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/perennial/test/unit/marketfactory/MarketFactory.test.ts
@@ -246,6 +246,13 @@ describe('MarketFactory', () => {
         factory.connect(user).updateReferralFee(user.address, parse6decimal('0.3')),
       ).to.be.revertedWithCustomError(factory, 'OwnableNotOwnerError')
     })
+
+    it('reverts if too highr', async () => {
+      await expect(factory.updateReferralFee(user.address, parse6decimal('2.3'))).to.be.revertedWithCustomError(
+        factory,
+        'MarketFactoryInvalidReferralFeeError',
+      )
+    })
   })
 
   describe('#updateExtension', async () => {

--- a/packages/perennial/test/unit/types/ProtocolParameter.test.ts
+++ b/packages/perennial/test/unit/types/ProtocolParameter.test.ts
@@ -196,21 +196,20 @@ describe('ProtocolParameter', () => {
     })
 
     context('.referralFee', async () => {
-      const STORAGE_SIZE = 24
       it('saves if in range', async () => {
         await protocolParameter.validateAndStore({
           ...VALID_PROTOCOL_PARAMETER,
-          referralFee: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          referralFee: parse6decimal('1'),
         })
         const value = await protocolParameter.read()
-        expect(value.referralFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        expect(value.referralFee).to.equal(parse6decimal('1'))
       })
 
       it('reverts if out of range', async () => {
         await expect(
           protocolParameter.validateAndStore({
             ...VALID_PROTOCOL_PARAMETER,
-            referralFee: BigNumber.from(2).pow(STORAGE_SIZE),
+            referralFee: parse6decimal('1').add(1),
           }),
         ).to.be.revertedWithCustomError(protocolParameter, 'ProtocolParameterStorageInvalidError')
       })


### PR DESCRIPTION
Limits the following parameters to `100%`
- `Intent.fee` field that is passed in in an intent order
- `Protocol.referralFee` global referral fee setting
- `MarketFactory.referralFees` per-referrer referral fee setting