### PR TITLE
[Fix] riskParameter migration compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@codechecks/client": "^0.1.10",
     "@defi-wonderland/smock": "^2.0.7",
-    "@equilibria/root": "2.3.0-rc2",
+    "@equilibria/root": "2.3.0-rc3",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -302,8 +302,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         newRiskParameter = _riskParameter.read();
 
         // update global exposure
-        newGlobal.exposure = newGlobal.exposure.sub(latestRiskParameter.takerFee
-                .update(newRiskParameter.takerFee, latestPosition.skew(), newGlobal.latestPrice.abs()));
+        Fixed6 exposureChange = latestRiskParameter.takerFee
+            .exposure(newRiskParameter.takerFee, latestPosition.skew(), newGlobal.latestPrice.abs());
+        newGlobal.exposure = newGlobal.exposure.sub(exposureChange);
         _global.store(newGlobal);
 
         emit RiskParameterUpdated(newRiskParameter);

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -302,9 +302,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         newRiskParameter = _riskParameter.read();
 
         // update global exposure
-        Fixed6 exposureChange = latestRiskParameter.takerFee
-            .exposure(newRiskParameter.takerFee, latestPosition.skew(), newGlobal.latestPrice.abs());
-        newGlobal.exposure = newGlobal.exposure.sub(exposureChange);
+        newGlobal.update(latestRiskParameter, newRiskParameter, latestPosition);
         _global.store(newGlobal);
 
         emit RiskParameterUpdated(newRiskParameter);

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -42,6 +42,22 @@ using GlobalStorageLib for GlobalStorage global;
 /// @title Global
 /// @notice Holds the global market state
 library GlobalLib {
+    /// @notice Updates market exposure based on a change in the risk parameter configuration
+    /// @param self The Global object to update
+    /// @param latestRiskParameter The latest risk parameter configuration
+    /// @param newRiskParameter The new risk parameter configuration
+    /// @param latestPosition The latest position
+    function update(
+        Global memory self,
+        RiskParameter memory latestRiskParameter,
+        RiskParameter memory newRiskParameter,
+        Position memory latestPosition
+    ) internal pure {
+        Fixed6 exposureChange = latestRiskParameter.takerFee
+            .exposure(newRiskParameter.takerFee, latestPosition.skew(), self.latestPrice.abs());
+        self.exposure = self.exposure.sub(exposureChange);
+    }
+
     /// @notice Increments the fees by `amount` using current parameters
     /// @param self The Global object to update
     /// @param newLatestId The new latest position id

--- a/packages/perennial/contracts/types/RiskParameter.sol
+++ b/packages/perennial/contracts/types/RiskParameter.sol
@@ -59,15 +59,16 @@ using RiskParameterStorageLib for RiskParameterStorage global;
 //        uint24 maintenance;                         // <= 1677%
 //        uint24 takerLinearFee;                      // <= 1677%
 //        uint24 takerProportionalFee;                // <= 1677%
-//        uint24 takerAdiabaticFee;                   // <= 1677%
+//        uint24 takerAdiabaticFee;                   // <= 1677% (must maintain location due to updateRiskParameter)
 //        uint24 makerLinearFee;                      // <= 1677%
 //        uint24 makerProportionalFee;                // <= 1677%
 //        uint48 makerLimit;                          // <= 281t (no decimals)
 //        uint24 efficiencyLimit;                     // <= 1677%
 //
 //        /* slot 1 */ (28)
+//        bytes3 __unallocated__;
 //        uint48 makerSkewScale;                      // <= 281t (no decimals)
-//        uint48 takerSkewScale;                      // <= 281t (no decimals)
+//        uint48 takerSkewScale;                      // <= 281t (no decimals) (must maintain location due to updateRiskParameter)
 //        uint24 utilizationCurveMinRate;             // <= 1677%
 //        uint24 utilizationCurveMaxRate;             // <= 1677%
 //        uint24 utilizationCurveTargetRate;          // <= 1677%
@@ -96,27 +97,27 @@ library RiskParameterStorageLib {
                 UFixed6.wrap(uint256(   slot0 << (256 - 24 - 24 - 24)) >> (256 - 24)),
                 UFixed6.wrap(uint256(   slot0 << (256 - 24 - 24 - 24 - 24)) >> (256 - 24)),
                 UFixed6.wrap(uint256(   slot0 << (256 - 24 - 24 - 24 - 24 - 24)) >> (256 - 24)),
-                UFixed6Lib.from(uint256(slot1 << (256 - 48 - 48)) >> (256 - 48))
+                UFixed6Lib.from(uint256(slot1 << (256 - 24 - 48 - 48)) >> (256 - 48))
             ),
             NoopAdiabatic6(
                 UFixed6.wrap(uint256(   slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 24)) >> (256 - 24)),
                 UFixed6.wrap(uint256(   slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 24 - 24)) >> (256 - 24)),
