### PR TITLE
Add address metadata to OrderCreated event

### DIFF
--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -491,7 +491,7 @@ describe('Orders', () => {
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 },
             { ...DEFAULT_GUARANTEE },
             constants.AddressZero,
-            constants.AddressZero,
+            userB.address,
             constants.AddressZero,
           )
           .to.emit(market, 'OrderCreated')
@@ -506,7 +506,7 @@ describe('Orders', () => {
             },
             { ...DEFAULT_GUARANTEE },
             constants.AddressZero,
-            constants.AddressZero,
+            userB.address,
             constants.AddressZero,
           )
           .to.emit(multiInvoker, 'InterfaceFeeCharged')
@@ -559,7 +559,7 @@ describe('Orders', () => {
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 },
             { ...DEFAULT_GUARANTEE },
             constants.AddressZero,
-            constants.AddressZero,
+            userB.address,
             constants.AddressZero,
           )
           .to.emit(market, 'OrderCreated')
@@ -568,7 +568,7 @@ describe('Orders', () => {
             { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition, takerReferral: 5e6 },
             { ...DEFAULT_GUARANTEE },
             constants.AddressZero,
-            constants.AddressZero,
+            userB.address,
             constants.AddressZero,
           )
           .to.emit(multiInvoker, 'InterfaceFeeCharged')
@@ -623,7 +623,7 @@ describe('Orders', () => {
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 },
             { ...DEFAULT_GUARANTEE },
             constants.AddressZero,
-            constants.AddressZero,
+            userB.address,
             constants.AddressZero,
           )
           .to.emit(market, 'OrderCreated')
@@ -632,7 +632,7 @@ describe('Orders', () => {
             { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition, takerReferral: 5e6 },
             { ...DEFAULT_GUARANTEE },
             constants.AddressZero,
-            constants.AddressZero,
+            userB.address,
             constants.AddressZero,
           )
           .to.emit(multiInvoker, 'InterfaceFeeCharged')

--- a/packages/perennial-extensions/test/integration/core/Orders.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Orders.test.ts
@@ -490,6 +490,9 @@ describe('Orders', () => {
             user.address,
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
           .to.emit(market, 'OrderCreated')
           .withArgs(
@@ -502,6 +505,9 @@ describe('Orders', () => {
               takerReferral: 5e6,
             },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
           .to.emit(multiInvoker, 'InterfaceFeeCharged')
           .withArgs(user.address, market.address, { receiver: userB.address, amount: 50e6, unwrap: false })
@@ -552,12 +558,18 @@ describe('Orders', () => {
             user.address,
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
           .to.emit(market, 'OrderCreated')
           .withArgs(
             user.address,
             { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition, takerReferral: 5e6 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
           .to.emit(multiInvoker, 'InterfaceFeeCharged')
           .withArgs(user.address, market.address, { receiver: userB.address, amount: 50e6, unwrap: true })
@@ -610,12 +622,18 @@ describe('Orders', () => {
             user.address,
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: -50e6 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
           .to.emit(market, 'OrderCreated')
           .withArgs(
             user.address,
             { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition, takerReferral: 5e6 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
           .to.emit(multiInvoker, 'InterfaceFeeCharged')
           .withArgs(user.address, market.address, { receiver: userB.address, amount: 50e6, unwrap: true })
@@ -666,6 +684,9 @@ describe('Orders', () => {
             userB.address,
             { ...DEFAULT_ORDER, timestamp: 1631114005, collateral: collateral.div(-4) },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
 
         expect(await usdc.balanceOf(userB.address)).to.eq(balanceBefore.add(collateral.div(4)))
@@ -937,6 +958,9 @@ describe('Orders', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: 1631114005, orders: 1, longPos: userPosition },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
         })
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -603,7 +603,14 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         if (newOrder.collateral.sign() == -1) token.push(msg.sender, UFixed18Lib.from(newOrder.collateral.abs()));
 
         // events
-        emit OrderCreated(context.account, newOrder, newGuarantee);
+        emit OrderCreated(
+            context.account,
+            newOrder,
+            newGuarantee,
+            updateContext.liquidator,
+            updateContext.orderReferrer,
+            updateContext.guaranteeReferrer
+        );
     }
 
     /// @notice Processes the referral fee for the given order

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -61,7 +61,7 @@ interface IMarket is IInstance {
     }
 
     event Updated(address indexed sender, address indexed account, uint256 version, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer);
-    event OrderCreated(address indexed account, Order order, Guarantee guarantee);
+    event OrderCreated(address indexed account, Order order, Guarantee guarantee, address liquidator, address orderReferrer, address guaranteeReferrer);
     event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
     event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
     event BeneficiaryUpdated(address newBeneficiary);

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -5,7 +5,7 @@ import "./Order.sol";
 
 /// @dev Guarantee type
 struct Guarantee {
-    /// @dev The quantity of orders that are included in this guarantee
+    /// @dev The quantity of guarantees that that will be exempt from the settlement fee
     uint256 orders;
 
     /// @dev The notional of the magnitude with the price override (local only)
@@ -17,7 +17,7 @@ struct Guarantee {
     /// @dev The negative skew (close long / open short) guarantee size
     UFixed6 takerNeg;
 
-    /// @dev The magnitude of the guarantee that is applicable to the fee
+    /// @dev The magnitude of the guarantee that be exempt from the trade fee
     UFixed6 takerFee;
 
     /// @dev The referral fee multiplied by the size applicable to the referral (local only)

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -121,6 +121,9 @@ describe('Fees', () => {
           user.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, makerPos: POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       // Settle the market with a new oracle version
@@ -214,6 +217,9 @@ describe('Fees', () => {
           user.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, makerPos: POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()
@@ -322,6 +328,9 @@ describe('Fees', () => {
           userB.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: LONG_POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()
@@ -449,6 +458,9 @@ describe('Fees', () => {
           userB.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, longPos: LONG_POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()
@@ -609,6 +621,9 @@ describe('Fees', () => {
           userB.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: LONG_POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()
@@ -773,6 +788,9 @@ describe('Fees', () => {
           userB.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, shortPos: SHORT_POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()
@@ -900,6 +918,9 @@ describe('Fees', () => {
           userB.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, shortPos: SHORT_POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()
@@ -1060,6 +1081,9 @@ describe('Fees', () => {
           userB.address,
           { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, shortPos: SHORT_POSITION, collateral: COLLATERAL },
           { ...DEFAULT_GUARANTEE },
+          constants.AddressZero,
+          constants.AddressZero,
+          constants.AddressZero,
         )
 
       await nextWithConstantPrice()

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -137,6 +137,9 @@ describe('Happy Path', () => {
           makerPos: POSITION,
         },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // Check user is in the correct state
@@ -247,6 +250,9 @@ describe('Happy Path', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, makerPos: POSITION.div(2) },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // Check user is in the correct state
@@ -363,6 +369,9 @@ describe('Happy Path', () => {
           makerNeg: POSITION,
         },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // User state
@@ -437,6 +446,9 @@ describe('Happy Path', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION.div(2) },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // User state
@@ -522,6 +534,9 @@ describe('Happy Path', () => {
           longPos: POSITION_B,
         },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // User State
@@ -671,6 +686,9 @@ describe('Happy Path', () => {
         userB.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: POSITION_B.div(2) },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // User State
@@ -801,6 +819,9 @@ describe('Happy Path', () => {
           longNeg: POSITION_B,
         },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // User State
@@ -890,6 +911,9 @@ describe('Happy Path', () => {
         userB.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, longNeg: POSITION_B.div(2) },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // User State
@@ -992,6 +1016,9 @@ describe('Happy Path', () => {
         userB.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, longPos: POSITION_B, collateral: COLLATERAL },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // 50 rounds (120% max)
@@ -1037,6 +1064,9 @@ describe('Happy Path', () => {
         userB.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_1, orders: 1, shortPos: POSITION_B, collateral: COLLATERAL },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // 50 rounds (120% max)
@@ -1147,6 +1177,9 @@ describe('Happy Path', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_5, orders: 1, makerPos: POSITION.div(2), collateral: -1 },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     // Check user is in the correct state

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -39,7 +39,7 @@ describe('Liquidate', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION, protection: 1 },
         { ...DEFAULT_GUARANTEE },
-        constants.AddressZero,
+        userB.address,
         constants.AddressZero,
         constants.AddressZero,
       )
@@ -180,7 +180,7 @@ describe('Liquidate', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION, protection: 1 },
         { ...DEFAULT_GUARANTEE },
-        constants.AddressZero,
+        userB.address,
         constants.AddressZero,
         constants.AddressZero,
       )
@@ -294,7 +294,7 @@ describe('Liquidate', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_3, orders: 1, makerNeg: parse6decimal('5'), protection: 1 },
         { ...DEFAULT_GUARANTEE },
-        constants.AddressZero,
+        userC.address,
         constants.AddressZero,
         constants.AddressZero,
       )
@@ -366,8 +366,8 @@ describe('Liquidate', () => {
           makerReferral: parse6decimal('1.2'),
         },
         { ...DEFAULT_GUARANTEE },
-        constants.AddressZero,
-        constants.AddressZero,
+        userB.address,
+        userC.address,
         constants.AddressZero,
       )
 

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -39,6 +39,9 @@ describe('Liquidate', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION, protection: 1 },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
@@ -177,6 +180,9 @@ describe('Liquidate', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_2, orders: 1, makerNeg: POSITION, protection: 1 },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     await chainlink.next()
@@ -288,6 +294,9 @@ describe('Liquidate', () => {
         user.address,
         { ...DEFAULT_ORDER, timestamp: TIMESTAMP_3, orders: 1, makerNeg: parse6decimal('5'), protection: 1 },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
     expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
     expect(await market.liquidators(user.address, 2)).to.eq(userC.address)
@@ -357,6 +366,9 @@ describe('Liquidate', () => {
           makerReferral: parse6decimal('1.2'),
         },
         { ...DEFAULT_GUARANTEE },
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
       )
 
     expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -19117,7 +19117,7 @@ describe('Market', () => {
               },
               { ...DEFAULT_GUARANTEE },
               constants.AddressZero,
-              constants.AddressZero,
+              liquidator.address,
               constants.AddressZero,
             )
 
@@ -19228,7 +19228,7 @@ describe('Market', () => {
               },
               { ...DEFAULT_GUARANTEE },
               constants.AddressZero,
-              constants.AddressZero,
+              liquidator.address,
               constants.AddressZero,
             )
 
@@ -19372,7 +19372,7 @@ describe('Market', () => {
               },
               { ...DEFAULT_GUARANTEE },
               constants.AddressZero,
-              constants.AddressZero,
+              user.address,
               constants.AddressZero,
             )
 

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -945,6 +945,9 @@ describe('Market', () => {
             userB.address,
             { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION, protection: 1 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
         oracleVersion = {
           ...oracleVersion,
@@ -1141,6 +1144,9 @@ describe('Market', () => {
             userB.address,
             { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION, protection: 1 },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
         oracleVersion = {
           ...oracleVersion,
@@ -1198,12 +1204,10 @@ describe('Market', () => {
 
         // update risk parameters, introducing exposure
         await expect(
-          market
-            .connect(owner)
-            .updateRiskParameter({
-              ...defaultRiskParameter,
-              takerFee: { ...defaultRiskParameter.takerFee, scale: parse6decimal('50.5') },
-            }),
+          market.connect(owner).updateRiskParameter({
+            ...defaultRiskParameter,
+            takerFee: { ...defaultRiskParameter.takerFee, scale: parse6decimal('50.5') },
+          }),
         ).to.emit(market, 'RiskParameterUpdated')
 
         // maker exposure is 0, so
@@ -1305,6 +1309,9 @@ describe('Market', () => {
               collateral: COLLATERAL,
             },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
 
         oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1416,6 +1423,9 @@ describe('Market', () => {
               collateral: COLLATERAL,
             },
             { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
           )
 
         oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -1532,6 +1542,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1586,6 +1599,9 @@ describe('Market', () => {
                 collateral: -COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1632,6 +1648,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1688,6 +1707,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, collateral: COLLATERAL.mul(-1) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1738,6 +1760,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1794,6 +1819,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_6.timestamp, collateral: COLLATERAL.mul(-1) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -1863,6 +1891,9 @@ describe('Market', () => {
                   makerPos: POSITION,
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             expectLocalEq(await market.locals(user.address), {
@@ -1944,6 +1975,9 @@ describe('Market', () => {
                   collateral: COLLATERAL,
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2032,6 +2066,9 @@ describe('Market', () => {
                 user.address,
                 { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, makerPos: POSITION },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             expectLocalEq(await market.locals(user.address), {
@@ -2086,6 +2123,9 @@ describe('Market', () => {
                 user.address,
                 { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, makerPos: POSITION },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2153,6 +2193,9 @@ describe('Market', () => {
                 user.address,
                 { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerPos: POSITION },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             expectLocalEq(await market.locals(user.address), {
@@ -2218,6 +2261,9 @@ describe('Market', () => {
                 user.address,
                 { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerPos: POSITION },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2292,6 +2338,9 @@ describe('Market', () => {
                   collateral: COLLATERAL,
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2379,6 +2428,9 @@ describe('Market', () => {
                   collateral: COLLATERAL,
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -2461,6 +2513,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -2518,6 +2573,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2579,6 +2637,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -2640,6 +2701,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2705,6 +2769,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -2770,6 +2837,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -2827,6 +2897,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -2902,6 +2975,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3004,6 +3080,9 @@ describe('Market', () => {
                     longPos: POSITION,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -3073,6 +3152,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3144,6 +3226,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -3206,6 +3291,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3281,6 +3369,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -3354,6 +3445,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3457,6 +3551,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3578,6 +3675,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -3712,6 +3812,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3847,6 +3950,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -3905,6 +4011,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -3999,6 +4108,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -4061,6 +4173,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -4159,6 +4274,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 await settle(market, user)
@@ -4265,6 +4383,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -4380,6 +4501,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -4490,6 +4614,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -5018,6 +5145,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -5225,6 +5355,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -5473,6 +5606,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -5601,6 +5737,9 @@ describe('Market', () => {
                   userB.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -5697,6 +5836,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -5888,6 +6030,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6012,6 +6157,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6203,6 +6351,9 @@ describe('Market', () => {
                     shortPos: POSITION,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6273,6 +6424,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6344,6 +6498,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, shortPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6407,6 +6564,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, shortPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6482,6 +6642,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -6555,6 +6718,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -6663,6 +6829,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6788,6 +6957,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -6925,6 +7097,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7059,6 +7234,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -7117,6 +7295,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7212,6 +7393,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -7274,6 +7458,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7373,6 +7560,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, shortNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 await settle(market, userB)
@@ -7479,6 +7669,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, shortNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -7596,6 +7789,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -7708,6 +7904,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, shortNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -8243,6 +8442,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -8458,6 +8660,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -8683,6 +8888,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -8803,6 +9011,9 @@ describe('Market', () => {
                   userB.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -8899,6 +9110,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -9096,6 +9310,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9222,6 +9439,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -9399,6 +9619,9 @@ describe('Market', () => {
                 user.address,
                 { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, makerNeg: POSITION.div(2) },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             const marketParameter2 = { ...(await market.parameter()) }
@@ -9554,6 +9777,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9625,6 +9851,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -9697,6 +9926,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9761,6 +9993,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -9837,6 +10072,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -9911,6 +10149,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longPos: POSITION.div(2) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -10031,6 +10272,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10180,6 +10424,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10310,6 +10557,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10432,6 +10682,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10559,6 +10812,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10681,6 +10937,9 @@ describe('Market', () => {
                     collateral: COLLATERAL,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -10843,6 +11102,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -10902,6 +11164,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -11011,6 +11276,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 expectLocalEq(await market.locals(user.address), {
@@ -11074,6 +11342,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -11187,6 +11458,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 await settle(market, user)
@@ -11302,6 +11576,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(4) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -11449,6 +11726,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -11548,6 +11828,9 @@ describe('Market', () => {
                     user.address,
                     { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_3.timestamp, orders: 1, longNeg: POSITION.div(2) },
                     { ...DEFAULT_GUARANTEE },
+                    constants.AddressZero,
+                    constants.AddressZero,
+                    constants.AddressZero,
                   )
 
                 oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -12113,6 +12396,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -12367,6 +12653,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -12500,6 +12789,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -12741,6 +13033,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(user.address), {
@@ -12878,6 +13173,9 @@ describe('Market', () => {
                   userB.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -12985,6 +13283,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -13236,6 +13537,9 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               // rate_1 = rate_0 + (elapsed * skew / k)
@@ -13387,6 +13691,9 @@ describe('Market', () => {
                   user.address,
                   { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, collateral: shortfall.mul(-1) },
                   { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
                 )
 
               expectLocalEq(await market.locals(liquidator.address), {
@@ -13966,6 +14273,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longNeg: POSITION.div(2) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -14001,6 +14311,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, orders: 1, longNeg: POSITION.div(2) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -14483,6 +14796,9 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -14660,6 +14976,9 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4)
@@ -14761,6 +15080,9 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at
@@ -14788,6 +15110,9 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
           await settle(market, userB)
 
@@ -15340,6 +15665,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15496,6 +15824,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15512,6 +15843,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longPos: POSITION.div(2) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4 })
@@ -15696,6 +16030,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -15712,6 +16049,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, longPos: POSITION.div(2) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns({ ...ORACLE_VERSION_4, valid: false })
@@ -15886,6 +16226,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.status.returns([{ ...ORACLE_VERSION_2 }, ORACLE_VERSION_4.timestamp])
@@ -15901,6 +16244,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -16076,6 +16422,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.status.returns([{ ...ORACLE_VERSION_2 }, ORACLE_VERSION_4.timestamp])
@@ -16091,6 +16440,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns({ ...ORACLE_VERSION_3, valid: false })
@@ -16108,6 +16460,9 @@ describe('Market', () => {
               user.address,
               { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_5.timestamp, orders: 1, longPos: POSITION.div(2) },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_5.timestamp).returns({ ...ORACLE_VERSION_5 })
@@ -16286,6 +16641,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -16676,6 +17034,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -16755,6 +17116,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           expectLocalEq(await market.locals(user.address), {
@@ -16897,6 +17261,9 @@ describe('Market', () => {
                 longPos: POSITION.div(2),
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
             .to.emit(market, 'OrderCreated')
             .withArgs(
@@ -16909,6 +17276,9 @@ describe('Market', () => {
                 takerReferral: POSITION.div(2).mul(2).div(10),
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -18729,6 +19099,9 @@ describe('Market', () => {
                 makerReferral: POSITION.div(5),
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -18837,6 +19210,9 @@ describe('Market', () => {
                 takerReferral: POSITION.div(10),
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -18978,6 +19354,9 @@ describe('Market', () => {
                 takerReferral: POSITION.div(10),
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -19101,6 +19480,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -19116,6 +19498,9 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at
@@ -19270,6 +19655,9 @@ describe('Market', () => {
                 collateral: COLLATERAL,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -19285,6 +19673,9 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
@@ -19306,6 +19697,9 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
               },
               { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4) // latest
@@ -19441,7 +19835,7 @@ describe('Market', () => {
         })
 
         context('opens position', async () => {
-          it('fills the positions and settles later with fee (above / long)', async () => {
+          it.only('fills the positions and settles later with fee (above / long)', async () => {
             factory.parameter.returns({
               maxPendingIds: 5,
               protocolFee: parse6decimal('0.50'),
@@ -19512,7 +19906,7 @@ describe('Market', () => {
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
-                user.address,
+                user.address, // (address: string) => {console.log("test", address); return true}, (calls)
                 {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_2.timestamp,
@@ -19520,6 +19914,9 @@ describe('Market', () => {
                   longPos: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero, // (address: string) => {console.log("test", address); return true}, (does not call)
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -19532,8 +19929,10 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
-
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -19722,6 +20121,9 @@ describe('Market', () => {
                   shortPos: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -19734,6 +20136,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -19924,6 +20329,9 @@ describe('Market', () => {
                   longPos: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -19936,6 +20344,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -20126,6 +20537,9 @@ describe('Market', () => {
                   shortPos: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20138,6 +20552,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -20343,6 +20760,9 @@ describe('Market', () => {
                   longNeg: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20355,6 +20775,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -20561,6 +20984,9 @@ describe('Market', () => {
                   shortNeg: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20573,6 +20999,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -20779,6 +21208,9 @@ describe('Market', () => {
                   shortPos: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20791,6 +21223,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -20999,6 +21434,9 @@ describe('Market', () => {
                   longPos: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21011,6 +21449,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -21225,6 +21666,9 @@ describe('Market', () => {
                   longNeg: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21237,6 +21681,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -21451,6 +21898,9 @@ describe('Market', () => {
                   shortNeg: POSITION.div(2),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21463,6 +21913,9 @@ describe('Market', () => {
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 { ...DEFAULT_GUARANTEE },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -57,14 +57,16 @@ const TIMESTAMP = 1636401093
 const PRICE = parse6decimal('123')
 
 const DEFAULT_VERSION_ACCUMULATION_RESULT = {
-  positionFee: 0,
-  positionFeeMaker: 0,
-  positionFeeProtocol: 0,
-  positionFeeSubtractive: 0,
-  positionFeeExposure: 0,
-  positionFeeExposureMaker: 0,
-  positionFeeExposureProtocol: 0,
-  positionFeeImpact: 0,
+  tradeFee: 0,
+  subtractiveFee: 0,
+
+  tradeOffset: 0,
+  tradeOffsetMaker: 0,
+  tradeOffsetMarket: 0,
+
+  adiabaticExposure: 0,
+  adiabaticExposureMaker: 0,
+  adiabaticExposureMarket: 0,
 
   fundingMaker: 0,
   fundingLong: 0,
@@ -86,12 +88,13 @@ const DEFAULT_VERSION_ACCUMULATION_RESULT = {
 
 const DEFAULT_LOCAL_ACCUMULATION_RESULT = {
   collateral: 0,
-  linearFee: 0,
-  proportionalFee: 0,
-  adiabaticFee: 0,
-  subtractiveFee: 0,
+  priceOverride: 0,
+  tradeFee: 0,
+  offset: 0,
   settlementFee: 0,
   liquidationFee: 0,
+  subtractiveFee: 0,
+  solverFee: 0,
 }
 
 const ORACLE_VERSION_0 = {
@@ -945,7 +948,7 @@ describe('Market', () => {
             userB.address,
             { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION, protection: 1 },
             { ...DEFAULT_GUARANTEE },
-            constants.AddressZero,
+            liquidator.address,
             constants.AddressZero,
             constants.AddressZero,
           )
@@ -1144,7 +1147,7 @@ describe('Market', () => {
             userB.address,
             { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_4.timestamp, orders: 1, makerNeg: POSITION, protection: 1 },
             { ...DEFAULT_GUARANTEE },
-            constants.AddressZero,
+            liquidator.address,
             constants.AddressZero,
             constants.AddressZero,
           )
@@ -5145,7 +5148,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -5355,7 +5358,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -5606,7 +5609,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -5836,7 +5839,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -6030,7 +6033,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -8442,7 +8445,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -8660,7 +8663,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -8888,7 +8891,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -9110,7 +9113,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -9310,7 +9313,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -12396,7 +12399,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -12653,7 +12656,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -12789,7 +12792,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -13033,7 +13036,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -13283,7 +13286,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -13537,7 +13540,7 @@ describe('Market', () => {
                     protection: 1,
                   },
                   { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
+                  liquidator.address,
                   constants.AddressZero,
                   constants.AddressZero,
                 )
@@ -14796,7 +14799,7 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
+              liquidator.address,
               constants.AddressZero,
               constants.AddressZero,
             )
@@ -14976,7 +14979,7 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
+              liquidator.address,
               constants.AddressZero,
               constants.AddressZero,
             )
@@ -15080,7 +15083,7 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
+              liquidator.address,
               constants.AddressZero,
               constants.AddressZero,
             )
@@ -15110,7 +15113,7 @@ describe('Market', () => {
                 protection: 1,
               },
               { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
+              liquidator.address,
               constants.AddressZero,
               constants.AddressZero,
             )
@@ -17260,7 +17263,14 @@ describe('Market', () => {
                 orders: 1,
                 longPos: POSITION.div(2),
               },
-              { ...DEFAULT_GUARANTEE },
+              {
+                ...DEFAULT_GUARANTEE,
+                orders: 1,
+                takerPos: POSITION.div(2),
+                notional: POSITION.div(2).mul(125),
+                takerFee: POSITION.div(2),
+                referral: 0,
+              },
               constants.AddressZero,
               constants.AddressZero,
               constants.AddressZero,
@@ -17275,10 +17285,17 @@ describe('Market', () => {
                 shortPos: POSITION.div(2),
                 takerReferral: POSITION.div(2).mul(2).div(10),
               },
-              { ...DEFAULT_GUARANTEE },
+              {
+                ...DEFAULT_GUARANTEE,
+                orders: 0,
+                takerNeg: POSITION.div(2),
+                notional: -POSITION.div(2).mul(125),
+                takerFee: 0,
+                referral: POSITION.div(2).div(10),
+              },
               constants.AddressZero,
-              constants.AddressZero,
-              constants.AddressZero,
+              liquidator.address, // originator
+              owner.address, // solver
             )
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -19835,7 +19852,7 @@ describe('Market', () => {
         })
 
         context('opens position', async () => {
-          it.only('fills the positions and settles later with fee (above / long)', async () => {
+          it('fills the positions and settles later with fee (above / long)', async () => {
             factory.parameter.returns({
               maxPendingIds: 5,
               protocolFee: parse6decimal('0.50'),
@@ -19906,15 +19923,22 @@ describe('Market', () => {
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
-                user.address, // (address: string) => {console.log("test", address); return true}, (calls)
+                user.address,
                 {
                   ...DEFAULT_ORDER,
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
-                constants.AddressZero, // (address: string) => {console.log("test", address); return true}, (does not call)
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
+                constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
               )
@@ -19928,10 +19952,17 @@ describe('Market', () => {
                   shortPos: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
 
@@ -20120,7 +20151,14 @@ describe('Market', () => {
                   orders: 1,
                   shortPos: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -20135,10 +20173,17 @@ describe('Market', () => {
                   longPos: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -20328,7 +20373,14 @@ describe('Market', () => {
                   orders: 1,
                   longPos: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(121),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -20343,10 +20395,17 @@ describe('Market', () => {
                   shortPos: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(121),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -20536,7 +20595,14 @@ describe('Market', () => {
                   orders: 1,
                   shortPos: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(121),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -20551,10 +20617,17 @@ describe('Market', () => {
                   longPos: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(121),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
@@ -20759,7 +20832,14 @@ describe('Market', () => {
                   orders: 1,
                   longNeg: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -20774,10 +20854,17 @@ describe('Market', () => {
                   longPos: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -20983,7 +21070,14 @@ describe('Market', () => {
                   orders: 1,
                   shortNeg: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -20998,10 +21092,17 @@ describe('Market', () => {
                   shortPos: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -21207,7 +21308,14 @@ describe('Market', () => {
                   orders: 1,
                   shortPos: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -21222,10 +21330,17 @@ describe('Market', () => {
                   shortNeg: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -21433,7 +21548,14 @@ describe('Market', () => {
                   orders: 1,
                   longPos: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -21448,10 +21570,17 @@ describe('Market', () => {
                   longNeg: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -21665,7 +21794,14 @@ describe('Market', () => {
                   orders: 1,
                   longNeg: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -21680,10 +21816,17 @@ describe('Market', () => {
                   shortNeg: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
@@ -21897,7 +22040,14 @@ describe('Market', () => {
                   orders: 1,
                   shortNeg: POSITION.div(2),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
                 constants.AddressZero,
                 constants.AddressZero,
                 constants.AddressZero,
@@ -21912,10 +22062,17 @@ describe('Market', () => {
                   longNeg: POSITION.div(2),
                   takerReferral: POSITION.div(2).mul(2).div(10),
                 },
-                { ...DEFAULT_GUARANTEE },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
 
             oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)

--- a/patches/@nomicfoundation+hardhat-chai-matchers+1.0.6.patch
+++ b/patches/@nomicfoundation+hardhat-chai-matchers+1.0.6.patch
@@ -1,24 +1,30 @@
 diff --git a/node_modules/@nomicfoundation/hardhat-chai-matchers/internal/emit.js b/node_modules/@nomicfoundation/hardhat-chai-matchers/internal/emit.js
-index 9251f34..865651a 100644
+index 9251f34..897b581 100644
 --- a/node_modules/@nomicfoundation/hardhat-chai-matchers/internal/emit.js
 +++ b/node_modules/@nomicfoundation/hardhat-chai-matchers/internal/emit.js
-@@ -112,6 +112,12 @@ function assertArgsArraysEqual(context, Assertion, chaiUtils, expectedArgs, log,
+@@ -112,7 +112,13 @@ function assertArgsArraysEqual(context, Assertion, chaiUtils, expectedArgs, log,
                  new Assertion(actualArgs[index].hash, undefined, ssfi, true).to.equal(expectedHash, `The actual value was an indexed and hashed value of the event argument. The expected value provided to the assertion was hashed to produce ${expectedHash}. The actual hash and the expected hash did not match`);
              }
              else {
+-                new Assertion(actualArgs[index], undefined, ssfi, true).equal(expectedArgs[index]);
 +                if (isStruct(actualArgs[index])) {
 +                    new Assertion(
 +                        convertStructToPlainObject(actualArgs[index])
 +                    ).to.deep.equal(expectedArgs[index]);
-+                    return;
++                } else {
++                    new Assertion(actualArgs[index], undefined, ssfi, true).equal(expectedArgs[index]);
 +                }
-                 new Assertion(actualArgs[index], undefined, ssfi, true).equal(expectedArgs[index]);
              }
          }
-@@ -135,4 +141,23 @@ const tryAssertArgsArraysEqual = (context, Assertion, chaiUtils, expectedArgs, l
+     }
+@@ -133,6 +139,26 @@ const tryAssertArgsArraysEqual = (context, Assertion, chaiUtils, expectedArgs, l
+         }
+     }
      const eventName = chaiUtils.flag(context, "eventName");
-     assert(false, `The specified arguments (${util_1.default.inspect(expectedArgs)}) were not included in any of the ${context.logs.length} emitted "${eventName}" events`);
- };
+-    assert(false, `The specified arguments (${util_1.default.inspect(expectedArgs)}) were not included in any of the ${context.logs.length} emitted "${eventName}" events`);
++    const allEvents = logs.map(log => chaiUtils.flag(context, "contract").interface.parseLog(log).args);
++    assert(false, `The specified arguments (${util_1.default.inspect(expectedArgs)}) were not included in any of the ${context.logs.length} emitted "${eventName}" events\n\n${util_1.default.inspect(allEvents)}`);
++};
 +const isStruct = (arr) => {
 +    if (!Array.isArray(arr)) return false;
 +    const keys = Object.keys(arr);
@@ -37,5 +43,6 @@ index 9251f34..865651a 100644
 +        }),
 +        {}
 +    );
-+};
+ };
  //# sourceMappingURL=emit.js.map
+\ No newline at end of file

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,7 +1715,7 @@
 
 "@nomicfoundation/hardhat-chai-matchers@^1.0.6":
   version "1.0.6"
-  resolved "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.6.tgz"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.6.tgz#72a2e312e1504ee5dd73fe302932736432ba96bc"
   integrity sha512-f5ZMNmabZeZegEfuxn/0kW+mm7+yV7VNDxLpMOMGXWFJ2l/Ct3QShujzDRF9cOkK9Ui/hbDeOWGZqyQALDXVCQ==
   dependencies:
     "@ethersproject/abi" "^5.1.2"


### PR DESCRIPTION
- Adds `liquidator`, `orderReferrer`, and `guaranteeReferrer` to the `OrderCreated` event.
- Incorporates https://github.com/equilibria-xyz/perennial-v2/pull/359 into v2.3.
- Adds extra logic to `hardhat-chai-matchers` to output all eligible events in the event that a `.to.emit().withArgs()` fails.