### PR TITLE
Add newPrice option oracle request

### DIFF
--- a/packages/perennial-extensions/test/integration/core/Pyth.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Pyth.test.ts
@@ -120,7 +120,7 @@ describe('PythOracleFactory', () => {
   describe('PerennialAction.COMMIT_PRICE', async () => {
     it('commits a requested pyth version', async () => {
       const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
-      await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+      await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
       // Base fee isn't working properly in coverage, so we need to set it manually
       await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1000'])

--- a/packages/perennial-oracle/contracts/Oracle.sol
+++ b/packages/perennial-oracle/contracts/Oracle.sol
@@ -35,12 +35,13 @@ contract Oracle is IOracle, Instance {
     /// @notice Requests a new version at the current timestamp
     /// @param market Original market to optionally use for callbacks
     /// @param account Original sender to optionally use for callbacks
-    function request(IMarket market, address account) external onlyAuthorized {
+    /// @param newPrice Whether a new price should be requested
+    function request(IMarket market, address account, bool newPrice) external onlyAuthorized {
         (OracleVersion memory latestVersion, uint256 currentTimestamp) = oracles[global.current].provider.status();
 
         oracles[
             (currentTimestamp > oracles[global.latest].timestamp) ? global.current : global.latest
-        ].provider.request(market, account);
+        ].provider.request(market, account, newPrice);
 
         oracles[global.current].timestamp = uint96(currentTimestamp);
         _updateLatest(latestVersion);

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -552,7 +552,7 @@ testOracles.forEach(testOracle => {
       it('commits successfully and incentivizes the keeper', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
         const originalFactoryDSUBalance = await dsu.callStatic.balanceOf(oracleFactory.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.globalCallbacks(STARTING_TIME)).to.deep.eq([market.address])
         expect(await keeperOracle.localCallbacks(STARTING_TIME, market.address)).to.deep.eq([user.address])
 
@@ -584,7 +584,7 @@ testOracles.forEach(testOracle => {
       it('commits successfully with payoff and incentivizes the keeper', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
         const originalFactoryDSUBalance = await dsu.callStatic.balanceOf(oracleFactory.address)
-        await keeperOraclePayoff.connect(oracleSigner).request(market.address, user.address)
+        await keeperOraclePayoff.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOraclePayoff.globalCallbacks(STARTING_TIME)).to.deep.eq([market.address])
         expect(await keeperOraclePayoff.localCallbacks(STARTING_TIME, market.address)).to.deep.eq([user.address])
 
@@ -625,7 +625,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('does not allow committing with invalid signature', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
@@ -645,7 +645,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('does not allow committing with invalid signature', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
@@ -665,7 +665,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('does not allow committing with no signature', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
@@ -706,7 +706,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('commits successfully if report is barely not too early', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
 
@@ -723,7 +723,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('commits successfully if report is barely not too late', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
 
@@ -752,7 +752,7 @@ testOracles.forEach(testOracle => {
             .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME + 3, listify(PAYLOAD)),
         ).to.revertedWithCustomError(metaquantsOracleFactory, 'KeeperFactoryVersionOutsideRangeError')
 
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
 
@@ -771,13 +771,13 @@ testOracles.forEach(testOracle => {
       })
 
       it('does not commit a version that has already been committed', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME, listify(PAYLOAD))
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await expect(
           metaquantsOracleFactory
             .connect(user)
@@ -786,8 +786,8 @@ testOracles.forEach(testOracle => {
       })
 
       it('cannot skip a version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.versions(2)).to.be.equal(STARTING_TIME + 1)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
@@ -799,9 +799,9 @@ testOracles.forEach(testOracle => {
       })
 
       it('cannot skip a version if the grace period has expired', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await time.increase(59)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.versions(2)).to.be.equal(STARTING_TIME + 60)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
@@ -860,13 +860,13 @@ testOracles.forEach(testOracle => {
       })
 
       it('can commit if there are committed versions and requested versions', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await time.increase(1)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME, listify(PAYLOAD))
         await time.increaseTo(STARTING_TIME + 160)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         const secondRequestedVersion = await currentBlockTimestamp()
         const nonRequestedOracleVersion = STARTING_TIME + 60
         await metaquantsOracleFactory
@@ -890,7 +890,7 @@ testOracles.forEach(testOracle => {
 
       it('must be more recent than the most recently committed version', async () => {
         await time.increase(2)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME + 2, listify(PAYLOAD))
@@ -904,7 +904,7 @@ testOracles.forEach(testOracle => {
 
       it('does not commitRequested if oracleVersion is incorrect', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
         await metaquantsOracleFactory
@@ -930,7 +930,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('cant commit non-requested version until after an invalid has passed grace period', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect((await keeperOracle.global()).latestIndex).to.equal(0)
 
         await time.increase(59)
@@ -942,7 +942,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('reverts if committing invalid non-requested version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect((await keeperOracle.global()).latestIndex).to.equal(0)
 
         await time.increase(60)
@@ -980,7 +980,7 @@ testOracles.forEach(testOracle => {
       it('settles successfully and incentivizes the keeper', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
         const originalFactoryDSUBalance = await dsu.callStatic.balanceOf(oracleFactory.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
@@ -1014,7 +1014,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('reverts if array lengths mismatch', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME, listify(PAYLOAD))
@@ -1038,7 +1038,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('reverts if calldata is ids is empty', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME, listify(PAYLOAD))
@@ -1052,7 +1052,7 @@ testOracles.forEach(testOracle => {
 
     describe('#status', async () => {
       it('returns the correct versions', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME, listify(PAYLOAD))
@@ -1075,11 +1075,27 @@ testOracles.forEach(testOracle => {
       it('can request a version', async () => {
         // No requested versions
         expect((await keeperOracle.global()).currentIndex).to.equal(0)
-        await expect(keeperOracle.connect(oracleSigner).request(market.address, user.address))
+        await expect(keeperOracle.connect(oracleSigner).request(market.address, user.address, true))
           .to.emit(keeperOracle, 'OracleProviderVersionRequested')
-          .withArgs(STARTING_TIME)
+          .withArgs(STARTING_TIME, true)
         // Now there is exactly one requested version
         expect(await keeperOracle.versions(1)).to.equal(STARTING_TIME)
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+      })
+
+      it('can request a version (no new price)', async () => {
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await increase(10)
+
+        // One requested version
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+        await expect(keeperOracle.connect(oracleSigner).request(market.address, user.address, false))
+          .to.emit(keeperOracle, 'OracleProviderVersionRequested')
+          .withArgs(STARTING_TIME + 11, false)
+
+        // Should link back to requested version
+        expect(await keeperOracle.versions(1)).to.equal(STARTING_TIME)
+        expect(await keeperOracle.links(STARTING_TIME + 11)).to.equal(STARTING_TIME)
         expect((await keeperOracle.global()).currentIndex).to.equal(1)
       })
 
@@ -1088,7 +1104,7 @@ testOracles.forEach(testOracle => {
 
         // No requested versions
         expect((await keeperOracle.global()).currentIndex).to.equal(0)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         const currentTimestamp = await metaquantsOracleFactory.current()
 
         // Now there is exactly one requested version
@@ -1104,22 +1120,77 @@ testOracles.forEach(testOracle => {
         const badSigner = await impersonateWithBalance(badInstance.address, utils.parseEther('10'))
 
         await expect(
-          keeperOracle.connect(badSigner).request(market.address, user.address),
+          keeperOracle.connect(badSigner).request(market.address, user.address, true),
         ).to.be.revertedWithCustomError(keeperOracle, 'OracleProviderUnauthorizedError')
       })
 
-      it('a version can only be requested once', async () => {
+      it('a version can only be requested once (new, new)', async () => {
         await ethers.provider.send('evm_setAutomine', [false])
         await ethers.provider.send('evm_setIntervalMining', [0])
 
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
         await ethers.provider.send('evm_mine', [])
 
         const currentTimestamp = await metaquantsOracleFactory.current()
         expect(await keeperOracle.callStatic.versions(1)).to.equal(currentTimestamp)
         expect(await keeperOracle.callStatic.versions(2)).to.equal(0)
+      })
+
+      it('a version can only be requested once (no new, no new)', async () => {
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await increase(10)
+
+        await ethers.provider.send('evm_setAutomine', [false])
+        await ethers.provider.send('evm_setIntervalMining', [0])
+
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+
+        await ethers.provider.send('evm_mine', [])
+
+        const currentTimestamp = await metaquantsOracleFactory.current()
+        expect(await keeperOracle.versions(1)).to.equal(STARTING_TIME)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(STARTING_TIME)
+        expect(await keeperOracle.versions(2)).to.equal(0)
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+      })
+
+      it('a version can only be requested once (new, no new)', async () => {
+        await ethers.provider.send('evm_setAutomine', [false])
+        await ethers.provider.send('evm_setIntervalMining', [0])
+
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+
+        await ethers.provider.send('evm_mine', [])
+
+        const currentTimestamp = await metaquantsOracleFactory.current()
+        expect(await keeperOracle.versions(1)).to.equal(currentTimestamp)
+        expect(await keeperOracle.versions(2)).to.equal(0)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(0)
+      })
+
+      it('a new price request will overtake a previous no new price request', async () => {
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await increase(10)
+
+        await ethers.provider.send('evm_setAutomine', [false])
+        await ethers.provider.send('evm_setIntervalMining', [0])
+
+        // One requested version
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+
+        await ethers.provider.send('evm_mine', [])
+
+        const currentTimestamp = await metaquantsOracleFactory.current()
+        expect(await keeperOracle.versions(1)).to.equal(currentTimestamp.sub(11))
+        expect(await keeperOracle.versions(2)).to.equal(currentTimestamp)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(0)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(0)
       })
     })
 
@@ -1237,7 +1308,7 @@ testOracles.forEach(testOracle => {
 
     describe('#atVersion', async () => {
       it('returns the correct version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await metaquantsOracleFactory
           .connect(user)
           .commit([METAQUANTS_BAYC_ETH_PRICE_FEED], STARTING_TIME, listify(PAYLOAD))
@@ -1252,7 +1323,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('returns invalid version if that version was requested but not committed', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         const version = await keeperOracle.connect(user).at(STARTING_TIME)
         expect(version.valid).to.be.false
       })

--- a/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -520,7 +520,7 @@ testOracles.forEach(testOracle => {
       it('commits successfully and incentivizes the keeper', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
         const originalFactoryDSUBalance = await dsu.callStatic.balanceOf(oracleFactory.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.globalCallbacks(STARTING_TIME)).to.deep.eq([market.address])
         expect(await keeperOracle.localCallbacks(STARTING_TIME, market.address)).to.deep.eq([user.address])
 
@@ -553,7 +553,7 @@ testOracles.forEach(testOracle => {
       it('commits successfully with payoff and incentivizes the keeper', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
         const originalFactoryDSUBalance = await dsu.callStatic.balanceOf(oracleFactory.address)
-        await keeperOraclePayoff.connect(oracleSigner).request(market.address, user.address)
+        await keeperOraclePayoff.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOraclePayoff.globalCallbacks(STARTING_TIME)).to.deep.eq([market.address])
         expect(await keeperOraclePayoff.localCallbacks(STARTING_TIME, market.address)).to.deep.eq([user.address])
 
@@ -584,7 +584,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('commits successfully if report is barely not too early', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
 
@@ -601,7 +601,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('commits successfully if report is barely not too late', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
 
@@ -618,7 +618,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('fails to commit if report is outside of time range', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
 
@@ -640,7 +640,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('fails to commit if update fee is not provided', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
         await expect(
@@ -649,13 +649,13 @@ testOracles.forEach(testOracle => {
       })
 
       it('does not commit a version that has already been committed', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await expect(
           chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
             value: getFee(REPORT),
@@ -664,7 +664,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('rejects invalid update data', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
         await expect(
@@ -675,8 +675,8 @@ testOracles.forEach(testOracle => {
       })
 
       it('cannot skip a version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.versions(2)).to.be.equal(STARTING_TIME + 1)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
@@ -688,9 +688,9 @@ testOracles.forEach(testOracle => {
       })
 
       it('cannot skip a version if the grace period has expired', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await time.increase(59)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
         expect(await keeperOracle.versions(2)).to.be.equal(STARTING_TIME + 60)
         expect(await keeperOracle.next()).to.be.equal(STARTING_TIME)
@@ -734,14 +734,14 @@ testOracles.forEach(testOracle => {
 
       it('can commit if there are requested versions but no committed versions', async () => {
         await time.increase(30)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
       })
 
       it('can commit if there are committed versions but no requested versions', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
@@ -754,13 +754,13 @@ testOracles.forEach(testOracle => {
       })
 
       it('can commit if there are committed versions and requested versions', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await time.increase(1)
         await chainlinkOracleFactory
           .connect(user)
           .commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, { value: getFee(REPORT) })
         await time.increaseTo(STARTING_TIME + 160)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         const secondRequestedVersion = await currentBlockTimestamp()
         const nonRequestedOracleVersion = STARTING_TIME + 60
         await chainlinkOracleFactory
@@ -788,7 +788,7 @@ testOracles.forEach(testOracle => {
 
       it('must be more recent than the most recently committed version', async () => {
         await time.increase(2)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME + 2, REPORT, {
           value: getFee(REPORT),
         })
@@ -802,7 +802,7 @@ testOracles.forEach(testOracle => {
 
       it('does not commitRequested if oracleVersion is incorrect', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME - 1, REPORT, {
@@ -829,7 +829,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('cant commit non-requested version until after an invalid has passed grace period', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect((await keeperOracle.global()).latestIndex).to.equal(0)
 
         await time.increase(59)
@@ -843,7 +843,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('reverts if committing invalid non-requested version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         expect((await keeperOracle.global()).latestIndex).to.equal(0)
 
         await time.increase(60)
@@ -856,7 +856,7 @@ testOracles.forEach(testOracle => {
         await time.increaseTo(BATCH_STARTING_TIME - 1)
 
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
         await chainlinkOracleFactory
           .connect(user)
@@ -889,7 +889,7 @@ testOracles.forEach(testOracle => {
       it('settles successfully and incentivizes the keeper', async () => {
         const originalDSUBalance = await dsu.callStatic.balanceOf(user.address)
         const originalFactoryDSUBalance = await dsu.callStatic.balanceOf(oracleFactory.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         // Base fee isn't working properly in coverage, so we need to set it manually
         await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x5F5E100'])
         expect(await keeperOracle.versions(1)).to.be.equal(STARTING_TIME)
@@ -922,7 +922,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('reverts if array lengths mismatch', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
@@ -946,7 +946,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('reverts if calldata is ids is empty', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
@@ -960,7 +960,7 @@ testOracles.forEach(testOracle => {
 
     describe('#status', async () => {
       it('returns the correct versions', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
@@ -983,11 +983,27 @@ testOracles.forEach(testOracle => {
       it('can request a version', async () => {
         // No requested versions
         expect((await keeperOracle.global()).currentIndex).to.equal(0)
-        await expect(keeperOracle.connect(oracleSigner).request(market.address, user.address))
+        await expect(keeperOracle.connect(oracleSigner).request(market.address, user.address, true))
           .to.emit(keeperOracle, 'OracleProviderVersionRequested')
-          .withArgs(STARTING_TIME)
+          .withArgs(STARTING_TIME, true)
         // Now there is exactly one requested version
         expect(await keeperOracle.versions(1)).to.equal(STARTING_TIME)
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+      })
+
+      it('can request a version (no new price)', async () => {
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await increase(10)
+
+        // One requested version
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+        await expect(keeperOracle.connect(oracleSigner).request(market.address, user.address, false))
+          .to.emit(keeperOracle, 'OracleProviderVersionRequested')
+          .withArgs(STARTING_TIME + 11, false)
+
+        // Should link back to requested version
+        expect(await keeperOracle.versions(1)).to.equal(STARTING_TIME)
+        expect(await keeperOracle.links(STARTING_TIME + 11)).to.equal(STARTING_TIME)
         expect((await keeperOracle.global()).currentIndex).to.equal(1)
       })
 
@@ -996,7 +1012,7 @@ testOracles.forEach(testOracle => {
 
         // No requested versions
         expect((await keeperOracle.global()).currentIndex).to.equal(0)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         const currentTimestamp = await chainlinkOracleFactory.current()
 
         // Now there is exactly one requested version
@@ -1012,16 +1028,16 @@ testOracles.forEach(testOracle => {
         const badSigner = await impersonateWithBalance(badInstance.address, utils.parseEther('10'))
 
         await expect(
-          keeperOracle.connect(badSigner).request(market.address, user.address),
+          keeperOracle.connect(badSigner).request(market.address, user.address, true),
         ).to.be.revertedWithCustomError(keeperOracle, 'OracleProviderUnauthorizedError')
       })
 
-      it('a version can only be requested once', async () => {
+      it('a version can only be requested once (new, new)', async () => {
         await ethers.provider.send('evm_setAutomine', [false])
         await ethers.provider.send('evm_setIntervalMining', [0])
 
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
         await ethers.provider.send('evm_mine', [])
 
@@ -1029,11 +1045,66 @@ testOracles.forEach(testOracle => {
         expect(await keeperOracle.callStatic.versions(1)).to.equal(currentTimestamp)
         expect(await keeperOracle.callStatic.versions(2)).to.equal(0)
       })
+
+      it('a version can only be requested once (no new, no new)', async () => {
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await increase(10)
+
+        await ethers.provider.send('evm_setAutomine', [false])
+        await ethers.provider.send('evm_setIntervalMining', [0])
+
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+
+        await ethers.provider.send('evm_mine', [])
+
+        const currentTimestamp = await chainlinkOracleFactory.current()
+        expect(await keeperOracle.versions(1)).to.equal(STARTING_TIME)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(STARTING_TIME)
+        expect(await keeperOracle.versions(2)).to.equal(0)
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+      })
+
+      it('a version can only be requested once (new, no new)', async () => {
+        await ethers.provider.send('evm_setAutomine', [false])
+        await ethers.provider.send('evm_setIntervalMining', [0])
+
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+
+        await ethers.provider.send('evm_mine', [])
+
+        const currentTimestamp = await chainlinkOracleFactory.current()
+        expect(await keeperOracle.versions(1)).to.equal(currentTimestamp)
+        expect(await keeperOracle.versions(2)).to.equal(0)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(0)
+      })
+
+      it('a new price request will overtake a previous no new price request', async () => {
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+        await increase(10)
+
+        await ethers.provider.send('evm_setAutomine', [false])
+        await ethers.provider.send('evm_setIntervalMining', [0])
+
+        // One requested version
+        expect((await keeperOracle.global()).currentIndex).to.equal(1)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, false)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+
+        await ethers.provider.send('evm_mine', [])
+
+        const currentTimestamp = await chainlinkOracleFactory.current()
+        expect(await keeperOracle.versions(1)).to.equal(currentTimestamp.sub(11))
+        expect(await keeperOracle.versions(2)).to.equal(currentTimestamp)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(0)
+        expect(await keeperOracle.links(currentTimestamp)).to.equal(0)
+      })
     })
 
     describe('#latest', async () => {
       it('returns the latest version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
@@ -1147,7 +1218,7 @@ testOracles.forEach(testOracle => {
 
     describe('#atVersion', async () => {
       it('returns the correct version', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         await chainlinkOracleFactory.connect(user).commit([CHAINLINK_ETH_USD_PRICE_FEED], STARTING_TIME, REPORT, {
           value: getFee(REPORT),
         })
@@ -1162,7 +1233,7 @@ testOracles.forEach(testOracle => {
       })
 
       it('returns invalid version if that version was requested but not committed', async () => {
-        await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+        await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
         const version = await keeperOracle.connect(user).at(STARTING_TIME)
         expect(version.valid).to.be.false
       })

--- a/packages/perennial-oracle/test/unit/chainlink/ChainlinkFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/chainlink/ChainlinkFactory.test.ts
@@ -169,7 +169,7 @@ describe('ChainlinkFactory', () => {
   })
 
   it('parses Chainlink report correctly', async () => {
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
     const report = listify(
       overwriteTimestamp(
@@ -191,7 +191,7 @@ describe('ChainlinkFactory', () => {
   })
 
   it('commit reverts if msg.value is too low', async () => {
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
 
     const report = listify(
       overwriteTimestamp(

--- a/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
@@ -201,7 +201,7 @@ describe('KeeperOracle', () => {
 
     // request a version
     await increase(10)
-    const tx = await keeperOracle.connect(oracleSigner).request(market.address, user.address, {
+    const tx = await keeperOracle.connect(oracleSigner).request(market.address, user.address, true, {
       maxFeePerGas: 100000000,
     })
     // TODO: weaponize this transaction-to-blocktime facility into a utility function

--- a/packages/perennial-oracle/test/unit/oracle/Oracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/Oracle.test.ts
@@ -181,7 +181,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687230000)
         expect(latestVersion.price).to.equal(parse6decimal('1000'))
@@ -230,7 +230,7 @@ describe('Oracle', () => {
           },
           1687230905,
         )
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
         await expect(oracle.connect(oracleFactorySigner).update(underlying1.address))
           .to.emit(oracle, 'OracleUpdated')
           .withArgs(underlying1.address)
@@ -268,7 +268,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687230005)
         expect(latestVersion.price).to.equal(parse6decimal('1001'))
@@ -315,7 +315,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687230605)
         expect(latestVersion.price).to.equal(parse6decimal('1006'))
@@ -362,7 +362,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687230905)
         expect(latestVersion.price).to.equal(parse6decimal('1006'))
@@ -414,7 +414,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687230905)
         expect(latestVersion.price).to.equal(parse6decimal('1006'))
@@ -461,7 +461,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687230955)
         expect(latestVersion.price).to.equal(parse6decimal('1007'))
@@ -499,7 +499,7 @@ describe('Oracle', () => {
           },
           1687231005,
         )
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         mockVersion(
           underlying1,
@@ -519,7 +519,7 @@ describe('Oracle', () => {
           await oracle.connect(caller).current(),
         ]
         const [latestVersion, currentTimestamp] = await oracle.connect(caller).status()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect(latestVersion.timestamp).to.equal(1687235000)
         expect(latestVersion.price).to.equal(parse6decimal('1015'))
@@ -561,7 +561,7 @@ describe('Oracle', () => {
         underlying0.request.reset()
         underlying1.request.reset()
 
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect((await oracle.at(0)).timestamp).to.equal(0)
         expect((await oracle.at(0)).price).to.equal(parse6decimal('0'))
@@ -607,7 +607,7 @@ describe('Oracle', () => {
           },
           1687230905,
         )
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         mockVersion(
           underlying0,
@@ -681,7 +681,7 @@ describe('Oracle', () => {
         )
         underlying1.request.reset()
         underlying2.request.reset()
-        await oracle.connect(caller).request(market.address, user.address)
+        await oracle.connect(caller).request(market.address, user.address, true)
 
         expect((await oracle.global()).latest).to.equal(2)
         expect((await oracle.oracles(1)).timestamp).to.equal(0)
@@ -726,7 +726,7 @@ describe('Oracle', () => {
     it('reverts when not the authorized', async () => {
       oracleFactory.authorized.whenCalledWith(user.address).returns(false)
 
-      await expect(oracle.connect(user).request(market.address, user.address)).to.revertedWithCustomError(
+      await expect(oracle.connect(user).request(market.address, user.address, true)).to.revertedWithCustomError(
         oracle,
         'OracleProviderUnauthorizedError',
       )

--- a/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
@@ -145,7 +145,7 @@ describe('PythOracleFactory', () => {
 
   it('parses Pyth exponents correctly', async () => {
     const minDelay = await pythOracleFactory.validFrom()
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
     await pythOracleFactory
       .connect(user)
       .commit(
@@ -158,7 +158,7 @@ describe('PythOracleFactory', () => {
       )
     expect((await keeperOracle.callStatic.latest()).price).to.equal(ethers.utils.parseUnits('1000', 6))
 
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
     await pythOracleFactory
       .connect(user)
       .commit(

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -588,8 +588,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         // apply referrer
         _processReferrer(updateContext, newOrder, newGuarantee, orderReferrer, guaranteeReferrer);
 
-        // request version
-        if (!newOrder.isEmpty()) oracle.request(IMarket(this), context.account);
+        // request version, only request new price on position change
+        oracle.request(IMarket(this), context.account, !newOrder.isEmpty());
 
         // after
         InvariantLib.validate(context, updateContext, newOrder);

--- a/packages/perennial/contracts/interfaces/IOracleProvider.sol
+++ b/packages/perennial/contracts/interfaces/IOracleProvider.sol
@@ -18,10 +18,10 @@ interface IOracleProvider {
     // sig: 0x652fafab
     error OracleProviderUnauthorizedError();
 
-    event OracleProviderVersionRequested(uint256 indexed version);
+    event OracleProviderVersionRequested(uint256 indexed version, bool newPrice);
     event OracleProviderVersionFulfilled(OracleVersion version);
 
-    function request(IMarket market, address account) external;
+    function request(IMarket market, address account, bool newPrice) external;
     function status() external view returns (OracleVersion memory, uint256);
     function latest() external view returns (OracleVersion memory);
     function current() external view returns (uint256);


### PR DESCRIPTION
Adds a `newPrice` boolean argument to the `oracleProvider.request()` function which allows the end consumer to specify whether they would like a fresh price at the current timestamp, or whether it is acceptable to carry forward the latest previous price.

In either case a price is guaranteed to be populated at the current version in order as expected, however requests that do not require a fresh price do not need to pay for the settlement fee they do not trigger a keeper callback directly.

This allows us to remove all price-override logic from the market because we can ensure that a price is available for any case of market update.