### PR TITLE
Collateral accounts: deploy accounts to a BeaconProxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@codechecks/client": "^0.1.10",
     "@defi-wonderland/smock": "^2.0.7",
-    "@equilibria/root": "2.3.0-rc3",
+    "@equilibria/root": "2.3.0-rc5",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",

--- a/packages/perennial-account/contracts/Account.sol
+++ b/packages/perennial-account/contracts/Account.sol
@@ -46,14 +46,11 @@ contract Account is IAccount, Instance {
         owner = owner_;
 
         // approve the Controller to interact with this account's DSU
-        if (address(factory()) != address(0))
-            DSU.approve(address(factory()));
+        DSU.approve(address(factory()));
 
         // approve DSU facilities to wrap and unwrap USDC for this account
-        if (address(reserve) != address(0)) {
-            DSU.approve(address(reserve));
-            USDC.approve(address(reserve));
-        }
+        DSU.approve(address(reserve));
+        USDC.approve(address(reserve));
     }
 
     /// @inheritdoc IAccount

--- a/packages/perennial-account/contracts/Account.sol
+++ b/packages/perennial-account/contracts/Account.sol
@@ -22,35 +22,37 @@ contract Account is IAccount, Instance {
     address public owner;
 
     /// @dev USDC stablecoin address
-    Token6 public USDC; // solhint-disable-line var-name-mixedcase
+    Token6 public immutable USDC; // solhint-disable-line var-name-mixedcase
 
     /// @dev DSU address
-    Token18 public DSU; // solhint-disable-line var-name-mixedcase
+    Token18 public immutable DSU; // solhint-disable-line var-name-mixedcase
 
     /// @dev DSU Reserve address
-    IEmptySetReserve public reserve;
+    IEmptySetReserve public immutable reserve;
 
-    /// @inheritdoc IAccount
-    function initialize(
-        address owner_,
-        Token6 usdc_,
-        Token18 dsu_,
-        IEmptySetReserve reserve_
-    ) external initializer(1) {
-        __Instance__initialize();
-        owner = owner_;
+    /// @dev Construct collateral account and set approvals for controller and DSU reserve
+    /// @param usdc_ USDC stablecoin
+    /// @param dsu_ Digital Standard Unit stablecoin
+    /// @param reserve_ DSU SimpleReserve contract, used for wrapping/unwrapping USDC to/from DSU
+    constructor(Token6 usdc_, Token18 dsu_, IEmptySetReserve reserve_) {
         USDC = usdc_;
         DSU = dsu_;
         reserve = reserve_;
+    }
+
+    /// @inheritdoc IAccount
+    function initialize(address owner_) external initializer(1) {
+        __Instance__initialize();
+        owner = owner_;
 
         // approve the Controller to interact with this account's DSU
         if (address(factory()) != address(0))
-            dsu_.approve(address(factory()));
+            DSU.approve(address(factory()));
 
         // approve DSU facilities to wrap and unwrap USDC for this account
         if (address(reserve) != address(0)) {
-            dsu_.approve(address(reserve));
-            usdc_.approve(address(reserve));
+            DSU.approve(address(reserve));
+            USDC.approve(address(reserve));
         }
     }
 

--- a/packages/perennial-account/contracts/Account.sol
+++ b/packages/perennial-account/contracts/Account.sol
@@ -3,56 +3,51 @@ pragma solidity 0.8.24;
 
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
-import { Token6 } from "@equilibria/root/token/types/Token6.sol";
-import { Token18 } from "@equilibria/root/token/types/Token18.sol";
+import { Instance } from "@equilibria/root/attribute/Instance.sol";
 import { Fixed6, Fixed6Lib } from "@equilibria/root/number/types/Fixed6.sol";
-import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
 import { UFixed18, UFixed18Lib } from "@equilibria/root/number/types/UFixed18.sol";
+import { Token6 } from "@equilibria/root/token/types/Token6.sol";
+import { Token18 } from "@equilibria/root/token/types/Token18.sol";
 
 import { IAccount } from "./interfaces/IAccount.sol";
 import { IMarket, Position } from "@equilibria/perennial-v2/contracts/interfaces/IMarket.sol";
 
 /// @title Account
 /// @notice Collateral Accounts allow users to manage collateral across Perennial markets
-contract Account is IAccount {
+contract Account is IAccount, Instance {
     UFixed6 private constant UNCHANGED_POSITION = UFixed6Lib.MAX;
 
     /// @dev EOA of the user who owns this collateral account
-    address public immutable owner;
-
-    /// @dev address of the Controller contract, used for checking permissions
-    address public immutable controller;
+    address public owner;
 
     /// @dev USDC stablecoin address
-    Token6 public immutable USDC; // solhint-disable-line var-name-mixedcase
+    Token6 public USDC; // solhint-disable-line var-name-mixedcase
 
     /// @dev DSU address
-    Token18 public immutable DSU; // solhint-disable-line var-name-mixedcase
+    Token18 public DSU; // solhint-disable-line var-name-mixedcase
 
     /// @dev DSU Reserve address
-    IEmptySetReserve public immutable reserve;
+    IEmptySetReserve public reserve;
 
-    /// @dev Construct collateral account and set approvals for controller and DSU reserve
-    /// @param owner_ EOA of the user for whom this collateral account belongs
-    /// @param controller_ Controller contract used for setting approvals and checking permissions
+    /// @notice Sets owner, contract, and token addresses, and runs approvals for a collateral account
+    /// @param owner_ Address of the user for which the account was created
     /// @param usdc_ USDC stablecoin
     /// @param dsu_ Digital Standard Unit stablecoin
     /// @param reserve_ DSU SimpleReserve contract, used for wrapping/unwrapping USDC to/from DSU
-    constructor(
+    function initialize(
         address owner_,
-        address controller_,
         Token6 usdc_,
         Token18 dsu_,
         IEmptySetReserve reserve_
-    ) {
+    ) external initializer(1) {
         owner = owner_;
-        controller = controller_;
         USDC = usdc_;
         DSU = dsu_;
         reserve = reserve_;
 
-        dsu_.approve(controller_);
+        // approve the Controller to interact with this account's DSU
+        dsu_.approve(address(factory()));
 
         // approve DSU facilities to wrap and unwrap USDC for this account
         dsu_.approve(address(reserve));
@@ -110,7 +105,7 @@ contract Account is IAccount {
 
     /// @dev Reverts if not called by the owner of the collateral account, or the collateral account controller
     modifier ownerOrController {
-        if (msg.sender != owner && msg.sender != controller) revert AccountNotAuthorizedError();
+        if (msg.sender != owner && msg.sender != address(factory())) revert AccountNotAuthorizedError();
         _;
     }
 }

--- a/packages/perennial-account/contracts/Account.sol
+++ b/packages/perennial-account/contracts/Account.sol
@@ -30,28 +30,28 @@ contract Account is IAccount, Instance {
     /// @dev DSU Reserve address
     IEmptySetReserve public reserve;
 
-    /// @notice Sets owner, contract, and token addresses, and runs approvals for a collateral account
-    /// @param owner_ Address of the user for which the account was created
-    /// @param usdc_ USDC stablecoin
-    /// @param dsu_ Digital Standard Unit stablecoin
-    /// @param reserve_ DSU SimpleReserve contract, used for wrapping/unwrapping USDC to/from DSU
+    /// @inheritdoc IAccount
     function initialize(
         address owner_,
         Token6 usdc_,
         Token18 dsu_,
         IEmptySetReserve reserve_
     ) external initializer(1) {
+        __Instance__initialize();
         owner = owner_;
         USDC = usdc_;
         DSU = dsu_;
         reserve = reserve_;
 
         // approve the Controller to interact with this account's DSU
-        dsu_.approve(address(factory()));
+        if (address(factory()) != address(0))
+            dsu_.approve(address(factory()));
 
         // approve DSU facilities to wrap and unwrap USDC for this account
-        dsu_.approve(address(reserve));
-        usdc_.approve(address(reserve));
+        if (address(reserve) != address(0)) {
+            dsu_.approve(address(reserve));
+            usdc_.approve(address(reserve));
+        }
     }
 
     /// @inheritdoc IAccount

--- a/packages/perennial-account/contracts/Controller.sol
+++ b/packages/perennial-account/contracts/Controller.sol
@@ -58,21 +58,20 @@ contract Controller is Factory, IController {
     mapping(address => mapping(uint256 => UFixed6)) public groupToMaxRebalanceFee;
 
     /// @dev Creates instance of Controller
-    /// @param implementation_ Pristine 0-initialized collateral account contract
-    constructor(address implementation_) Factory(implementation_) {}
+    /// @param implementation_ Collateral account contract initialized with stablecoin addresses
+    constructor(address implementation_) Factory(implementation_) {
+        USDC = Account(implementation_).USDC();
+        DSU = Account(implementation_).DSU();
+    }
 
     /// @inheritdoc IController
     function initialize(
         IMarketFactory marketFactory_,
-        IVerifier verifier_,
-        Token6 usdc_,
-        Token18 dsu_
+        IVerifier verifier_
     ) external initializer(1) {
         __Factory__initialize();
         marketFactory = marketFactory_;
         verifier = verifier_;
-        USDC = usdc_;
-        DSU = dsu_;
     }
 
     /// @inheritdoc IController

--- a/packages/perennial-account/contracts/Controller.sol
+++ b/packages/perennial-account/contracts/Controller.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.24;
 
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
-import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
 import { Factory } from "@equilibria/root/attribute/Factory.sol";
 import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { Token18 } from "@equilibria/root/token/types/Token18.sol";
@@ -43,9 +42,6 @@ contract Controller is Factory, IController {
     /// @dev Contract used to validate message signatures
     IVerifier public verifier;
 
-    /// @dev DSU Reserve address
-    IEmptySetReserve public reserve;
-
     /// @dev Mapping of rebalance configuration
     /// owner => group => market => config
     mapping(address => mapping(uint256 => mapping(address => RebalanceConfig))) public config;
@@ -70,15 +66,13 @@ contract Controller is Factory, IController {
         IMarketFactory marketFactory_,
         IVerifier verifier_,
         Token6 usdc_,
-        Token18 dsu_,
-        IEmptySetReserve reserve_
+        Token18 dsu_
     ) external initializer(1) {
         __Factory__initialize();
         marketFactory = marketFactory_;
         verifier = verifier_;
         USDC = usdc_;
         DSU = dsu_;
-        reserve = reserve_;
     }
 
     /// @inheritdoc IController
@@ -174,8 +168,9 @@ contract Controller is Factory, IController {
 
     function _createAccount(address owner) internal returns (IAccount account) {
         // initialize outside of _create2, such that other init params do not impact deployment address
+        // TODO: can initialize in _create2 now that owner is only argument
         account = Account(address(_create2("", keccak256(abi.encode(SALT, owner)))));
-        account.initialize(owner, USDC, DSU, reserve);
+        account.initialize(owner);
         emit AccountDeployed(owner, account);
     }
 

--- a/packages/perennial-account/contracts/Controller.sol
+++ b/packages/perennial-account/contracts/Controller.sol
@@ -78,7 +78,7 @@ contract Controller is Factory, IController {
     /// @inheritdoc IController
     function getAccountAddress(address owner) public view returns (address) {
         // calculate the hash for an uninitialized account for the owner
-        return _computeCreate2Address("", keccak256(abi.encode(SALT, owner)));
+        return _computeCreate2Address(abi.encodeCall(Account.initialize, (owner)), SALT);
     }
 
     /// @inheritdoc IController
@@ -167,10 +167,7 @@ contract Controller is Factory, IController {
     }
 
     function _createAccount(address owner) internal returns (IAccount account) {
-        // initialize outside of _create2, such that other init params do not impact deployment address
-        // TODO: can initialize in _create2 now that owner is only argument
-        account = Account(address(_create2("", keccak256(abi.encode(SALT, owner)))));
-        account.initialize(owner);
+        account = Account(address(_create2(abi.encodeCall(Account.initialize, (owner)), SALT)));
         emit AccountDeployed(owner, account);
     }
 

--- a/packages/perennial-account/contracts/Controller_Arbitrum.sol
+++ b/packages/perennial-account/contracts/Controller_Arbitrum.sol
@@ -39,14 +39,12 @@ contract Controller_Arbitrum is Controller, Kept_Arbitrum {
     /// @param verifier_ Contract used to validate EIP-712 message signatures
     /// @param usdc_ USDC token address
     /// @param dsu_ DSU token address
-    /// @param reserve_ DSU Reserve address, used by Account
     /// @param chainlinkFeed_ ETH-USD price feed used for calculating keeper compensation
     function initialize(
         IMarketFactory marketFactory_,
         IVerifier verifier_,
         Token6 usdc_,
         Token18 dsu_,
-        IEmptySetReserve reserve_,
         AggregatorV3Interface chainlinkFeed_
     ) external initializer(1) {
         __Factory__initialize();
@@ -55,7 +53,6 @@ contract Controller_Arbitrum is Controller, Kept_Arbitrum {
         verifier = verifier_;
         USDC = usdc_;
         DSU = dsu_;
-        reserve = reserve_;
     }
 
     /// @inheritdoc IController

--- a/packages/perennial-account/contracts/Controller_Arbitrum.sol
+++ b/packages/perennial-account/contracts/Controller_Arbitrum.sol
@@ -27,7 +27,10 @@ import { Withdrawal } from "./types/Withdrawal.sol";
 contract Controller_Arbitrum is Controller, Kept_Arbitrum {
     KeepConfig public keepConfig;
 
-    constructor(KeepConfig memory keepConfig_) {
+    /// @dev Creates instance of Controller which compensates keepers
+    /// @param implementation_ Pristine 0-initialized collateral account contract
+    /// @param keepConfig_ Configuration used to compensate keepers
+    constructor(address implementation_, KeepConfig memory keepConfig_) Controller(implementation_) {
         keepConfig = keepConfig_;
     }
 
@@ -46,7 +49,7 @@ contract Controller_Arbitrum is Controller, Kept_Arbitrum {
         IEmptySetReserve reserve_,
         AggregatorV3Interface chainlinkFeed_
     ) external initializer(1) {
-        __Instance__initialize();
+        __Factory__initialize();
         __Kept__initialize(chainlinkFeed_, dsu_);
         marketFactory = marketFactory_;
         verifier = verifier_;

--- a/packages/perennial-account/contracts/Controller_Arbitrum.sol
+++ b/packages/perennial-account/contracts/Controller_Arbitrum.sol
@@ -37,22 +37,16 @@ contract Controller_Arbitrum is Controller, Kept_Arbitrum {
     /// @notice Configures message verification and keeper compensation
     /// @param marketFactory_ Contract used to validate delegated signers
     /// @param verifier_ Contract used to validate EIP-712 message signatures
-    /// @param usdc_ USDC token address
-    /// @param dsu_ DSU token address
     /// @param chainlinkFeed_ ETH-USD price feed used for calculating keeper compensation
     function initialize(
         IMarketFactory marketFactory_,
         IVerifier verifier_,
-        Token6 usdc_,
-        Token18 dsu_,
         AggregatorV3Interface chainlinkFeed_
     ) external initializer(1) {
         __Factory__initialize();
-        __Kept__initialize(chainlinkFeed_, dsu_);
+        __Kept__initialize(chainlinkFeed_, DSU);
         marketFactory = marketFactory_;
         verifier = verifier_;
-        USDC = usdc_;
-        DSU = dsu_;
     }
 
     /// @inheritdoc IController

--- a/packages/perennial-account/contracts/interfaces/IAccount.sol
+++ b/packages/perennial-account/contracts/interfaces/IAccount.sol
@@ -1,16 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
+import { IMarket } from "@equilibria/perennial-v2/contracts/interfaces/IMarket.sol";
 import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
 import { UFixed18 } from "@equilibria/root/number/types/UFixed18.sol";
 import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
-import { IMarket } from "@equilibria/perennial-v2/contracts/interfaces/IMarket.sol";
+import { Token6 } from "@equilibria/root/token/types/Token6.sol";
+import { Token18 } from "@equilibria/root/token/types/Token18.sol";
 
 /// @notice Collateral Accounts allow users to manage collateral across Perennial markets
 interface IAccount {
     // sig: 0x9041f6c1
     /// @custom:error Only the owner or the collateral account controller may withdraw
     error AccountNotAuthorizedError();
+
+    /// @notice Sets owner, contract, and token addresses, and runs approvals for a collateral account
+    /// @param owner Address of the user for which the account was created
+    /// @param usdc USDC stablecoin
+    /// @param dsu Digital Standard Unit stablecoin
+    /// @param reserve DSU SimpleReserve contract, used for wrapping/unwrapping USDC to/from DSU
+    function initialize(
+        address owner,
+        Token6 usdc,
+        Token18 dsu,
+        IEmptySetReserve reserve
+    ) external;
 
     /// @notice Transfer USDC collateral from msg.sender to this account
     /// @param amount Quantity of USDC to transfer in 6-decimal precision

--- a/packages/perennial-account/contracts/interfaces/IAccount.sol
+++ b/packages/perennial-account/contracts/interfaces/IAccount.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
 import { IMarket } from "@equilibria/perennial-v2/contracts/interfaces/IMarket.sol";
 import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
 import { UFixed18 } from "@equilibria/root/number/types/UFixed18.sol";
@@ -17,15 +16,7 @@ interface IAccount {
 
     /// @notice Sets owner, contract, and token addresses, and runs approvals for a collateral account
     /// @param owner Address of the user for which the account was created
-    /// @param usdc USDC stablecoin
-    /// @param dsu Digital Standard Unit stablecoin
-    /// @param reserve DSU SimpleReserve contract, used for wrapping/unwrapping USDC to/from DSU
-    function initialize(
-        address owner,
-        Token6 usdc,
-        Token18 dsu,
-        IEmptySetReserve reserve
-    ) external;
+    function initialize(address owner) external;
 
     /// @notice Transfer USDC collateral from msg.sender to this account
     /// @param amount Quantity of USDC to transfer in 6-decimal precision

--- a/packages/perennial-account/contracts/interfaces/IController.sol
+++ b/packages/perennial-account/contracts/interfaces/IController.sol
@@ -88,13 +88,9 @@ interface IController {
     /// @notice Sets contract addresses used for message verification and token management
     /// @param marketFactory Contract used to validate delegated signers
     /// @param verifier Contract used to validate message signatures
-    /// @param usdc USDC token address
-    /// @param dsu DSU token address
     function initialize(
         IMarketFactory marketFactory,
-        IVerifier verifier,
-        Token6 usdc,
-        Token18 dsu
+        IVerifier verifier
     ) external;
 
     /// @notice Returns the deterministic address of the collateral account for a user,

--- a/packages/perennial-account/contracts/interfaces/IController.sol
+++ b/packages/perennial-account/contracts/interfaces/IController.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
 import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
 import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { Token18 } from "@equilibria/root/token/types/Token18.sol";
@@ -91,13 +90,11 @@ interface IController {
     /// @param verifier Contract used to validate message signatures
     /// @param usdc USDC token address
     /// @param dsu DSU token address
-    /// @param reserve DSU Reserve address, used by Account
     function initialize(
         IMarketFactory marketFactory,
         IVerifier verifier,
         Token6 usdc,
-        Token18 dsu,
-        IEmptySetReserve reserve
+        Token18 dsu
     ) external;
 
     /// @notice Returns the deterministic address of the collateral account for a user,

--- a/packages/perennial-account/test/helpers/arbitrumHelpers.ts
+++ b/packages/perennial-account/test/helpers/arbitrumHelpers.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
 import { BigNumber, CallOverrides, constants, utils } from 'ethers'
-import { Address } from 'hardhat-deploy/dist/types'
 import {
   IKeeperOracle,
   IMarketFactory,

--- a/packages/perennial-account/test/helpers/arbitrumHelpers.ts
+++ b/packages/perennial-account/test/helpers/arbitrumHelpers.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { BigNumber, CallOverrides, constants, utils } from 'ethers'
+import { Address } from 'hardhat-deploy/dist/types'
 import {
   IKeeperOracle,
   IMarketFactory,
@@ -131,10 +132,10 @@ export async function deployAndInitializeController(
 ): Promise<[IERC20Metadata, IERC20Metadata, Controller]> {
   const dsu = IERC20Metadata__factory.connect(DSU_ADDRESS, owner)
   const usdc = IERC20Metadata__factory.connect(USDCe_ADDRESS, owner)
-  const controller = await deployController(owner)
+  const controller = await deployController(owner, usdc.address, dsu.address, DSU_RESERVE)
 
   const verifier = await new Verifier__factory(owner).deploy()
-  await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address, DSU_RESERVE)
+  await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address)
   return [dsu, usdc, controller]
 }
 
@@ -144,8 +145,8 @@ export async function deployControllerArbitrum(
   keepConfig: IKept.KeepConfigStruct,
   overrides?: CallOverrides,
 ): Promise<Controller_Arbitrum> {
-  const accountImpl = await new Account__factory(owner).deploy()
-  accountImpl.initialize(constants.AddressZero, constants.AddressZero, constants.AddressZero, constants.AddressZero)
+  const accountImpl = await new Account__factory(owner).deploy(USDCe_ADDRESS, DSU_ADDRESS, DSU_RESERVE)
+  accountImpl.initialize(constants.AddressZero)
   const controller = await new Controller_Arbitrum__factory(
     {
       'contracts/libs/RebalanceLib.sol:RebalanceLib': (await new RebalanceLib__factory(owner).deploy()).address,

--- a/packages/perennial-account/test/helpers/arbitrumHelpers.ts
+++ b/packages/perennial-account/test/helpers/arbitrumHelpers.ts
@@ -86,7 +86,7 @@ export async function deployAndInitializeController(
 ): Promise<[IERC20Metadata, IERC20Metadata, Controller]> {
   const dsu = IERC20Metadata__factory.connect(DSU_ADDRESS, owner)
   const usdc = IERC20Metadata__factory.connect(USDCe_ADDRESS, owner)
-  const controller = await deployController(owner, usdc.address, dsu.address, DSU_RESERVE)
+  const controller = await deployController(owner)
 
   const verifier = await new Verifier__factory(owner).deploy()
   await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address, DSU_RESERVE)

--- a/packages/perennial-account/test/helpers/arbitrumHelpers.ts
+++ b/packages/perennial-account/test/helpers/arbitrumHelpers.ts
@@ -134,7 +134,7 @@ export async function deployAndInitializeController(
   const controller = await deployController(owner, usdc.address, dsu.address, DSU_RESERVE)
 
   const verifier = await new Verifier__factory(owner).deploy()
-  await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address)
+  await controller.initialize(marketFactory.address, verifier.address)
   return [dsu, usdc, controller]
 }
 

--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -9,10 +9,7 @@ import { smock } from '@defi-wonderland/smock'
 import {
   Account__factory,
   Controller,
-  Controller_Arbitrum,
   Controller__factory,
-  IAccount,
-  IController,
   IERC20Metadata,
   RebalanceLib__factory,
 } from '../../types/generated'
@@ -144,6 +141,7 @@ export async function createMarket(
   return market
 }
 
+// TODO: eliminate token and reserve args, init with 0 addresses
 export async function deployController(
   owner: SignerWithAddress,
   usdc: Address,

--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -141,15 +141,9 @@ export async function createMarket(
   return market
 }
 
-// TODO: eliminate token and reserve args, init with 0 addresses
-export async function deployController(
-  owner: SignerWithAddress,
-  usdc: Address,
-  dsu: Address,
-  reserve: Address,
-): Promise<Controller> {
+export async function deployController(owner: SignerWithAddress): Promise<Controller> {
   const accountImpl = await new Account__factory(owner).deploy()
-  accountImpl.initialize(constants.AddressZero, usdc, dsu, reserve)
+  accountImpl.initialize(constants.AddressZero, constants.AddressZero, constants.AddressZero, constants.AddressZero)
   const controller = await new Controller__factory(
     {
       'contracts/libs/RebalanceLib.sol:RebalanceLib': (await new RebalanceLib__factory(owner).deploy()).address,

--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -1,12 +1,21 @@
 import HRE, { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { Address } from 'hardhat-deploy/dist/types'
-import { BigNumber, CallOverrides, ContractTransaction, utils } from 'ethers'
+import { BigNumber, CallOverrides, constants, ContractTransaction, utils } from 'ethers'
 import { impersonateWithBalance } from '../../../common/testutil/impersonate'
 import { parse6decimal } from '../../../common/testutil/types'
 import { smock } from '@defi-wonderland/smock'
 
-import { Controller__factory, IERC20Metadata, RebalanceLib__factory } from '../../types/generated'
+import {
+  Account__factory,
+  Controller,
+  Controller_Arbitrum,
+  Controller__factory,
+  IAccount,
+  IController,
+  IERC20Metadata,
+  RebalanceLib__factory,
+} from '../../types/generated'
 import {
   CheckpointLib__factory,
   CheckpointStorageLib__factory,
@@ -134,13 +143,21 @@ export async function createMarket(
 
   return market
 }
-export async function deployController(owner: SignerWithAddress): Promise<Controller> {
+
+export async function deployController(
+  owner: SignerWithAddress,
+  usdc: Address,
+  dsu: Address,
+  reserve: Address,
+): Promise<Controller> {
+  const accountImpl = await new Account__factory(owner).deploy()
+  accountImpl.initialize(constants.AddressZero, usdc, dsu, reserve)
   const controller = await new Controller__factory(
     {
       'contracts/libs/RebalanceLib.sol:RebalanceLib': (await new RebalanceLib__factory(owner).deploy()).address,
     },
     owner,
-  ).deploy()
+  ).deploy(accountImpl.address)
   return controller
 }
 

--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -149,9 +149,14 @@ export async function createMarket(
   return market
 }
 
-export async function deployController(owner: SignerWithAddress): Promise<Controller> {
-  const accountImpl = await new Account__factory(owner).deploy()
-  accountImpl.initialize(constants.AddressZero, constants.AddressZero, constants.AddressZero, constants.AddressZero)
+export async function deployController(
+  owner: SignerWithAddress,
+  usdcAddress: Address,
+  dsuAddress: Address,
+  reserveAddress: Address,
+): Promise<Controller> {
+  const accountImpl = await new Account__factory(owner).deploy(usdcAddress, dsuAddress, reserveAddress)
+  accountImpl.initialize(constants.AddressZero)
   const controller = await new Controller__factory(
     {
       'contracts/libs/RebalanceLib.sol:RebalanceLib': (await new RebalanceLib__factory(owner).deploy()).address,

--- a/packages/perennial-account/test/integration/Controller_Arbitrum.ts
+++ b/packages/perennial-account/test/integration/Controller_Arbitrum.ts
@@ -37,7 +37,6 @@ const { ethers } = HRE
 
 const CHAINLINK_ETH_USD_FEED = '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612' // price feed used for keeper compensation
 const DEFAULT_MAX_FEE = utils.parseEther('0.5')
-const DSU_RESERVE = '0x0d49c416103Cbd276d9c3cd96710dB264e3A0c27'
 
 // hack around issues estimating gas for instrumented contracts when running tests under coverage
 const TX_OVERRIDES = { gasLimit: 3_000_000, maxFeePerGas: 200_000_000 }

--- a/packages/perennial-account/test/integration/Controller_Arbitrum.ts
+++ b/packages/perennial-account/test/integration/Controller_Arbitrum.ts
@@ -149,11 +149,9 @@ describe('Controller_Arbitrum', () => {
     controller = await deployControllerArbitrum(owner, keepConfig, { maxFeePerGas: 100000000 })
     verifier = await new Verifier__factory(owner).deploy({ maxFeePerGas: 100000000 })
     // chainlink feed is used by Kept for keeper compensation
-    await controller['initialize(address,address,address,address,address)'](
+    await controller['initialize(address,address,address)'](
       marketFactory.address,
       verifier.address,
-      usdc.address,
-      dsu.address,
       CHAINLINK_ETH_USD_FEED,
     )
     // fund userA

--- a/packages/perennial-account/test/integration/Controller_Arbitrum.ts
+++ b/packages/perennial-account/test/integration/Controller_Arbitrum.ts
@@ -150,12 +150,11 @@ describe('Controller_Arbitrum', () => {
     controller = await deployControllerArbitrum(owner, keepConfig, { maxFeePerGas: 100000000 })
     verifier = await new Verifier__factory(owner).deploy({ maxFeePerGas: 100000000 })
     // chainlink feed is used by Kept for keeper compensation
-    await controller['initialize(address,address,address,address,address,address)'](
+    await controller['initialize(address,address,address,address,address)'](
       marketFactory.address,
       verifier.address,
       usdc.address,
       dsu.address,
-      DSU_RESERVE,
       CHAINLINK_ETH_USD_FEED,
     )
     // fund userA

--- a/packages/perennial-account/test/unit/Controller.ts
+++ b/packages/perennial-account/test/unit/Controller.ts
@@ -79,15 +79,14 @@ describe('Controller', () => {
 
   const fixture = async () => {
     ;[owner, userA, userB, keeper] = await ethers.getSigners()
-    controller = await deployController(owner)
-
-    marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
-    verifier = await new Verifier__factory(owner).deploy()
-
     const usdc = await smock.fake<IERC20>('IERC20')
     const dsu = await smock.fake<IERC20>('IERC20')
     const reserve = await smock.fake<IEmptySetReserve>('IEmptySetReserve')
-    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address, reserve.address)
+    controller = await deployController(owner, usdc.address, dsu.address, reserve.address)
+
+    marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
+    verifier = await new Verifier__factory(owner).deploy()
+    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address)
   }
 
   beforeEach(async () => {

--- a/packages/perennial-account/test/unit/Controller.ts
+++ b/packages/perennial-account/test/unit/Controller.ts
@@ -5,6 +5,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { BigNumber, constants, utils } from 'ethers'
 import {
+  Account__factory,
   Controller,
   IAccount,
   IAccount__factory,
@@ -164,6 +165,17 @@ describe('Controller', () => {
       await expect(
         controller.connect(keeper).deployAccountWithSignature(deployAccountMessage, signature),
       ).to.be.revertedWithCustomError(controller, 'ControllerInvalidSignerError')
+    })
+
+    it('account implementation cannot be initialized', async () => {
+      const accountImpl = Account__factory.connect(await controller.implementation(), owner)
+      expect(await accountImpl.owner()).to.equal(constants.AddressZero)
+
+      // another user should not be able to initialize the Account implementation
+      await expect(accountImpl.connect(userB).initialize(userB.address)).to.be.revertedWithCustomError(
+        controller,
+        'InitializableAlreadyInitializedError',
+      )
     })
   })
 

--- a/packages/perennial-account/test/unit/Controller.ts
+++ b/packages/perennial-account/test/unit/Controller.ts
@@ -86,7 +86,7 @@ describe('Controller', () => {
 
     marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
     verifier = await new Verifier__factory(owner).deploy()
-    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address)
+    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address, reserve.address)
   }
 
   beforeEach(async () => {

--- a/packages/perennial-account/test/unit/Controller.ts
+++ b/packages/perennial-account/test/unit/Controller.ts
@@ -82,11 +82,11 @@ describe('Controller', () => {
     const usdc = await smock.fake<IERC20>('IERC20')
     const dsu = await smock.fake<IERC20>('IERC20')
     const reserve = await smock.fake<IEmptySetReserve>('IEmptySetReserve')
-    controller = await deployController(owner)
+    controller = await deployController(owner, usdc.address, dsu.address, reserve.address)
 
     marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
     verifier = await new Verifier__factory(owner).deploy()
-    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address, reserve.address)
+    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address)
   }
 
   beforeEach(async () => {

--- a/packages/perennial-account/test/unit/Controller.ts
+++ b/packages/perennial-account/test/unit/Controller.ts
@@ -87,7 +87,7 @@ describe('Controller', () => {
 
     marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
     verifier = await new Verifier__factory(owner).deploy()
-    await controller.initialize(marketFactory.address, verifier.address, usdc.address, dsu.address)
+    await controller.initialize(marketFactory.address, verifier.address)
   }
 
   beforeEach(async () => {

--- a/packages/perennial-account/test/unit/Controller.ts
+++ b/packages/perennial-account/test/unit/Controller.ts
@@ -82,7 +82,7 @@ describe('Controller', () => {
     const usdc = await smock.fake<IERC20>('IERC20')
     const dsu = await smock.fake<IERC20>('IERC20')
     const reserve = await smock.fake<IEmptySetReserve>('IEmptySetReserve')
-    controller = await deployController(owner, usdc.address, dsu.address, reserve.address)
+    controller = await deployController(owner)
 
     marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
     verifier = await new Verifier__factory(owner).deploy()

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,10 +152,10 @@
   dependencies:
     "@openzeppelin/contracts" "4.6.0"
 
-"@equilibria/root@2.3.0-rc3":
-  version "2.3.0-rc3"
-  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-2.3.0-rc3.tgz#d11fa30cfb158bc33de382106e9d4bd45ae27875"
-  integrity sha512-od3aZ7cwEjV1bBrlJh8fQ1Wn5yymmwEqRWu3CoximIYvR3oNhcusi+LnMpYQW3TOJAj+aDCEQ9xOljC1rTPpWA==
+"@equilibria/root@2.3.0-rc5":
+  version "2.3.0-rc5"
+  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-2.3.0-rc5.tgz#eb02fa4407f4cacea10f18a8e4c3845cc86d3da7"
+  integrity sha512-1WMOf928atqPiprqEtQvPOtbAVCVsSNrWC05uf6Vd0TO/qB9iCUsMXLHOtZ+QxOPasFr2G+2wGyaNtCwpPXFQQ==
   dependencies:
     "@openzeppelin/contracts" "4.6.0"
 


### PR DESCRIPTION
https://github.com/equilibria-xyz/root/pull/97 adds _create2_ functionality to the existing `Factory` attribute, and is a dependency for this change.  Will need to update `package.json` once a new RC is published, such that everything (including CI) will compile and run.  Until then, can use `yarn link` to use a local checkout of that `root` branch.

This PR deterministically deploys _Accounts_ to a `BeaconProxy`, similar to how factories are used elsewhere in the protocol.  The proxy for the _Controller_ itself is to be handled as a deployment task, outside the scope of this PR.