### PR TITLE
Flip OracleVersionFulfilled / settlement callback order

### DIFF
--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -134,10 +134,10 @@ contract KeeperOracle is IKeeperOracle, Instance {
         requested = (version.timestamp == next()) ? _commitRequested(version) : _commitUnrequested(version);
         _global.latestVersion = uint64(version.timestamp);
 
+        emit OracleProviderVersionFulfilled(version);
+
         for (uint256 i; i < _globalCallbacks[version.timestamp].length(); i++)
             _settle(IMarket(_globalCallbacks[version.timestamp].at(i)), address(0));
-
-        emit OracleProviderVersionFulfilled(version);
     }
 
     /// @notice Performs an asynchronous local settlement callback


### PR DESCRIPTION
Emits the `OracleVersionFulfilled` before making the settlement callback in the KeeperOracle for better cleanliness with respect to the data pipeline.