-                UFixed6Lib.from(uint256(slot1 << (256 - 48)) >> (256 - 48))
+                UFixed6Lib.from(uint256(slot1 << (256 - 24 - 48)) >> (256 - 48))
             ),
             UFixed6Lib.from(uint256(    slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 24 - 24 - 48)) >> (256 - 48)),
             UFixed6.wrap(uint256(       slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 24 - 24 - 48 - 24)) >> (256 - 24)),
 
             UFixed6.wrap(uint256(       slot2 << (256 - 48 - 32 - 48 - 48 - 48)) >> (256 - 48)),
             UJumpRateUtilizationCurve6(
-                UFixed6.wrap(uint256(   slot1 << (256 - 48 - 48 - 24)) >> (256 - 24)),
-                UFixed6.wrap(uint256(   slot1 << (256 - 48 - 48 - 24 - 24)) >> (256 - 24)),
-                UFixed6.wrap(uint256(   slot1 << (256 - 48 - 48 - 24 - 24 - 24)) >> (256 - 24)),
-                UFixed6.wrap(uint256(   slot1 << (256 - 48 - 48 - 24 - 24 - 24 - 24)) >> (256 - 24))
+                UFixed6.wrap(uint256(   slot1 << (256 - 24 - 48 - 48 - 24)) >> (256 - 24)),
+                UFixed6.wrap(uint256(   slot1 << (256 - 24 - 48 - 48 - 24 - 24)) >> (256 - 24)),
+                UFixed6.wrap(uint256(   slot1 << (256 - 24 - 48 - 48 - 24 - 24 - 24)) >> (256 - 24)),
+                UFixed6.wrap(uint256(   slot1 << (256 - 24 - 48 - 48 - 24 - 24 - 24 - 24)) >> (256 - 24))
             ),
 
             PController6(
                 UFixed6.wrap(uint256(   slot2 << (256 - 48)) >> (256 - 48)),
-                Fixed6.wrap(int256(     slot1 << (256 - 48 - 48 - 24 - 24 - 24 - 24 - 32)) >> (256 - 32)),
+                Fixed6.wrap(int256(     slot1 << (256 - 24 - 48 - 48 - 24 - 24 - 24 - 24 - 32)) >> (256 - 32)),
                 Fixed6.wrap(int256(     slot2 << (256 - 48 - 32)) >> (256 - 32))
             ),
             UFixed6.wrap(uint256(       slot2 << (256 - 48 - 32 - 48)) >> (256 - 48)),
@@ -182,13 +183,13 @@ library RiskParameterStorageLib {
             uint256(UFixed6.unwrap(newValue.efficiencyLimit)           << (256 - 24)) >> (256 - 24 - 24 - 24 - 24 - 24 - 24 - 24 - 48 - 24);
 
         uint256 encoded1 =
-            uint256(newValue.makerFee.scale.truncate()                          << (256 - 48)) >> (256 - 48) |
-            uint256(newValue.takerFee.scale.truncate()                          << (256 - 48)) >> (256 - 48 - 48) |
-            uint256(UFixed6.unwrap(newValue.utilizationCurve.minRate)           << (256 - 24)) >> (256 - 48 - 48 - 24) |
-            uint256(UFixed6.unwrap(newValue.utilizationCurve.maxRate)           << (256 - 24)) >> (256 - 48 - 48 - 24 - 24) |
-            uint256(UFixed6.unwrap(newValue.utilizationCurve.targetRate)        << (256 - 24)) >> (256 - 48 - 48 - 24 - 24 - 24) |
-            uint256(UFixed6.unwrap(newValue.utilizationCurve.targetUtilization) << (256 - 24)) >> (256 - 48 - 48 - 24 - 24 - 24 - 24) |
-            uint256(Fixed6.unwrap(newValue.pController.min)                     << (256 - 32)) >> (256 - 48 - 48 - 24 - 24 - 24 - 24 - 32);
+            uint256(newValue.makerFee.scale.truncate()                          << (256 - 48)) >> (256 - 24 - 48) |
+            uint256(newValue.takerFee.scale.truncate()                          << (256 - 48)) >> (256 - 24 - 48 - 48) |
+            uint256(UFixed6.unwrap(newValue.utilizationCurve.minRate)           << (256 - 24)) >> (256 - 24 - 48 - 48 - 24) |
+            uint256(UFixed6.unwrap(newValue.utilizationCurve.maxRate)           << (256 - 24)) >> (256 - 24 - 48 - 48 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.utilizationCurve.targetRate)        << (256 - 24)) >> (256 - 24 - 48 - 48 - 24 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.utilizationCurve.targetUtilization) << (256 - 24)) >> (256 - 24 - 48 - 48 - 24 - 24 - 24 - 24) |
+            uint256(Fixed6.unwrap(newValue.pController.min)                     << (256 - 32)) >> (256 - 24 - 48 - 48 - 24 - 24 - 24 - 24 - 32);
 
         uint256 encoded2 =
             uint256(UFixed6.unwrap(newValue.pController.k)                  << (256 - 48)) >> (256 - 48) |

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,10 +152,10 @@
   dependencies:
     "@openzeppelin/contracts" "4.6.0"
 
-"@equilibria/root@2.3.0-rc2":
-  version "2.3.0-rc2"
-  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-2.3.0-rc2.tgz#0b33e6d7f4773579953e946ad52aaed4f7451d00"
-  integrity sha512-oTv+MZH5QBWIGwS0P9BE6HCn4RYGLvy9apyYxHhaza3Xldlg13bValyvvzKTGoWiLMmPLJK/oG20ReS087Allg==
+"@equilibria/root@2.3.0-rc3":
+  version "2.3.0-rc3"
+  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-2.3.0-rc3.tgz#d11fa30cfb158bc33de382106e9d4bd45ae27875"
+  integrity sha512-od3aZ7cwEjV1bBrlJh8fQ1Wn5yymmwEqRWu3CoximIYvR3oNhcusi+LnMpYQW3TOJAj+aDCEQ9xOljC1rTPpWA==
   dependencies:
     "@openzeppelin/contracts" "4.6.0"
 


### PR DESCRIPTION
Ensures that the latest -> new storage accessors properly work in `updateRiskParameter` during the v2.3 migration process.

- Cleans up the `updateRiskParameter` logic, to require minimal backwards compatibility.
- Updates `RiskParameter` layout to ensure `takerFee.adiabatic / takerFee.scale` are backwards compatible. 