### PR TITLE
Remove no-op updates

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -56,7 +56,6 @@ export interface Global {
   oracleFee: BigNumberish
   riskFee: BigNumberish
   donation: BigNumberish
-  latestPrice: BigNumberish
   exposure: BigNumberish
 }
 
@@ -132,7 +131,6 @@ export function expectGlobalEq(a: Global, b: Global): void {
   expect(a.oracleFee).to.equal(b.oracleFee, 'Global:OracleFee')
   expect(a.riskFee).to.equal(b.riskFee, 'Global:RiskFee')
   expect(a.donation).to.equal(b.donation, 'Global:Donation')
-  expect(a.latestPrice).to.equal(b.latestPrice, 'Global:LatestPrice')
   expect(a.exposure).to.equal(b.exposure, 'Global:Exposure')
 }
 
@@ -208,7 +206,6 @@ export const DEFAULT_GLOBAL: Global = {
   riskFee: 0,
   donation: 0,
   exposure: 0,
-  latestPrice: 0,
 }
 
 export const DEFAULT_LOCAL: Local = {

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -676,7 +676,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Order memory nextOrder;
 
         // settle - process orders whose requested prices are now available from oracle
-        //        - all requested prices are guarenteed to be present in the oracle, but could be stale
+        //        - all requested prices are guaranteed to be present in the oracle, but could be stale
         while (
             context.global.currentId != context.global.latestId &&
             (nextOrder = _pendingOrder[context.global.latestId + 1].read()).ready(context.latestOracleVersion)
@@ -688,7 +688,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         ) _processOrderLocal(context, settlementContext, context.local.latestId + 1, nextOrder.timestamp, nextOrder);
 
         // sync - advance position timestamps to the latest oracle version
-        //      - latest versions are guarenteed to have present prices in the oracle, but could be stale
+        //      - latest versions are guaranteed to have present prices in the oracle, but could be stale
         if (context.latestOracleVersion.timestamp > context.latestPositionGlobal.timestamp)
             _processOrderGlobal(
                 context,

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -296,13 +296,14 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Global memory newGlobal = _global.read();
         Position memory latestPosition = _position.read();
         RiskParameter memory latestRiskParameter = _riskParameter.read();
+        Fixed6 latestPrice = oracle.at(latestPosition.timestamp).price;
 
         // update risk parameter (first to capture truncation)
         _riskParameter.validateAndStore(newRiskParameter, IMarketFactory(address(factory())).parameter());
         newRiskParameter = _riskParameter.read();
 
         // update global exposure
-        newGlobal.update(latestRiskParameter, newRiskParameter, latestPosition);
+        newGlobal.update(latestRiskParameter, newRiskParameter, latestPosition, latestPrice);
         _global.store(newGlobal);
 
         emit RiskParameterUpdated(newRiskParameter);
@@ -665,8 +666,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         settlementContext.latestVersion = _versions[context.latestPositionGlobal.timestamp].read();
         settlementContext.latestCheckpoint = _checkpoints[context.account][context.latestPositionLocal.timestamp].read();
         settlementContext.orderOracleVersion = oracle.at(context.latestPositionGlobal.timestamp);
-        if (settlementContext.orderOracleVersion.price.isZero())
-            settlementContext.orderOracleVersion.price = context.global.latestPrice;
     }
 
     /// @notice Settles the account position up to the latest version
@@ -677,6 +676,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Order memory nextOrder;
 
         // settle - process orders whose requested prices are now available from oracle
+        //        - all requested prices are guarenteed to be present in the oracle, but could be stale
         while (
             context.global.currentId != context.global.latestId &&
             (nextOrder = _pendingOrder[context.global.latestId + 1].read()).ready(context.latestOracleVersion)
@@ -687,7 +687,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             (nextOrder = _pendingOrders[context.account][context.local.latestId + 1].read()).ready(context.latestOracleVersion)
         ) _processOrderLocal(context, settlementContext, context.local.latestId + 1, nextOrder.timestamp, nextOrder);
 
-        // sync  - advance position timestamps with the latest oracle version
+        // sync - advance position timestamps to the latest oracle version
+        //      - latest versions are guarenteed to have present prices in the oracle, but could be stale
         if (context.latestOracleVersion.timestamp > context.latestPositionGlobal.timestamp)
             _processOrderGlobal(
                 context,
@@ -749,7 +750,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Order memory newOrder
     ) private {
         OracleVersion memory oracleVersion = oracle.at(newOrderTimestamp);
-        if (oracleVersion.price.isZero()) oracleVersion.price = context.global.latestPrice;
         Guarantee memory newGuarantee = _guarantee[newOrderId].read();
 
         // if latest timestamp is more recent than order timestamp, sync the order data

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -107,7 +107,6 @@ library VersionLib {
 
         // record oracle version
         (next.valid, next.price) = (context.toOracleVersion.valid, context.toOracleVersion.price);
-        context.global.latestPrice = context.toOracleVersion.price;
 
         // accumulate settlement fee
         result.settlementFee = _accumulateSettlementFee(next, context);

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -26,9 +26,6 @@ struct Global {
     /// @dev The accrued donation
     UFixed6 donation;
 
-    /// @dev The latest seen price
-    Fixed6 latestPrice;
-
     /// @dev The accumulated market exposure
     Fixed6 exposure;
 
@@ -48,14 +45,16 @@ library GlobalLib {
     /// @param latestRiskParameter The latest risk parameter configuration
     /// @param newRiskParameter The new risk parameter configuration
     /// @param latestPosition The latest position
+    /// @param latestPrice The latest price
     function update(
         Global memory self,
         RiskParameter memory latestRiskParameter,
         RiskParameter memory newRiskParameter,
-        Position memory latestPosition
+        Position memory latestPosition,
+        Fixed6 latestPrice
     ) internal pure {
         Fixed6 exposureChange = latestRiskParameter.takerFee
-            .exposure(newRiskParameter.takerFee, latestPosition.skew(), self.latestPrice.abs());
+            .exposure(newRiskParameter.takerFee, latestPosition.skew(), latestPrice.abs());
         self.exposure = self.exposure.sub(exposureChange);
     }
 
@@ -108,7 +107,7 @@ library GlobalLib {
 ///         /* slot 1 */
 ///         int32 pAccumulator.value;   // <= 214000%
 ///         int24 pAccumulator.skew;    // <= 838%
-///         int64 latestPrice;          // <= 9.22t
+///         int64 __UNSAFE___;          // <= 9.22t (deprecated in v2.3, unsafe to reuse until reset)
 ///         int64 exposure;             // <= 9.22t
 ///     }
 ///
@@ -125,7 +124,6 @@ library GlobalStorageLib {
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 48 - 48)) >> (256 - 48)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 48 - 48 - 48)) >> (256 - 48)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 48 - 48 - 48 - 48)) >> (256 - 48)),
-            Fixed6.wrap(int256(slot1 << (256 - 32 - 24 - 64)) >> (256 - 64)),
             Fixed6.wrap(int256(slot1 << (256 - 32 - 24 - 64 - 64)) >> (256 - 64)),
             PAccumulator6(
                 Fixed6.wrap(int256(slot1 << (256 - 32)) >> (256 - 32)),
@@ -141,8 +139,6 @@ library GlobalStorageLib {
         if (newValue.oracleFee.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
         if (newValue.riskFee.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
         if (newValue.donation.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
-        if (newValue.latestPrice.gt(Fixed6.wrap(type(int64).max))) revert GlobalStorageInvalidError();
-        if (newValue.latestPrice.lt(Fixed6.wrap(type(int64).min))) revert GlobalStorageInvalidError();
         if (newValue.exposure.gt(Fixed6.wrap(type(int64).max))) revert GlobalStorageInvalidError();
         if (newValue.exposure.lt(Fixed6.wrap(type(int64).min))) revert GlobalStorageInvalidError();
         if (newValue.pAccumulator._value.gt(Fixed6.wrap(type(int32).max))) revert GlobalStorageInvalidError();
@@ -161,7 +157,6 @@ library GlobalStorageLib {
         uint256 encoded1 =
             uint256(Fixed6.unwrap(newValue.pAccumulator._value) << (256 - 32)) >> (256 - 32) |
             uint256(Fixed6.unwrap(newValue.pAccumulator._skew) << (256 - 24)) >> (256 - 32 - 24) |
-            uint256(Fixed6.unwrap(newValue.latestPrice) << (256 - 64)) >> (256 - 32 - 24 - 64) |
             uint256(Fixed6.unwrap(newValue.exposure) << (256 - 64)) >> (256 - 32 - 24 - 64 - 64);
 
         assembly {

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -144,16 +144,21 @@ describe('Fees', () => {
       // check user state
       expectLocalEq(await market.locals(user.address), {
         ...DEFAULT_LOCAL,
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         collateral: COLLATERAL.sub(expectedMakerFee).sub(expectedMakerLinear).sub(expectedMakerProportional),
       })
-      expectOrderEq(await market.pendingOrders(user.address, 2), {
+      expectOrderEq(await market.pendingOrders(user.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        makerPos: POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(user.address, 2), {
+      expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedMakerFee.add(expectedMakerLinear).add(expectedMakerProportional),
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(user.address), {
         ...DEFAULT_POSITION,
@@ -167,7 +172,7 @@ describe('Fees', () => {
       const expectedRiskFee = BigNumber.from('50108508') // = (250542544 - 125271272) * 0.4
       const expectedDonation = BigNumber.from('37581383') // = 250542544 - 125271272 - 37581381 - 50108508
       expectGlobalEq(await market.global(), {
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -175,9 +180,12 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(2), {
+      expectOrderEq(await market.pendingOrder(1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        makerPos: POSITION,
+        collateral: COLLATERAL,
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -246,16 +254,20 @@ describe('Fees', () => {
       // check user state
       expectLocalEq(await market.locals(user.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         collateral: COLLATERAL.sub(expectedMakerFee).sub(10), // Maker gets part of their fee refunded since they were an exisiting maker
       })
-      expectOrderEq(await market.pendingOrders(user.address, 3), {
+      expectOrderEq(await market.pendingOrders(user.address, 2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        makerNeg: POSITION,
       })
-      expectCheckpointEq(await market.checkpoints(user.address, 3), {
+      expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_2), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedMakerFee.add(expectedMakerLinear).add(expectedMakerProportional),
+        collateral: COLLATERAL.add(expectedMakerLinear).add(expectedMakerProportional).sub(10),
       })
       expectPositionEq(await market.positions(user.address), {
         ...DEFAULT_POSITION,
@@ -268,7 +280,7 @@ describe('Fees', () => {
       const expectedRiskFee = BigNumber.from('11388297') // = (56941487 - 28470743) * 0.4
       const expectedDonation = BigNumber.from('8541224') // = 56941487 - 28470743 - 8541223 - 11388297
       expectGlobalEq(await market.global(), {
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -276,9 +288,11 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(3), {
+      expectOrderEq(await market.pendingOrder(2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        makerNeg: POSITION,
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -367,7 +381,7 @@ describe('Fees', () => {
 
       // Global State
       expectGlobalEq(await market.global(), {
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -375,9 +389,13 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(2), {
+      expectOrderEq(await market.pendingOrder(1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
+        timestamp: TIMESTAMP_1,
+        orders: 2,
+        longPos: LONG_POSITION,
+        makerPos: MAKER_POSITION,
+        collateral: COLLATERAL.mul(2),
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -389,19 +407,24 @@ describe('Fees', () => {
       // Long State
       expectLocalEq(await market.locals(userB.address), {
         ...DEFAULT_LOCAL,
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         collateral: COLLATERAL.sub(expectedTakerFee)
           .sub(expectedTakerLinear)
           .sub(expectedTakerProportional)
           .sub(expectedtakerAdiabatic),
       })
-      expectOrderEq(await market.pendingOrders(userB.address, 2), {
+      expectOrderEq(await market.pendingOrders(userB.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        longPos: LONG_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(userB.address, 2), {
+      expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedTakerFee.add(expectedTakerLinear).add(expectedTakerProportional).add(expectedtakerAdiabatic),
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(userB.address), {
         ...DEFAULT_POSITION,
@@ -494,7 +517,7 @@ describe('Fees', () => {
 
       // Global State
       expectGlobalEq(await market.global(), {
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -502,9 +525,12 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(3), {
+      expectOrderEq(await market.pendingOrder(2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        longPos: LONG_POSITION,
+        collateral: COLLATERAL,
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -516,19 +542,24 @@ describe('Fees', () => {
       // Long State
       expectLocalEq(await market.locals(userB.address), {
         ...DEFAULT_LOCAL,
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         collateral: COLLATERAL.sub(expectedTakerFee)
           .sub(expectedTakerLinear)
           .sub(expectedTakerProportional)
           .sub(expectedTakerAdiabatic),
       })
-      expectOrderEq(await market.pendingOrders(userB.address, 2), {
+      expectOrderEq(await market.pendingOrders(userB.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        longPos: LONG_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(userB.address, 2), {
+      expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_2), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedTakerFee.add(expectedTakerLinear).add(expectedTakerProportional).add(expectedTakerAdiabatic),
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(userB.address), {
         ...DEFAULT_POSITION,
@@ -547,16 +578,20 @@ describe('Fees', () => {
       // Maker State
       expectLocalEq(await market.locals(user.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
-        latestId: 2,
+        currentId: 1,
+        latestId: 1,
         collateral: COLLATERAL.add(expectedMakerFee),
       })
-      expectOrderEq(await market.pendingOrders(user.address, 3), {
+      expectOrderEq(await market.pendingOrders(user.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        makerPos: MAKER_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(user.address, 3), {
+      expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(user.address), {
         ...DEFAULT_POSITION,
@@ -674,7 +709,7 @@ describe('Fees', () => {
 
       // Global State
       expectGlobalEq(await market.global(), {
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -682,9 +717,11 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(3), {
+      expectOrderEq(await market.pendingOrder(2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        longNeg: LONG_POSITION,
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -695,19 +732,23 @@ describe('Fees', () => {
       // Long State
       expectLocalEq(await market.locals(userB.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         collateral: COLLATERAL.sub(expectedTakerFee)
           .sub(expectedTakerLinear)
           .sub(expectedTakerProportional)
           .sub(expectedTakerAdiabatic),
       })
-      expectOrderEq(await market.pendingOrders(userB.address, 3), {
+      expectOrderEq(await market.pendingOrders(userB.address, 2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        longNeg: LONG_POSITION,
       })
-      expectCheckpointEq(await market.checkpoints(userB.address, 3), {
+      expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_2), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedTakerFee.add(expectedTakerLinear).add(expectedTakerProportional).add(expectedTakerAdiabatic),
+        collateral: COLLATERAL,
       })
       expectPositionEq(await market.positions(userB.address), {
         ...DEFAULT_POSITION,
@@ -725,16 +766,20 @@ describe('Fees', () => {
       // Maker State
       expectLocalEq(await market.locals(user.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
-        latestId: 2,
+        currentId: 1,
+        latestId: 1,
         collateral: COLLATERAL.add(expectedMakerFee),
       })
-      expectOrderEq(await market.pendingOrders(user.address, 3), {
+      expectOrderEq(await market.pendingOrders(user.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        makerPos: MAKER_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(user.address, 3), {
+      expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(user.address), {
         ...DEFAULT_POSITION,
@@ -824,7 +869,7 @@ describe('Fees', () => {
 
       // Global State
       expectGlobalEq(await market.global(), {
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -832,9 +877,13 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(2), {
+      expectOrderEq(await market.pendingOrder(1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
+        timestamp: TIMESTAMP_1,
+        orders: 2,
+        makerPos: MAKER_POSITION,
+        shortPos: SHORT_POSITION,
+        collateral: COLLATERAL.mul(2),
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -846,19 +895,24 @@ describe('Fees', () => {
       // Long State
       expectLocalEq(await market.locals(userB.address), {
         ...DEFAULT_LOCAL,
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         collateral: COLLATERAL.sub(expectedTakerFee)
           .sub(expectedTakerLinear)
           .sub(expectedTakerProportional)
           .sub(expectedtakerAdiabatic),
       })
-      expectOrderEq(await market.pendingOrders(userB.address, 2), {
+      expectOrderEq(await market.pendingOrders(userB.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_2,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        shortPos: SHORT_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(userB.address, 2), {
+      expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedTakerFee.add(expectedTakerLinear).add(expectedTakerProportional).add(expectedtakerAdiabatic),
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(userB.address), {
         ...DEFAULT_POSITION,
@@ -951,7 +1005,7 @@ describe('Fees', () => {
 
       // Global State
       expectGlobalEq(await market.global(), {
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -959,9 +1013,12 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(3), {
+      expectOrderEq(await market.pendingOrder(2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        shortPos: SHORT_POSITION,
+        collateral: COLLATERAL,
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -973,18 +1030,21 @@ describe('Fees', () => {
       // Long State
       expectLocalEq(await market.locals(userB.address), {
         ...DEFAULT_LOCAL,
-        currentId: 2,
+        currentId: 1,
         latestId: 1,
         collateral: COLLATERAL.sub(expectedTakerFee)
           .sub(expectedTakerLinear)
           .sub(expectedTakerProportional)
           .sub(expectedTakerAdiabatic),
       })
-      expectOrderEq(await market.pendingOrders(userB.address, 2), {
+      expectOrderEq(await market.pendingOrders(userB.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        shortPos: SHORT_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(userB.address, 2), {
+      expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
       })
       expectPositionEq(await market.positions(userB.address), {
@@ -1004,16 +1064,20 @@ describe('Fees', () => {
       // Maker State
       expectLocalEq(await market.locals(user.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
-        latestId: 2,
+        currentId: 1,
+        latestId: 1,
         collateral: COLLATERAL.add(expectedMakerFee),
       })
-      expectOrderEq(await market.pendingOrders(user.address, 3), {
+      expectOrderEq(await market.pendingOrders(user.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        makerPos: MAKER_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(user.address, 3), {
+      expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(user.address), {
         ...DEFAULT_POSITION,
@@ -1130,7 +1194,7 @@ describe('Fees', () => {
 
       // Global State
       expectGlobalEq(await market.global(), {
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         protocolFee: expectedProtocolFee,
         riskFee: expectedRiskFee,
@@ -1138,9 +1202,11 @@ describe('Fees', () => {
         donation: expectedDonation,
         exposure: 0,
       })
-      expectOrderEq(await market.pendingOrder(3), {
+      expectOrderEq(await market.pendingOrder(2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        shortNeg: SHORT_POSITION,
       })
       expectPositionEq(await market.position(), {
         ...DEFAULT_POSITION,
@@ -1151,19 +1217,23 @@ describe('Fees', () => {
       // Long State
       expectLocalEq(await market.locals(userB.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
+        currentId: 2,
         latestId: 2,
         collateral: COLLATERAL.sub(expectedTakerFee)
           .sub(expectedTakerLinear)
           .sub(expectedTakerProportional)
           .sub(expectedTakerAdiabatic),
       })
-      expectOrderEq(await market.pendingOrders(userB.address, 3), {
+      expectOrderEq(await market.pendingOrders(userB.address, 2), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_2,
+        orders: 1,
+        shortNeg: SHORT_POSITION,
       })
-      expectCheckpointEq(await market.checkpoints(userB.address, 3), {
+      expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_2), {
         ...DEFAULT_CHECKPOINT,
+        tradeFee: expectedTakerFee.add(expectedTakerLinear).add(expectedTakerProportional).add(expectedTakerAdiabatic),
+        collateral: COLLATERAL,
       })
       expectPositionEq(await market.positions(userB.address), {
         ...DEFAULT_POSITION,
@@ -1181,16 +1251,20 @@ describe('Fees', () => {
       // Maker State
       expectLocalEq(await market.locals(user.address), {
         ...DEFAULT_LOCAL,
-        currentId: 3,
-        latestId: 2,
+        currentId: 1,
+        latestId: 1,
         collateral: COLLATERAL.add(expectedMakerFee),
       })
-      expectOrderEq(await market.pendingOrders(user.address, 3), {
+      expectOrderEq(await market.pendingOrders(user.address, 1), {
         ...DEFAULT_ORDER,
-        timestamp: TIMESTAMP_3,
+        timestamp: TIMESTAMP_1,
+        orders: 1,
+        makerPos: MAKER_POSITION,
+        collateral: COLLATERAL,
       })
-      expectCheckpointEq(await market.checkpoints(user.address, 3), {
+      expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
         ...DEFAULT_CHECKPOINT,
+        transfer: COLLATERAL,
       })
       expectPositionEq(await market.positions(user.address), {
         ...DEFAULT_POSITION,
@@ -1571,7 +1645,7 @@ describe('Fees', () => {
 
         expectGlobalEq(await market.global(), {
           ...DEFAULT_GLOBAL,
-          currentId: 3,
+          currentId: 2,
           latestId: 2,
           oracleFee: expectedSettlementFee,
         })
@@ -2178,7 +2252,7 @@ describe('Fees', () => {
       await settle(market, userB)
       await settle(market, userC) // update userC to clear values
       expect(await market.orderReferrers(userC.address, currentId)).to.equal(userB.address)
-      expect((await market.locals(userC.address)).currentId).to.equal(currentId.add(1))
+      expect((await market.locals(userC.address)).currentId).to.equal(currentId)
 
       // ensure the proper amount of the base fee is claimable by the referrer
       // takerFee = position * takerFee * price = 3 * 0.025 * 113.882975 = 8.541223

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -173,7 +173,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -276,7 +275,6 @@ describe('Fees', () => {
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
         exposure: 0,
-        latestPrice: PRICE,
       })
       expectOrderEq(await market.pendingOrder(3), {
         ...DEFAULT_ORDER,
@@ -375,7 +373,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -503,7 +500,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(3), {
@@ -684,7 +680,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(3), {
@@ -835,7 +830,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -963,7 +957,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(3), {
@@ -1143,7 +1136,6 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
-        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(3), {
@@ -1582,7 +1574,6 @@ describe('Fees', () => {
           currentId: 3,
           latestId: 2,
           oracleFee: expectedSettlementFee,
-          latestPrice: PRICE,
         })
       })
 
@@ -1622,7 +1613,6 @@ describe('Fees', () => {
           currentId: 2,
           latestId: 2,
           oracleFee: expectedSettlementFee,
-          latestPrice: PRICE,
         })
       })
     })

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants, ContractTransaction, utils } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle, updateNoOp } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
 import {
   DEFAULT_CHECKPOINT,
   DEFAULT_POSITION,
@@ -128,7 +128,7 @@ describe('Fees', () => {
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
-      const tx = await updateNoOp(market, user)
+      const tx = await settle(market, user)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -230,7 +230,7 @@ describe('Fees', () => {
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
-      const tx = await updateNoOp(market, user)
+      const tx = await settle(market, user)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -332,7 +332,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await updateNoOp(market, userB)
+      const txLong = await settle(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -436,7 +436,7 @@ describe('Fees', () => {
 
       // Settle maker to give them portion of fees
       await nextWithConstantPrice()
-      await updateNoOp(market, user)
+      await settle(market, user)
 
       await expect(
         market
@@ -461,7 +461,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await updateNoOp(market, userB)
+      const txLong = await settle(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -536,7 +536,7 @@ describe('Fees', () => {
         long: LONG_POSITION,
       })
 
-      const txMaker = await updateNoOp(market, user)
+      const txMaker = await settle(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -623,8 +623,8 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      await updateNoOp(market, userB)
-      await updateNoOp(market, user)
+      await settle(market, userB)
+      await settle(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
       await market.updateRiskParameter({
@@ -651,7 +651,7 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
 
       await nextWithConstantPrice()
-      const txLong = await updateNoOp(market, userB)
+      const txLong = await settle(market, userB)
 
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
@@ -714,7 +714,7 @@ describe('Fees', () => {
         timestamp: TIMESTAMP_2,
       })
 
-      const txMaker = await updateNoOp(market, user)
+      const txMaker = await settle(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -789,7 +789,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await updateNoOp(market, userB)
+      const txLong = await settle(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -893,7 +893,7 @@ describe('Fees', () => {
 
       // Settle maker to give them portion of fees
       await nextWithConstantPrice()
-      await updateNoOp(market, user)
+      await settle(market, user)
 
       await expect(
         market
@@ -918,7 +918,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await updateNoOp(market, userB)
+      const txLong = await settle(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -993,7 +993,7 @@ describe('Fees', () => {
         short: SHORT_POSITION,
       })
 
-      const txMaker = await updateNoOp(market, user)
+      const txMaker = await settle(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1080,8 +1080,8 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      await updateNoOp(market, userB)
-      await updateNoOp(market, user)
+      await settle(market, userB)
+      await settle(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
       await market.updateRiskParameter({
@@ -1107,7 +1107,7 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
 
       await nextWithConstantPrice()
-      const txLong = await updateNoOp(market, userB)
+      const txLong = await settle(market, userB)
 
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
@@ -1170,7 +1170,7 @@ describe('Fees', () => {
         timestamp: TIMESTAMP_2,
       })
 
-      const txMaker = await updateNoOp(market, user)
+      const txMaker = await settle(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1560,7 +1560,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const tx = await updateNoOp(market, instanceVars.user)
+        const tx = await settle(market, instanceVars.user)
 
         const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
@@ -2176,7 +2176,7 @@ describe('Fees', () => {
       await nextWithConstantPrice()
       await settle(market, user)
       await settle(market, userB)
-      await updateNoOp(market, userC) // update userC to clear values
+      await settle(market, userC) // update userC to clear values
       expect(await market.orderReferrers(userC.address, currentId)).to.equal(userB.address)
       expect((await market.locals(userC.address)).currentId).to.equal(currentId.add(1))
 

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -168,7 +168,6 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
-      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -216,7 +215,6 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
-      latestPrice: PRICE_2,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -281,7 +279,6 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
-      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -329,7 +326,6 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
-      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -401,7 +397,6 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
-      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -478,7 +473,6 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
-      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -586,7 +580,6 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
-      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -619,7 +612,6 @@ describe('Happy Path', () => {
       latestId: 1,
       protocolFee: '18',
       donation: '18',
-      latestPrice: PRICE_3,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -717,7 +709,6 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
-      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -750,7 +741,6 @@ describe('Happy Path', () => {
       latestId: 1,
       protocolFee: '18',
       donation: '18',
-      latestPrice: PRICE_3,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -851,7 +841,6 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
-      latestPrice: PRICE_2,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -943,7 +932,6 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
-      latestPrice: PRICE_2,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -1212,7 +1200,6 @@ describe('Happy Path', () => {
       latestId: 2,
       protocolFee: '86263589',
       donation: '86263590',
-      latestPrice: '117462552',
     })
     expectOrderEq(await market.pendingOrder(3), {
       ...DEFAULT_ORDER,
@@ -1391,7 +1378,6 @@ describe('Happy Path', () => {
       riskFee: (await market.global()).riskFee,
       oracleFee: (await market.global()).oracleFee,
       donation: (await market.global()).donation,
-      latestPrice: PRICE,
       exposure: 0,
     })
     expectOrderEq(await market.pendingOrder(delay + 1), {

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -193,16 +193,20 @@ describe('Happy Path', () => {
     // check user state
     expectLocalEq(await market.locals(user.address), {
       ...DEFAULT_LOCAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
       collateral: COLLATERAL,
     })
-    expectOrderEq(await market.pendingOrders(user.address, 2), {
+    expectOrderEq(await market.pendingOrders(user.address, 1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_2,
+      timestamp: TIMESTAMP_1,
+      orders: 1,
+      makerPos: POSITION,
+      collateral: COLLATERAL,
     })
-    expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_2), {
+    expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
       ...DEFAULT_CHECKPOINT,
+      transfer: COLLATERAL,
     })
     expectPositionEq(await market.positions(user.address), {
       ...DEFAULT_POSITION,
@@ -213,12 +217,15 @@ describe('Happy Path', () => {
     // Check global post-settlement state
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
     })
-    expectOrderEq(await market.pendingOrder(2), {
+    expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_2,
+      timestamp: TIMESTAMP_1,
+      orders: 1,
+      makerPos: POSITION,
+      collateral: COLLATERAL,
     })
     expectPositionEq(await market.position(), {
       ...DEFAULT_POSITION,
@@ -304,16 +311,20 @@ describe('Happy Path', () => {
     // check user state
     expectLocalEq(await market.locals(user.address), {
       ...DEFAULT_LOCAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
       collateral: COLLATERAL,
     })
-    expectOrderEq(await market.pendingOrders(user.address, 2), {
+    expectOrderEq(await market.pendingOrders(user.address, 1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_2,
+      timestamp: TIMESTAMP_1,
+      orders: 2,
+      collateral: COLLATERAL,
+      makerPos: POSITION,
     })
-    expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_2), {
+    expectCheckpointEq(await market.checkpoints(user.address, TIMESTAMP_1), {
       ...DEFAULT_CHECKPOINT,
+      transfer: COLLATERAL,
     })
     expectPositionEq(await market.positions(user.address), {
       ...DEFAULT_POSITION,
@@ -324,12 +335,15 @@ describe('Happy Path', () => {
     // Check global post-settlement state
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
     })
-    expectOrderEq(await market.pendingOrder(2), {
+    expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_2,
+      timestamp: TIMESTAMP_1,
+      orders: 2,
+      collateral: COLLATERAL,
+      makerPos: POSITION,
     })
     expectPositionEq(await market.position(), {
       ...DEFAULT_POSITION,
@@ -608,14 +622,18 @@ describe('Happy Path', () => {
 
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
       protocolFee: '18',
       donation: '18',
     })
-    expectOrderEq(await market.pendingOrder(2), {
+    expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_3,
+      timestamp: TIMESTAMP_1,
+      orders: 2,
+      collateral: COLLATERAL.mul(2),
+      makerPos: POSITION,
+      longPos: POSITION_B,
     })
     expectPositionEq(await market.position(), {
       ...DEFAULT_POSITION,
@@ -626,16 +644,20 @@ describe('Happy Path', () => {
 
     expectLocalEq(await market.locals(userB.address), {
       ...DEFAULT_LOCAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
       collateral: COLLATERAL.add(BigNumber.from('1249392')),
     })
-    expectOrderEq(await market.pendingOrders(userB.address, 2), {
+    expectOrderEq(await market.pendingOrders(userB.address, 1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_3,
+      timestamp: TIMESTAMP_1,
+      orders: 1,
+      collateral: COLLATERAL,
+      longPos: POSITION_B,
     })
-    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_3), {
+    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_1), {
       ...DEFAULT_CHECKPOINT,
+      transfer: COLLATERAL,
     })
     expectPositionEq(await market.positions(userB.address), {
       ...DEFAULT_POSITION,
@@ -737,14 +759,18 @@ describe('Happy Path', () => {
 
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
       protocolFee: '18',
       donation: '18',
     })
-    expectOrderEq(await market.pendingOrder(2), {
+    expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_3,
+      timestamp: TIMESTAMP_1,
+      orders: 3,
+      collateral: COLLATERAL.mul(2),
+      makerPos: POSITION,
+      longPos: POSITION_B,
     })
     expectPositionEq(await market.position(), {
       ...DEFAULT_POSITION,
@@ -754,16 +780,20 @@ describe('Happy Path', () => {
     })
     expectLocalEq(await market.locals(userB.address), {
       ...DEFAULT_LOCAL,
-      currentId: 2,
+      currentId: 1,
       latestId: 1,
       collateral: COLLATERAL.add(BigNumber.from('1249392')),
     })
-    expectOrderEq(await market.pendingOrders(userB.address, 2), {
+    expectOrderEq(await market.pendingOrders(userB.address, 1), {
       ...DEFAULT_ORDER,
-      timestamp: TIMESTAMP_3,
+      timestamp: TIMESTAMP_1,
+      orders: 2,
+      collateral: COLLATERAL,
+      longPos: POSITION_B,
     })
-    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_3), {
+    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_1), {
       ...DEFAULT_CHECKPOINT,
+      transfer: COLLATERAL,
     })
     expectPositionEq(await market.positions(userB.address), {
       ...DEFAULT_POSITION,

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle, updateNoOp } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
 import {
   DEFAULT_ORDER,
   DEFAULT_POSITION,
@@ -188,7 +188,7 @@ describe('Happy Path', () => {
 
     // Settle the market with a new oracle version
     await chainlink.next()
-    await updateNoOp(market, user)
+    await settle(market, user)
 
     // check user state
     expectLocalEq(await market.locals(user.address), {
@@ -299,7 +299,7 @@ describe('Happy Path', () => {
 
     // Settle the market with a new oracle version
     await chainlink.next()
-    await updateNoOp(market, user)
+    await settle(market, user)
 
     // check user state
     expectLocalEq(await market.locals(user.address), {
@@ -604,7 +604,7 @@ describe('Happy Path', () => {
 
     // Another round
     await chainlink.next()
-    await updateNoOp(market, userB)
+    await settle(market, userB)
 
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
@@ -733,7 +733,7 @@ describe('Happy Path', () => {
 
     // Another round
     await chainlink.next()
-    await updateNoOp(market, userB)
+    await settle(market, userB)
 
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -274,19 +274,6 @@ export async function createMarket(
   return market
 }
 
-export async function updateNoOp(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
-  return market
-    .connect(account)
-    ['update(address,uint256,uint256,uint256,int256,bool)'](
-      account.address,
-      constants.MaxUint256,
-      constants.MaxUint256,
-      constants.MaxUint256,
-      0,
-      false,
-    )
-}
-
 export async function settle(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
   return market.connect(account).settle(account.address)
 }

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -682,7 +682,7 @@ describe('Market', () => {
       })
     })
 
-    describe.only('#updateRiskParameter', async () => {
+    describe('#updateRiskParameter', async () => {
       const defaultRiskParameter = {
         margin: parse6decimal('0.5'),
         maintenance: parse6decimal('0.4'),

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14983,19 +14983,19 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
-            latestId: 2,
+            currentId: 2,
+            latestId: 1,
             collateral: parse6decimal('216')
               .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
               .sub(EXPECTED_PNL),
           })
-          expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+          expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
             timestamp: ORACLE_VERSION_3.timestamp,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
+          expectOrderEq(await market.pendingOrders(user.address, 2), {
             ...DEFAULT_ORDER,
             timestamp: ORACLE_VERSION_4.timestamp,
             orders: 1,
@@ -15007,8 +15007,8 @@ describe('Market', () => {
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
-            latestId: 2,
+            currentId: 1,
+            latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
               .add(EXPECTED_PNL)
               .sub(8), // loss of precision
@@ -15018,17 +15018,20 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 3), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
           expectGlobalEq(await market.global(), {
-            currentId: 3,
-            latestId: 2,
+            currentId: 2,
+            latestId: 1,
             protocolFee: totalFee.div(2).sub(3), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -15041,7 +15044,7 @@ describe('Market', () => {
             maker: POSITION,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(3), {
+          expectOrderEq(await market.pendingOrder(2), {
             ...DEFAULT_ORDER,
             timestamp: ORACLE_VERSION_4.timestamp,
             orders: 1,
@@ -15326,8 +15329,8 @@ describe('Market', () => {
           })
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 6,
-            latestId: 5,
+            currentId: 3,
+            latestId: 3,
             collateral: parse6decimal('216')
               .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
               .sub(EXPECTED_INTEREST_5_123)
@@ -15341,17 +15344,20 @@ describe('Market', () => {
             ...DEFAULT_POSITION,
             timestamp: ORACLE_VERSION_6.timestamp,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 6), {
+          expectOrderEq(await market.pendingOrders(user.address, 3), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp + 3600,
+            timestamp: ORACLE_VERSION_5.timestamp,
+            orders: 1,
+            shortNeg: POSITION.div(2),
+            protection: 1,
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp + 3600), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 6,
-            latestId: 5,
+            currentId: 1,
+            latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
               .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_150)
@@ -15364,9 +15370,12 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_6.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 6), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp + 3600,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp + 3600), {
             ...DEFAULT_CHECKPOINT,
@@ -15376,8 +15385,8 @@ describe('Market', () => {
             .add(EXPECTED_INTEREST_FEE_5_150)
             .add(EXPECTED_ROUND_3_ACC_FEE)
           expectGlobalEq(await market.global(), {
-            currentId: 6,
-            latestId: 5,
+            currentId: 3,
+            latestId: 3,
             protocolFee: totalFee.div(2).sub(2), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -15389,9 +15398,11 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_6.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrder(6), {
+          expectOrderEq(await market.pendingOrder(3), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp + 3600,
+            timestamp: ORACLE_VERSION_5.timestamp,
+            orders: 1,
+            shortNeg: POSITION.div(2),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -15529,30 +15540,33 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 5,
-            latestId: 4,
+            currentId: 2,
+            latestId: 2,
             collateral: parse6decimal('216')
               .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123))
               .sub(EXPECTED_FUNDING_WITH_FEE_2_5_96.add(EXPECTED_INTEREST_5_96))
               .sub(EXPECTED_LIQUIDATION_FEE),
             claimable: EXPECTED_LIQUIDATION_FEE,
           })
-          expect(await market.liquidators(user.address, 3)).to.equal(user.address)
+          expect(await market.liquidators(user.address, 2)).to.equal(user.address)
           expectPositionEq(await market.positions(user.address), {
             ...DEFAULT_POSITION,
             timestamp: ORACLE_VERSION_5.timestamp,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 5), {
+          expectOrderEq(await market.pendingOrders(user.address, 2), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp,
+            timestamp: ORACLE_VERSION_4.timestamp,
+            orders: 1,
+            longNeg: POSITION.div(2),
+            protection: 1,
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 5,
-            latestId: 4,
+            currentId: 1,
+            latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
               .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_5_96))
               .sub(20), // loss of precision
@@ -15562,9 +15576,12 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_5.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 5), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -15573,8 +15590,8 @@ describe('Market', () => {
             EXPECTED_FUNDING_FEE_2_5_96.add(EXPECTED_INTEREST_FEE_5_96),
           )
           expectGlobalEq(await market.global(), {
-            currentId: 5,
-            latestId: 4,
+            currentId: 2,
+            latestId: 2,
             protocolFee: totalFee.div(2).sub(4), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -15586,9 +15603,11 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_5.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrder(5), {
+          expectOrderEq(await market.pendingOrder(2), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp,
+            timestamp: ORACLE_VERSION_4.timestamp,
+            orders: 1,
+            longNeg: POSITION.div(2),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -15710,9 +15729,9 @@ describe('Market', () => {
               userB.address,
             )
 
-          expect((await market.locals(user.address)).currentId).to.equal(3)
-          expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
-          expect(await market.orderReferrers(user.address, 3)).to.equal(userB.address)
+          expect((await market.locals(user.address)).currentId).to.equal(2)
+          expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
+          expect(await market.orderReferrers(user.address, 2)).to.equal(userB.address)
         })
 
         it('resets related accounts on update', async () => {
@@ -15766,8 +15785,8 @@ describe('Market', () => {
           oracle.status.returns([ORACLE_VERSION_4, ORACLE_VERSION_5.timestamp])
           oracle.request.whenCalledWith(user.address).returns()
 
-          expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
-          expect(await market.orderReferrers(user.address, 3)).to.equal(userB.address)
+          expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
+          expect(await market.orderReferrers(user.address, 2)).to.equal(userB.address)
 
           dsu.transferFrom.whenCalledWith(user.address, market.address, utils.parseEther('1000')).returns(true)
           await market
@@ -15782,9 +15801,9 @@ describe('Market', () => {
             )
           await settle(market, user)
 
-          expect((await market.locals(user.address)).currentId).to.equal(4)
-          expect(await market.liquidators(user.address, 4)).to.equal(constants.AddressZero)
-          expect(await market.orderReferrers(user.address, 4)).to.equal(constants.AddressZero)
+          expect((await market.locals(user.address)).currentId).to.equal(3)
+          expect(await market.liquidators(user.address, 3)).to.equal(constants.AddressZero)
+          expect(await market.orderReferrers(user.address, 3)).to.equal(constants.AddressZero)
         })
       })
 

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -832,7 +832,7 @@ describe('Market', () => {
           ...DEFAULT_GLOBAL,
           currentId: 2,
           latestId: 1,
-          latestPrice: PRICE,
+
           exposure: BigNumber.from(0).sub(parse6decimal('0.369')),
         })
 
@@ -1002,7 +1002,6 @@ describe('Market', () => {
           oracleFee: totalFee.div(2).div(10),
           riskFee: totalFee.div(2).div(10),
           donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-          latestPrice: parse6decimal('45'),
           exposure: 0,
         })
 
@@ -1025,7 +1024,6 @@ describe('Market', () => {
           oracleFee: totalFee.div(2).div(10),
           riskFee: totalFee.div(2).div(10),
           donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-          latestPrice: parse6decimal('45'),
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
         })
 
@@ -1057,7 +1055,6 @@ describe('Market', () => {
           oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
           riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
-          latestPrice: parse6decimal('62'),
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
         })
       })
@@ -1201,7 +1198,6 @@ describe('Market', () => {
           oracleFee: totalFee.div(2).div(10),
           riskFee: totalFee.div(2).div(10),
           donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-          latestPrice: parse6decimal('45'),
           exposure: 0,
         })
 
@@ -1226,7 +1222,6 @@ describe('Market', () => {
           oracleFee: totalFee.div(2).div(10),
           riskFee: totalFee.div(2).div(10),
           donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-          latestPrice: parse6decimal('45'),
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
         })
 
@@ -1258,7 +1253,6 @@ describe('Market', () => {
           oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
           riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
-          latestPrice: parse6decimal('62'),
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
         })
       })
@@ -1376,7 +1370,6 @@ describe('Market', () => {
           ...DEFAULT_GLOBAL,
           currentId: 1,
           latestId: 1,
-          latestPrice: PRICE,
         })
         expectPositionEq(await market.position(), {
           ...DEFAULT_POSITION,
@@ -1494,7 +1487,6 @@ describe('Market', () => {
           ...DEFAULT_GLOBAL,
           currentId: 1,
           latestId: 1,
-          latestPrice: PRICE,
         })
         expectPositionEq(await market.position(), {
           ...DEFAULT_POSITION,
@@ -1570,7 +1562,6 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1622,7 +1613,6 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1676,7 +1666,6 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1733,7 +1722,6 @@ describe('Market', () => {
             ...DEFAULT_GLOBAL,
             currentId: 2,
             latestId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1788,7 +1776,6 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1845,7 +1832,6 @@ describe('Market', () => {
             ...DEFAULT_GLOBAL,
             currentId: 2,
             latestId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1921,7 +1907,6 @@ describe('Market', () => {
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
               currentId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2036,7 +2021,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2096,7 +2080,6 @@ describe('Market', () => {
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
               currentId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2159,7 +2142,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2225,7 +2207,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2297,7 +2278,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 3,
               latestId: 2,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2375,7 +2355,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2468,7 +2447,6 @@ describe('Market', () => {
               oracleFee: MAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE),
               riskFee: MAKER_FEE.div(2).div(10),
               donation: MAKER_FEE.div(2).mul(8).div(10),
-              latestPrice: PRICE,
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -2545,7 +2523,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2608,7 +2585,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 3,
                 latestId: 2,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2669,7 +2645,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2736,7 +2711,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 3,
                 latestId: 2,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2801,7 +2775,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 3,
                 latestId: 2,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2872,7 +2845,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 4,
                 latestId: 3,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2934,7 +2906,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 3,
                 latestId: 2,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3016,7 +2987,6 @@ describe('Market', () => {
                 oracleFee: MAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE),
                 riskFee: MAKER_FEE.div(2).div(10),
                 donation: MAKER_FEE.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3110,7 +3080,6 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3188,7 +3157,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3256,7 +3224,6 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3327,7 +3294,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3401,7 +3367,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3506,7 +3471,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3614,7 +3578,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3743,7 +3706,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3881,7 +3843,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3982,7 +3943,6 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
-                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4071,7 +4031,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -4140,7 +4099,6 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
-                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4233,7 +4191,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -4333,7 +4290,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -4450,7 +4406,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -4563,7 +4518,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -4686,7 +4640,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
                 })
                 expectPositionEq(await market.position(), {
@@ -4795,7 +4748,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -4917,7 +4869,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-              latestPrice: parse6decimal('121'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -5051,7 +5002,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-              latestPrice: parse6decimal('125'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -5234,7 +5184,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
-                latestPrice: parse6decimal('150'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -5486,7 +5435,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
-                latestPrice: parse6decimal('150'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -5668,7 +5616,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: parse6decimal('203'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -5922,7 +5869,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: parse6decimal('96'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -6092,7 +6038,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: parse6decimal('43'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -6283,7 +6228,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 3,
               latestId: 2,
-              latestPrice: parse6decimal('128'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -6382,7 +6326,6 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6460,7 +6403,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6529,7 +6471,6 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6600,7 +6541,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6674,7 +6614,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6779,7 +6718,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -6892,7 +6830,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -7024,7 +6961,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -7164,7 +7100,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -7266,7 +7201,6 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
-                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7355,7 +7289,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -7425,7 +7358,6 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
-                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7518,7 +7450,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -7618,7 +7549,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -7736,7 +7666,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -7851,7 +7780,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -7976,7 +7904,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                  latestPrice: PRICE,
                   exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
                 })
                 expectPositionEq(await market.position(), {
@@ -8086,7 +8013,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -8208,7 +8134,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-              latestPrice: parse6decimal('121'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -8344,7 +8269,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-              latestPrice: parse6decimal('125'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -8527,7 +8451,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: parse6decimal('96'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -8775,7 +8698,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: parse6decimal('96'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -8944,7 +8866,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: parse6decimal('43'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -9198,7 +9119,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
-                latestPrice: parse6decimal('150'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -9372,7 +9292,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-                latestPrice: parse6decimal('203'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -9565,7 +9484,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 3,
               latestId: 2,
-              latestPrice: parse6decimal('118'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -9690,7 +9608,6 @@ describe('Market', () => {
               oracleFee: EXPECTED_MAKER_FEE.div(2).div(10).add(EXPECTED_SETTLEMENT_FEE),
               riskFee: EXPECTED_MAKER_FEE.div(2).div(10),
               donation: EXPECTED_MAKER_FEE.div(2).mul(8).div(10),
-              latestPrice: PRICE,
               exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
             })
             expectPositionEq(await market.position(), {
@@ -9808,7 +9725,6 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9887,7 +9803,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9957,7 +9872,6 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10029,7 +9943,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10104,7 +10017,6 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
-                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10212,7 +10124,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -10337,7 +10248,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -10497,7 +10407,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
                 riskFee: totalFee.div(2).div(10), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10), // loss of precision
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -10622,7 +10531,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -10751,7 +10659,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -10877,7 +10784,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -11006,7 +10912,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: PRICE,
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -11134,7 +11039,6 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
-                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11226,7 +11130,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10),
                   riskFee: totalFee.div(2).div(10),
                   donation: totalFee.div(2).mul(8).div(10),
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -11308,7 +11211,6 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
-                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11404,7 +11306,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10),
                   riskFee: totalFee.div(2).div(10),
                   donation: totalFee.div(2).mul(8).div(10),
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -11519,7 +11420,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10),
                   riskFee: totalFee.div(2).div(10),
                   donation: totalFee.div(2).mul(8).div(10),
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -11644,7 +11544,6 @@ describe('Market', () => {
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-                  latestPrice: PRICE,
                   exposure: 0,
                 })
                 expectPositionEq(await market.position(), {
@@ -11992,7 +11891,6 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -12122,7 +12020,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10),
-              latestPrice: parse6decimal('121'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -12277,7 +12174,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10),
-              latestPrice: parse6decimal('125'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -12488,7 +12384,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).sub(1), // loss of precision
-                latestPrice: parse6decimal('45'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -12703,7 +12598,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
-                latestPrice: PRICE,
                 exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
               })
               expectPositionEq(await market.position(), {
@@ -12885,7 +12779,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).sub(2), // loss of precision
-                latestPrice: parse6decimal('45'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -13096,7 +12989,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: parse6decimal('33'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -13392,7 +13284,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: parse6decimal('96'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -13614,7 +13505,6 @@ describe('Market', () => {
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
-                latestPrice: parse6decimal('43'),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -13825,7 +13715,6 @@ describe('Market', () => {
               oracleFee: 0,
               riskFee: 0,
               donation: 0,
-              latestPrice: parse6decimal('128'),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -14856,7 +14745,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: parse6decimal('43'),
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -15206,7 +15094,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
-            latestPrice: parse6decimal('150'),
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -15404,7 +15291,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10),
-            latestPrice: parse6decimal('96'),
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -15743,7 +15629,6 @@ describe('Market', () => {
             currentId: 3,
             latestId: 2,
             oracleFee: SETTLEMENT_FEE,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -15936,7 +15821,6 @@ describe('Market', () => {
             oracleFee: TAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE.mul(2)),
             riskFee: TAKER_FEE.div(2).div(10),
             donation: TAKER_FEE.div(2).mul(8).div(10),
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -16138,7 +16022,6 @@ describe('Market', () => {
             currentId: 4,
             latestId: 3,
             oracleFee: SETTLEMENT_FEE.mul(2),
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -16331,7 +16214,6 @@ describe('Market', () => {
             currentId: 4,
             latestId: 3,
             oracleFee: SETTLEMENT_FEE,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -16561,7 +16443,6 @@ describe('Market', () => {
             oracleFee: TAKER_FEE.div(20).add(SETTLEMENT_FEE.mul(2)),
             riskFee: TAKER_FEE.div(20),
             donation: TAKER_FEE.mul(2).div(5),
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -16704,7 +16585,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -16846,7 +16726,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -16980,7 +16859,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -17065,7 +16943,6 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17147,7 +17024,6 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17382,7 +17258,6 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
             exposure: 0,
-            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -18618,7 +18493,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
-              latestPrice: PRICE,
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -18747,7 +18621,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
-              latestPrice: PRICE,
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -19158,7 +19031,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE),
             riskFee: totalFee.div(2).div(10),
             donation: totalFee.div(2).mul(8).div(10),
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19297,7 +19169,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19438,7 +19309,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19601,7 +19471,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19796,7 +19665,6 @@ describe('Market', () => {
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            latestPrice: PRICE,
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -20048,7 +19916,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20270,7 +20137,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20492,7 +20358,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20714,7 +20579,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20954,7 +20818,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21192,7 +21055,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21432,7 +21294,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21672,7 +21533,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21918,7 +21778,6 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
-              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -22163,7 +22022,6 @@ describe('Market', () => {
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE.mul(2)), // loss of precision
               riskFee: totalFee.div(2).div(10), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
-              latestPrice: PRICE,
               exposure: 0,
             })
             expectPositionEq(await market.position(), {

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -681,7 +681,7 @@ describe('Market', () => {
       })
     })
 
-    describe('#updateRiskParameter', async () => {
+    describe.only('#updateRiskParameter', async () => {
       const defaultRiskParameter = {
         margin: parse6decimal('0.5'),
         maintenance: parse6decimal('0.4'),
@@ -821,9 +821,8 @@ describe('Market', () => {
         // after = (0.20 + 0) / 2 * 0.003 * 10 * 123 = 0.369
         expectGlobalEq(await market.global(), {
           ...DEFAULT_GLOBAL,
-          currentId: 2,
+          currentId: 1,
           latestId: 1,
-
           exposure: BigNumber.from(0).sub(parse6decimal('0.369')),
         })
 
@@ -15875,7 +15874,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE),
           })
@@ -15895,16 +15894,9 @@ describe('Market', () => {
             settlementFee: SETTLEMENT_FEE,
             transfer: COLLATERAL,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL,
           })
@@ -15924,16 +15916,9 @@ describe('Market', () => {
             ...DEFAULT_CHECKPOINT,
             transfer: COLLATERAL,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             oracleFee: SETTLEMENT_FEE,
           })
@@ -15948,10 +15933,6 @@ describe('Market', () => {
             orders: 1,
             collateral: COLLATERAL,
             longPos: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrder(3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
             ...DEFAULT_VERSION,
@@ -16052,7 +16033,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.sub(TAKER_OFFSET).sub(TAKER_FEE).sub(SETTLEMENT_FEE.mul(2)),
           })
@@ -16085,16 +16066,9 @@ describe('Market', () => {
             settlementFee: SETTLEMENT_FEE,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(TAKER_OFFSET_MAKER),
           })
@@ -16114,15 +16088,8 @@ describe('Market', () => {
             ...DEFAULT_CHECKPOINT,
             transfer: COLLATERAL,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectGlobalEq(await market.global(), {
-            currentId: 4,
+            currentId: 3,
             latestId: 3,
             protocolFee: TAKER_FEE.div(2),
             oracleFee: TAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE.mul(2)),
@@ -16148,10 +16115,6 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             orders: 1,
             longPos: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrder(4), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
             ...DEFAULT_VERSION,
@@ -16257,7 +16220,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE.mul(2)),
           })
@@ -16288,16 +16251,12 @@ describe('Market', () => {
             collateral: COLLATERAL.sub(SETTLEMENT_FEE),
             settlementFee: SETTLEMENT_FEE,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL,
           })
@@ -16317,16 +16276,9 @@ describe('Market', () => {
             ...DEFAULT_CHECKPOINT,
             transfer: COLLATERAL,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
-            currentId: 4,
+            currentId: 3,
             latestId: 3,
             oracleFee: SETTLEMENT_FEE.mul(2),
           })
@@ -16347,10 +16299,6 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             orders: 1,
             longPos: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrder(4), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
             ...DEFAULT_VERSION,
@@ -16452,7 +16400,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE), // does not charge fee if both were pending at once
           })
@@ -16480,16 +16428,9 @@ describe('Market', () => {
             ...DEFAULT_CHECKPOINT,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL,
           })
@@ -16509,16 +16450,9 @@ describe('Market', () => {
             ...DEFAULT_CHECKPOINT,
             transfer: COLLATERAL,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
-            currentId: 4,
+            currentId: 3,
             latestId: 3,
             oracleFee: SETTLEMENT_FEE,
           })
@@ -16537,10 +16471,6 @@ describe('Market', () => {
           expectOrderEq(await market.pendingOrder(3), {
             ...DEFAULT_ORDER,
             timestamp: ORACLE_VERSION_4.timestamp,
-          })
-          expectOrderEq(await market.pendingOrder(4), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
             ...DEFAULT_VERSION,
@@ -16666,7 +16596,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 4,
+            currentId: 3,
             latestId: 3,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE.mul(2)).sub(TAKER_OFFSET).sub(TAKER_FEE),
           })
@@ -16707,16 +16637,9 @@ describe('Market', () => {
             settlementFee: SETTLEMENT_FEE,
             collateral: COLLATERAL.sub(SETTLEMENT_FEE),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 4), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-          })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(TAKER_OFFSET_MAKER),
           })
@@ -16736,15 +16659,18 @@ describe('Market', () => {
             ...DEFAULT_CHECKPOINT,
             transfer: COLLATERAL,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectGlobalEq(await market.global(), {
-            currentId: 5,
+            currentId: 4,
             latestId: 4,
             protocolFee: TAKER_FEE.div(2),
             oracleFee: TAKER_FEE.div(20).add(SETTLEMENT_FEE.mul(2)),
@@ -16774,10 +16700,6 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_5.timestamp,
             orders: 1,
             longPos: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrder(5), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_6.timestamp,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
             ...DEFAULT_VERSION,
@@ -16848,7 +16770,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
           })
@@ -16857,16 +16779,19 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
+          expectOrderEq(await market.pendingOrders(user.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -16877,16 +16802,19 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
           expectGlobalEq(await market.global(), {
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             protocolFee: totalFee.div(2).sub(3), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -16900,9 +16828,13 @@ describe('Market', () => {
             maker: POSITION,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(2), {
+          expectOrderEq(await market.pendingOrder(1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 2,
+            makerPos: POSITION,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL.mul(2),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -16968,7 +16900,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
           })
@@ -16976,16 +16908,18 @@ describe('Market', () => {
             ...DEFAULT_POSITION,
             timestamp: ORACLE_VERSION_4.timestamp,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
+          expectOrderEq(await market.pendingOrders(user.address, 2), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            orders: 1,
+            longNeg: POSITION.div(2),
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -16998,16 +16932,19 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userC.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
           })
@@ -17016,9 +16953,12 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             short: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(userC.address, 2), {
+          expectOrderEq(await market.pendingOrders(userC.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            orders: 1,
+            shortPos: POSITION.div(2),
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -17027,7 +16967,7 @@ describe('Market', () => {
             .add(EXPECTED_FUNDING_FEE_1_5_123)
             .add(EXPECTED_INTEREST_FEE_5_123)
           expectGlobalEq(await market.global(), {
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             protocolFee: totalFee.div(2).sub(6), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
@@ -17041,9 +16981,13 @@ describe('Market', () => {
             maker: POSITION,
             short: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(3), {
+          expectOrderEq(await market.pendingOrder(2), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            orders: 2,
+            longNeg: POSITION.div(2),
+            shortPos: POSITION.div(2),
+            collateral: COLLATERAL,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_VERSION,
@@ -17101,7 +17045,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
           })
@@ -17109,16 +17053,18 @@ describe('Market', () => {
             ...DEFAULT_POSITION,
             timestamp: ORACLE_VERSION_4.timestamp,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
+          expectOrderEq(await market.pendingOrders(user.address, 2), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            orders: 1,
+            longNeg: POSITION.div(2),
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -17131,16 +17077,19 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userC.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
           })
@@ -17149,9 +17098,12 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_4.timestamp,
             short: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(userC.address, 2), {
+          expectOrderEq(await market.pendingOrders(userC.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            orders: 1,
+            shortPos: POSITION.div(2),
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_5.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -17160,7 +17112,7 @@ describe('Market', () => {
             .add(EXPECTED_FUNDING_FEE_1_5_123)
             .add(EXPECTED_INTEREST_FEE_5_123)
           expectGlobalEq(await market.global(), {
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             protocolFee: totalFee.div(2).sub(6), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
@@ -17174,9 +17126,13 @@ describe('Market', () => {
             maker: POSITION,
             short: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(3), {
+          expectOrderEq(await market.pendingOrder(2), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
+            timestamp: ORACLE_VERSION_3.timestamp,
+            orders: 2,
+            longNeg: POSITION.div(2),
+            shortPos: POSITION.div(2),
+            collateral: COLLATERAL,
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_VERSION,
@@ -17493,7 +17449,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
           })
@@ -17502,16 +17458,19 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
+          expectOrderEq(await market.pendingOrders(user.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
           })
@@ -17520,16 +17479,19 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userC.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
               .sub(TAKER_FEE)
@@ -17541,9 +17503,13 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             short: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(userC.address, 2), {
+          expectOrderEq(await market.pendingOrders(userC.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            shortPos: POSITION.div(2),
+            takerReferral: POSITION.div(2).mul(2).div(10),
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -17558,7 +17524,7 @@ describe('Market', () => {
           })
           const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
           expectGlobalEq(await market.global(), {
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             protocolFee: totalFee.div(2), // loss of precision
             oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
@@ -17573,9 +17539,15 @@ describe('Market', () => {
             long: POSITION.div(2),
             short: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(2), {
+          expectOrderEq(await market.pendingOrder(1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 3,
+            makerPos: POSITION,
+            shortPos: POSITION.div(2),
+            longPos: POSITION.div(2),
+            takerReferral: POSITION.div(2).mul(2).div(10),
+            collateral: COLLATERAL.mul(3),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -17672,13 +17644,13 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 3,
+            currentId: 2,
             latestId: 2,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -18756,8 +18728,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123_V).sub(EXPECTED_INTEREST_5_123),
             })
             expectPositionEq(await market.positions(user.address), {
@@ -18765,17 +18737,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123_V)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(13), // loss of precision
@@ -18785,17 +18760,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             const totalFee = EXPECTED_FUNDING_FEE_1_5_123_V.add(EXPECTED_INTEREST_FEE_5_123)
             expectGlobalEq(await market.global(), {
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: totalFee.div(2),
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
@@ -18808,9 +18786,13 @@ describe('Market', () => {
               maker: POSITION,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL.mul(2),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -18884,8 +18866,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123_V).sub(EXPECTED_INTEREST_5_123).add(5), // excess fundingFee taken from long
             })
             expectPositionEq(await market.positions(user.address), {
@@ -18893,17 +18875,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123_V)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                 .sub(13), // loss of precision
@@ -18913,17 +18898,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             const totalFee = EXPECTED_FUNDING_FEE_1_5_123_V.add(EXPECTED_INTEREST_FEE_5_123)
             expectGlobalEq(await market.global(), {
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: totalFee.div(2),
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
@@ -18936,9 +18924,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL.mul(2),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -19310,7 +19302,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(MAKER_FEE).sub(SETTLEMENT_FEE),
           })
@@ -19319,9 +19311,13 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
+          expectOrderEq(await market.pendingOrders(user.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
+            makerReferral: POSITION.div(5),
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -19332,7 +19328,7 @@ describe('Market', () => {
           })
           const totalFee = MAKER_FEE.sub(MAKER_FEE.mul(2).div(10))
           expectGlobalEq(await market.global(), {
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             protocolFee: totalFee.div(2),
             oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE),
@@ -19345,9 +19341,13 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrder(2), {
+          expectOrderEq(await market.pendingOrder(1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
+            makerReferral: POSITION.div(5),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -19422,7 +19422,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
               .sub(EXPECTED_INTEREST_5_123)
@@ -19434,16 +19434,20 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
+          expectOrderEq(await market.pendingOrders(user.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL,
+            takerReferral: POSITION.div(10),
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -19455,9 +19459,12 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -19470,7 +19477,7 @@ describe('Market', () => {
             TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)),
           )
           expectGlobalEq(await market.global(), {
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             protocolFee: totalFee.div(2).sub(3), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
@@ -19484,9 +19491,14 @@ describe('Market', () => {
             maker: POSITION,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(2), {
+          expectOrderEq(await market.pendingOrder(1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 2,
+            makerPos: POSITION,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL.mul(2),
+            takerReferral: POSITION.div(10),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -19565,7 +19577,7 @@ describe('Market', () => {
 
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
               .sub(EXPECTED_INTEREST_5_123)
@@ -19578,16 +19590,20 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
+          expectOrderEq(await market.pendingOrders(user.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL,
+            takerReferral: POSITION.div(10),
           })
           expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
           })
           expectLocalEq(await market.locals(userB.address), {
             ...DEFAULT_LOCAL,
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
               .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -19599,9 +19615,12 @@ describe('Market', () => {
             timestamp: ORACLE_VERSION_3.timestamp,
             maker: POSITION,
           })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
+          expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 1,
+            makerPos: POSITION,
+            collateral: COLLATERAL,
           })
           expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
             ...DEFAULT_CHECKPOINT,
@@ -19610,7 +19629,7 @@ describe('Market', () => {
             TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)),
           )
           expectGlobalEq(await market.global(), {
-            currentId: 2,
+            currentId: 1,
             latestId: 1,
             protocolFee: totalFee.div(2).sub(3), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
@@ -19624,9 +19643,14 @@ describe('Market', () => {
             maker: POSITION,
             long: POSITION.div(2),
           })
-          expectOrderEq(await market.pendingOrder(2), {
+          expectOrderEq(await market.pendingOrder(1), {
             ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            orders: 2,
+            makerPos: POSITION,
+            longPos: POSITION.div(2),
+            collateral: COLLATERAL.mul(2),
+            takerReferral: POSITION.div(10),
           })
           expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
             ...DEFAULT_VERSION,
@@ -19636,385 +19660,6 @@ describe('Market', () => {
             longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
             price: PRICE,
             liquidationFee: { _value: -riskParameter.liquidationFee },
-          })
-        })
-      })
-
-      context('requestless settlement', async () => {
-        beforeEach(async () => {
-          dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
-
-          dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
-          await market
-            .connect(userB)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
-        })
-
-        it('opens the position and settles later', async () => {
-          await expect(
-            market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                0,
-                POSITION.div(2),
-                0,
-                COLLATERAL,
-                false,
-              ),
-          )
-            .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                collateral: COLLATERAL,
-              },
-              { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
-              constants.AddressZero,
-              constants.AddressZero,
-            )
-
-          oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
-          oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
-          oracle.request.whenCalledWith(user.address).returns()
-
-          await expect(settle(market, user)) // requestless update for id 3
-            .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-              },
-              { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
-              constants.AddressZero,
-              constants.AddressZero,
-            )
-
-          oracle.at
-            .whenCalledWith(ORACLE_VERSION_3.timestamp)
-            .returns({ ...ORACLE_VERSION_0, timestamp: ORACLE_VERSION_3.timestamp }) // id 3, empty version
-
-          oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4) // latest
-          oracle.status.returns([ORACLE_VERSION_4, ORACLE_VERSION_5.timestamp])
-          oracle.request.whenCalledWith(user.address).returns()
-
-          await settle(market, user)
-          await settle(market, userB)
-
-          expectLocalEq(await market.locals(user.address), {
-            ...DEFAULT_LOCAL,
-            currentId: 3,
-            latestId: 2,
-            collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
-              .sub(EXPECTED_INTEREST_5_123)
-              .sub(EXPECTED_FUNDING_WITH_FEE_2_5_123)
-              .sub(EXPECTED_INTEREST_5_123),
-          })
-          expectPositionEq(await market.positions(user.address), {
-            ...DEFAULT_POSITION,
-            timestamp: ORACLE_VERSION_4.timestamp,
-            long: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_3.timestamp,
-          })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-            collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-            collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
-              .sub(EXPECTED_INTEREST_5_123)
-              .sub(EXPECTED_FUNDING_WITH_FEE_2_5_123)
-              .sub(EXPECTED_INTEREST_5_123),
-          })
-          expectLocalEq(await market.locals(userB.address), {
-            ...DEFAULT_LOCAL,
-            currentId: 2,
-            latestId: 1,
-            collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .sub(21), // loss of precision
-          })
-          expectPositionEq(await market.positions(userB.address), {
-            ...DEFAULT_POSITION,
-            timestamp: ORACLE_VERSION_4.timestamp,
-            maker: POSITION,
-          })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-            collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .sub(21), // loss of precision
-          })
-          const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
-            .add(EXPECTED_FUNDING_FEE_2_5_123)
-            .add(EXPECTED_INTEREST_FEE_5_123)
-          expectGlobalEq(await market.global(), {
-            currentId: 3,
-            latestId: 2,
-            protocolFee: totalFee.div(2).sub(5), // loss of precision
-            oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
-            riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-            donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            exposure: 0,
-          })
-          expectPositionEq(await market.position(), {
-            ...DEFAULT_POSITION,
-            timestamp: ORACLE_VERSION_4.timestamp,
-            maker: POSITION,
-            long: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrder(2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_3.timestamp,
-          })
-          expectOrderEq(await market.pendingOrder(3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
-            ...DEFAULT_VERSION,
-            valid: false,
-            makerValue: {
-              _value: EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123).div(10),
-            },
-            longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
-            price: PRICE,
-          })
-          expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_VERSION,
-            makerValue: {
-              _value: EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-                .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_123)
-                .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-                .div(10)
-                .sub(2),
-            },
-            longValue: {
-              _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123)
-                .add(EXPECTED_FUNDING_WITH_FEE_2_5_123)
-                .add(EXPECTED_INTEREST_5_123)
-                .div(5)
-                .mul(-1),
-            },
-            liquidationFee: { _value: -riskParameter.liquidationFee },
-            price: PRICE,
-          })
-        })
-
-        it('sets requestless version price to latestPrice', async () => {
-          await expect(
-            market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                0,
-                POSITION.div(2),
-                0,
-                COLLATERAL,
-                false,
-              ),
-          )
-            .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_2.timestamp,
-                orders: 1,
-                longPos: POSITION.div(2),
-                collateral: COLLATERAL,
-              },
-              { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
-              constants.AddressZero,
-              constants.AddressZero,
-            )
-
-          oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
-          // Sync
-          oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
-
-          await expect(settle(market, user)) // requestless update for id 3
-            .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
-              },
-              { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
-              constants.AddressZero,
-              constants.AddressZero,
-            )
-
-          oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
-
-          oracle.at
-            .whenCalledWith(ORACLE_VERSION_3.timestamp)
-            .returns({ ...ORACLE_VERSION_0, timestamp: ORACLE_VERSION_3.timestamp }) // id 3, empty version
-
-          await expect(
-            market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false),
-          )
-            .to.emit(market, 'OrderCreated')
-            .withArgs(
-              user.address,
-              {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
-              },
-              { ...DEFAULT_GUARANTEE },
-              constants.AddressZero,
-              constants.AddressZero,
-              constants.AddressZero,
-            )
-
-          oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns(ORACLE_VERSION_4) // latest
-          oracle.status.returns([ORACLE_VERSION_4, ORACLE_VERSION_5.timestamp])
-          oracle.request.whenCalledWith(user.address).returns()
-
-          await settle(market, user)
-          await settle(market, userB)
-
-          expectLocalEq(await market.locals(user.address), {
-            ...DEFAULT_LOCAL,
-            currentId: 4,
-            latestId: 3,
-            collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
-              .sub(EXPECTED_INTEREST_5_123)
-              .sub(EXPECTED_FUNDING_WITH_FEE_2_5_123)
-              .sub(EXPECTED_INTEREST_5_123),
-          })
-          expectPositionEq(await market.positions(user.address), {
-            ...DEFAULT_POSITION,
-            timestamp: ORACLE_VERSION_4.timestamp,
-            long: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrders(user.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_3.timestamp,
-          })
-          expectOrderEq(await market.pendingOrders(user.address, 3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-            collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
-          })
-          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-            collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
-              .sub(EXPECTED_INTEREST_5_123)
-              .sub(EXPECTED_FUNDING_WITH_FEE_2_5_123)
-              .sub(EXPECTED_INTEREST_5_123),
-          })
-          expectLocalEq(await market.locals(userB.address), {
-            ...DEFAULT_LOCAL,
-            currentId: 2,
-            latestId: 1,
-            collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .sub(21), // loss of precision
-          })
-          expectPositionEq(await market.positions(userB.address), {
-            ...DEFAULT_POSITION,
-            timestamp: ORACLE_VERSION_4.timestamp,
-            maker: POSITION,
-          })
-          expectOrderEq(await market.pendingOrders(userB.address, 2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_5.timestamp,
-          })
-          expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_CHECKPOINT,
-            collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_123)
-              .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-              .sub(21), // loss of precision
-          })
-          const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
-            .add(EXPECTED_FUNDING_FEE_2_5_123)
-            .add(EXPECTED_INTEREST_FEE_5_123)
-          expectGlobalEq(await market.global(), {
-            currentId: 4,
-            latestId: 3,
-            protocolFee: totalFee.div(2).sub(5), // loss of precision
-            oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
-            riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-            donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
-            exposure: 0,
-          })
-          expectPositionEq(await market.position(), {
-            ...DEFAULT_POSITION,
-            timestamp: ORACLE_VERSION_4.timestamp,
-            maker: POSITION,
-            long: POSITION.div(2),
-          })
-          expectOrderEq(await market.pendingOrder(2), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_3.timestamp,
-          })
-          expectOrderEq(await market.pendingOrder(3), {
-            ...DEFAULT_ORDER,
-            timestamp: ORACLE_VERSION_4.timestamp,
-          })
-          expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
-            ...DEFAULT_VERSION,
-            valid: false,
-            makerValue: {
-              _value: EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123).div(10),
-            },
-            longValue: { _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123).div(5).mul(-1) },
-            price: PRICE,
-          })
-          expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
-            ...DEFAULT_VERSION,
-            makerValue: {
-              _value: EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-                .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_123)
-                .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
-                .div(10)
-                .sub(2),
-            },
-            longValue: {
-              _value: EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123)
-                .add(EXPECTED_FUNDING_WITH_FEE_2_5_123)
-                .add(EXPECTED_INTEREST_5_123)
-                .div(5)
-                .mul(-1),
-            },
-            liquidationFee: { _value: -riskParameter.liquidationFee },
-            price: PRICE,
           })
         })
       })
@@ -20151,7 +19796,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
             })
@@ -20160,16 +19805,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 2), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
             })
@@ -20178,16 +19826,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
                 .sub(TAKER_FEE)
@@ -20199,9 +19850,13 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 2), {
+            expectOrderEq(await market.pendingOrders(userC.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -20216,7 +19871,7 @@ describe('Market', () => {
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
@@ -20231,9 +19886,15 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(2), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -20372,7 +20033,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL),
             })
@@ -20381,16 +20042,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 2), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
             })
@@ -20399,16 +20063,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
                 .sub(TAKER_FEE)
@@ -20420,9 +20087,13 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 2), {
+            expectOrderEq(await market.pendingOrders(userC.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -20437,7 +20108,7 @@ describe('Market', () => {
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
@@ -20452,9 +20123,15 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(2), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -20593,7 +20270,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL),
             })
@@ -20602,16 +20279,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 2), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
             })
@@ -20620,16 +20300,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
                 .sub(TAKER_FEE)
@@ -20641,9 +20324,13 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 2), {
+            expectOrderEq(await market.pendingOrders(userC.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -20658,7 +20345,7 @@ describe('Market', () => {
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
@@ -20673,9 +20360,15 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(2), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -20773,7 +20466,6 @@ describe('Market', () => {
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(121),
                   takerFee: POSITION.div(2),
-                  referral: 0,
                 },
                 constants.AddressZero,
                 constants.AddressZero,
@@ -20814,7 +20506,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
             })
@@ -20823,16 +20515,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 2), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
             })
@@ -20841,16 +20536,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
                 .sub(TAKER_FEE)
@@ -20862,9 +20560,13 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 2), {
+            expectOrderEq(await market.pendingOrders(userC.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -20879,7 +20581,7 @@ describe('Market', () => {
             })
             const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
             expectGlobalEq(await market.global(), {
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
@@ -20894,9 +20596,15 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(2), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -21048,7 +20756,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(2)) // open
@@ -21060,16 +20768,18 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              longNeg: POSITION.div(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(2)) // open
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -21081,16 +20791,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE).sub(SETTLEMENT_FEE).sub(EXPECTED_PNL), // open
             })
@@ -21099,9 +20812,12 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 3), {
+            expectOrderEq(await market.pendingOrders(userC.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21118,7 +20834,7 @@ describe('Market', () => {
               .add(TAKER_FEE) // setup
               .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
@@ -21132,9 +20848,13 @@ describe('Market', () => {
               maker: POSITION,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 2,
+              longNeg: POSITION.div(2),
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -21285,7 +21005,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(2)) // open
@@ -21297,16 +21017,18 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              shortNeg: POSITION.div(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(2)) // open
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -21318,16 +21040,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE).sub(SETTLEMENT_FEE).add(EXPECTED_PNL), // open
             })
@@ -21336,9 +21061,12 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 3), {
+            expectOrderEq(await market.pendingOrders(userC.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21355,7 +21083,7 @@ describe('Market', () => {
               .add(TAKER_FEE) // setup
               .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
@@ -21369,9 +21097,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 2,
+              shortNeg: POSITION.div(2),
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -21522,7 +21254,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.add(EXPECTED_PNL), // open
             })
@@ -21531,16 +21263,18 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(2)) // open
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -21552,16 +21286,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(2)) // open
@@ -21575,9 +21312,12 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 3), {
+            expectOrderEq(await market.pendingOrders(userC.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21594,7 +21334,7 @@ describe('Market', () => {
               .add(TAKER_FEE) // setup
               .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
@@ -21608,9 +21348,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 2,
+              shortPos: POSITION.div(2),
+              shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -21761,7 +21505,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(EXPECTED_PNL), // open
             })
@@ -21770,16 +21514,18 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(2)) // open
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -21791,16 +21537,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(2)) // open
@@ -21814,9 +21563,12 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 3), {
+            expectOrderEq(await market.pendingOrders(userC.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              longNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21833,7 +21585,7 @@ describe('Market', () => {
               .add(TAKER_FEE) // setup
               .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
@@ -21847,9 +21599,13 @@ describe('Market', () => {
               maker: POSITION,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 2,
+              longPos: POSITION.div(2),
+              longNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -22006,7 +21762,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(3).add(1)) // open
@@ -22017,16 +21773,18 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              longNeg: POSITION.div(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(3).add(1)) // open
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF) // while open
@@ -22037,16 +21795,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(3).add(1))
                 .sub(TAKER_FEE) // open
@@ -22059,9 +21820,12 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 3), {
+            expectOrderEq(await market.pendingOrders(userC.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22078,7 +21842,7 @@ describe('Market', () => {
               .add(EXPECTED_INTEREST_FEE_10_123_EFF) // while open
               .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE.mul(2)), // loss of precision
@@ -22091,9 +21855,13 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 2,
+              longNeg: POSITION.div(2),
+              shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -22251,7 +22019,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(3).add(1)) // open
@@ -22262,16 +22030,18 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              shortNeg: POSITION.div(2),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(3).add(1)) // open
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF) // while open
@@ -22282,16 +22052,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userC.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(3).add(1))
                 .sub(TAKER_FEE) // open
@@ -22304,9 +22077,12 @@ describe('Market', () => {
               ...DEFAULT_POSITION,
               timestamp: ORACLE_VERSION_3.timestamp,
             })
-            expectOrderEq(await market.pendingOrders(userC.address, 3), {
+            expectOrderEq(await market.pendingOrders(userC.address, 2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              longNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22323,7 +22099,7 @@ describe('Market', () => {
               .add(EXPECTED_INTEREST_FEE_10_123_EFF) // while open
               .add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10))) // fill
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE.mul(2)), // loss of precision
@@ -22336,9 +22112,13 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 2,
+              longNeg: POSITION.div(2),
+              shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -10032,7 +10032,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL,
               })
@@ -10041,16 +10041,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 long: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
               })
               expectPositionEq(await market.position(), {
@@ -10060,9 +10063,14 @@ describe('Market', () => {
                 long: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 3,
+                makerPos: POSITION,
+                longPos: POSITION,
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(3),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
                 ...DEFAULT_VERSION,
@@ -10172,7 +10180,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL,
               })
@@ -10181,16 +10189,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 long: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 2,
+                longPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
               })
               expectPositionEq(await market.position(), {
@@ -10200,9 +10211,14 @@ describe('Market', () => {
                 long: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 4,
+                makerPos: POSITION,
+                longPos: POSITION,
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(3),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
                 ...DEFAULT_VERSION,
@@ -10327,7 +10343,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
+                currentId: 2,
                 latestId: 2,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
@@ -10338,16 +10354,18 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 3), {
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -10358,16 +10376,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
+                currentId: 2,
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
@@ -10382,9 +10403,11 @@ describe('Market', () => {
                 long: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -10451,7 +10474,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
@@ -10462,16 +10485,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -10482,16 +10508,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
@@ -10506,9 +10535,14 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 3,
+                makerPos: POSITION,
+                longPos: POSITION.div(2),
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(3),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -10602,7 +10636,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
@@ -10616,16 +10650,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -10637,9 +10674,12 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -10650,7 +10690,7 @@ describe('Market', () => {
                 .add(TAKER_OFFSET_MAKER)
                 .add(TAKER_OFFSET_MAKER_C)
               expectGlobalEq(await market.global(), {
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
@@ -10665,9 +10705,14 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 3,
+                makerPos: POSITION,
+                longPos: POSITION.div(2),
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(3),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -10734,7 +10779,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
@@ -10745,16 +10790,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -10765,16 +10813,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
@@ -10789,9 +10840,14 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 3,
+                makerPos: POSITION,
+                longPos: POSITION.div(2),
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(3),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -10987,7 +11043,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
@@ -10998,16 +11054,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -11018,16 +11077,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
@@ -11042,138 +11104,14 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
-              })
-              expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
-                ...DEFAULT_VERSION,
-                makerValue: {
-                  _value: EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)
-                    .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
-                    .div(10)
-                    .sub(1), // loss of precision
-                },
-                longValue: {
-                  _value: EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)
-                    .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
-                    .div(5)
-                    .sub(1), // loss of precision
-                },
-                shortValue: {
-                  _value: EXPECTED_FUNDING_WITH_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_10_67_123_ALL.mul(2).div(3))
-                    .div(10)
-                    .mul(-1)
-                    .sub(1), // loss of precision
-                },
-                price: PRICE,
-                liquidationFee: { _value: -riskParameter.liquidationFee },
-              })
-            })
-
-            it('opens the position and deposits later from different account while stale', async () => {
-              await expect(
-                market
-                  .connect(user)
-                  ['update(address,uint256,uint256,uint256,int256,bool)'](
-                    user.address,
-                    0,
-                    POSITION.div(2),
-                    0,
-                    COLLATERAL,
-                    false,
-                  ),
-              )
-                .to.emit(market, 'OrderCreated')
-                .withArgs(
-                  user.address,
-                  {
-                    ...DEFAULT_ORDER,
-                    timestamp: ORACLE_VERSION_2.timestamp,
-                    orders: 1,
-                    longPos: POSITION.div(2),
-                    collateral: COLLATERAL,
-                  },
-                  { ...DEFAULT_GUARANTEE },
-                  constants.AddressZero,
-                  constants.AddressZero,
-                  constants.AddressZero,
-                )
-
-              oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns(ORACLE_VERSION_2)
-
-              oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns(ORACLE_VERSION_3)
-              oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_6.timestamp])
-              oracle.request.returns()
-
-              await deposit(market, COLLATERAL, user, userB)
-              await deposit(market, COLLATERAL, userB, user)
-
-              expectLocalEq(await market.locals(user.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 2,
-                latestId: 1,
-                collateral: COLLATERAL.add(COLLATERAL)
-                  .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
-                  .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
-                  .sub(2), // loss of precision
-              })
-              expectPositionEq(await market.positions(user.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                long: POSITION.div(2),
-              })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
-                collateral: COLLATERAL,
-              })
-              expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
-                ...DEFAULT_CHECKPOINT,
-              })
-              expectLocalEq(await market.locals(userB.address), {
-                ...DEFAULT_LOCAL,
-                currentId: 2,
-                latestId: 1,
-                collateral: COLLATERAL.add(COLLATERAL)
-                  .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
-                  .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
-                  .sub(13), // loss of precision
-              })
-              expectPositionEq(await market.positions(userB.address), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                maker: POSITION,
-              })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
-                collateral: COLLATERAL,
-              })
-              expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
-                ...DEFAULT_CHECKPOINT,
-              })
-              const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
-              expectGlobalEq(await market.global(), {
-                currentId: 2,
-                latestId: 1,
-                protocolFee: totalFee.div(2).sub(3), // loss of precision
-                oracleFee: totalFee.div(2).div(10),
-                riskFee: totalFee.div(2).div(10),
-                donation: totalFee.div(2).mul(8).div(10),
-                exposure: 0,
-              })
-              expectPositionEq(await market.position(), {
-                ...DEFAULT_POSITION,
-                timestamp: ORACLE_VERSION_3.timestamp,
-                maker: POSITION,
-                long: POSITION.div(2),
-                short: POSITION,
-              })
-              expectOrderEq(await market.pendingOrder(2), {
-                ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
-                collateral: COLLATERAL.mul(2),
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 3,
+                makerPos: POSITION,
+                longPos: POSITION.div(2),
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(3),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -11334,7 +11272,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -11344,16 +11282,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_3.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -11364,16 +11304,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
                 expectGlobalEq(await market.global(), {
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   protocolFee: totalFee.div(2).sub(3), // loss of precision
                   oracleFee: totalFee.div(2).div(10),
@@ -11387,9 +11330,11 @@ describe('Market', () => {
                   maker: POSITION,
                   short: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -11510,7 +11455,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -11520,16 +11465,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_3.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 2,
+                  longNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -11540,16 +11487,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
                 expectGlobalEq(await market.global(), {
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   protocolFee: totalFee.div(2).sub(3), // loss of precision
                   oracleFee: totalFee.div(2).div(10),
@@ -11563,9 +11513,11 @@ describe('Market', () => {
                   maker: POSITION,
                   short: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 2,
+                  longNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -11643,7 +11595,7 @@ describe('Market', () => {
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -11654,9 +11606,12 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -11742,7 +11697,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 4,
+                  currentId: 3,
                   latestId: 3,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_FUNDING_WITHOUT_FEE_2_10_123_ALL.div(4))
@@ -11754,16 +11709,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_4.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 4), {
+                expectOrderEq(await market.pendingOrders(user.address, 3), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_4.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(4),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .add(EXPECTED_FUNDING_WITHOUT_FEE_2_10_123_ALL.mul(3).div(4))
@@ -11776,9 +11733,12 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -11787,7 +11747,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
                   .add(EXPECTED_INTEREST_FEE_10_80_123_ALL)
                 expectGlobalEq(await market.global(), {
-                  currentId: 4,
+                  currentId: 3,
                   latestId: 3,
                   protocolFee: totalFee.div(2).sub(2), // loss of precision
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -11801,9 +11761,11 @@ describe('Market', () => {
                   maker: POSITION,
                   short: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(4), {
+                expectOrderEq(await market.pendingOrder(3), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_4.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(4),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -11893,7 +11855,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -11903,9 +11865,11 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_4.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -11916,9 +11880,11 @@ describe('Market', () => {
                   maker: POSITION,
                   short: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -11995,7 +11961,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                     .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -12008,9 +11974,11 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_4.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -12021,9 +11989,11 @@ describe('Market', () => {
                   maker: POSITION,
                   short: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  longNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -12102,7 +12072,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL,
             })
@@ -12111,16 +12081,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 2), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_3.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL,
             })
@@ -12129,16 +12102,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_3.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
             })
             expectPositionEq(await market.position(), {
@@ -12148,9 +12124,14 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION,
             })
-            expectOrderEq(await market.pendingOrder(2), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_3.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION,
+              collateral: COLLATERAL.mul(3),
             })
           })
 
@@ -12171,7 +12152,7 @@ describe('Market', () => {
             await expect(settle(market, user))
               .to.emit(market, 'PositionProcessed')
               .withArgs(
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionLowerPrice.timestamp },
                 {
                   ...DEFAULT_VERSION_ACCUMULATION_RESULT,
@@ -12191,7 +12172,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 user.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionLowerPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -12207,7 +12188,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 userB.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionLowerPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -12221,8 +12202,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_PNL.div(2))
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -12233,17 +12214,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_PNL.div(2))
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -12254,17 +12238,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
             expectGlobalEq(await market.global(), {
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
@@ -12278,9 +12265,14 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION,
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION,
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -12325,7 +12317,7 @@ describe('Market', () => {
             await expect(settle(market, user))
               .to.emit(market, 'PositionProcessed')
               .withArgs(
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionHigherPrice.timestamp },
                 {
                   ...DEFAULT_VERSION_ACCUMULATION_RESULT,
@@ -12345,7 +12337,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 user.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionHigherPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -12361,7 +12353,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 userB.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionHigherPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -12375,8 +12367,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_PNL.div(2))
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -12387,17 +12379,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_PNL.div(2))
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -12408,17 +12403,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
             expectGlobalEq(await market.global(), {
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10),
               riskFee: totalFee.div(2).div(10),
@@ -12432,9 +12430,14 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION,
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION,
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -12576,8 +12579,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_PNL)
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -12591,17 +12594,20 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 5), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('450')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -12610,14 +12616,17 @@ describe('Market', () => {
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(25), // loss of precision
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_5.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 5), {
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -12627,8 +12636,8 @@ describe('Market', () => {
                 .add(EXPECTED_INTEREST_FEE_10_67_45_ALL)
                 .add(EXPECTED_FUNDING_FEE_3_10_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(7), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -12641,9 +12650,11 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(5), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -12820,8 +12831,8 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 4,
-                latestId: 3,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('450')
                   .sub(EXPECTED_FUNDING_WITH_FEE_1.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
@@ -12841,8 +12852,8 @@ describe('Market', () => {
               const EXPOSURE_BEFORE = BigNumber.from(0)
               const EXPOSURE_AFTER = BigNumber.from(0).sub(parse6decimal('0.9225'))
               expectGlobalEq(await market.global(), {
-                currentId: 4,
-                latestId: 3,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(1), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -12969,8 +12980,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_1.div(3))
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_10_45_ALL.div(2))
@@ -12985,17 +12996,20 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 5), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('450')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.mul(5).div(12))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_1.mul(10).div(12))
@@ -13004,14 +13018,17 @@ describe('Market', () => {
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(19), // loss of precision
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_5.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 5), {
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -13022,8 +13039,8 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_FEE_3)
                 .add(EXPECTED_INTEREST_FEE_3)
               expectGlobalEq(await market.global(), {
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(10), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
@@ -13037,9 +13054,11 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(5), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -13185,8 +13204,8 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(EXPECTED_PNL)
@@ -13197,30 +13216,33 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 3), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                longPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 collateral: parse6decimal('450')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(EXPECTED_PNL)
                   .sub(13), // loss of precision
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 3), {
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -13232,8 +13254,8 @@ describe('Market', () => {
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
@@ -13247,7 +13269,7 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -13330,16 +13352,16 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 4,
-                latestId: 3,
+                currentId: 3,
+                latestId: 2,
                 collateral: 0,
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_4.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 4), {
+              expectOrderEq(await market.pendingOrders(userB.address, 3), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_5.timestamp,
                 collateral: shortfall.mul(-1),
@@ -13474,8 +13496,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('216')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
@@ -13484,22 +13506,25 @@ describe('Market', () => {
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(9), // loss of precision
               })
-              expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_5.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 5), {
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                longNeg: POSITION.div(2),
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_10_96_ALL.div(2))
@@ -13514,9 +13539,12 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 5), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -13527,8 +13555,8 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_FEE_3)
                 .add(EXPECTED_INTEREST_FEE_3)
               expectGlobalEq(await market.global(), {
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(5), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -13541,9 +13569,11 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(5), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                longNeg: POSITION.div(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -13701,21 +13731,21 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 collateral: parse6decimal('216')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
                   .sub(EXPECTED_PNL)
                   .sub(2), // loss of precision
               })
-              expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_3.timestamp,
                 long: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 3), {
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -13727,8 +13757,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
                   .sub(EXPECTED_PNL)
@@ -13739,17 +13769,20 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 3), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
                 riskFee: totalFee.div(2).div(10),
@@ -13763,7 +13796,7 @@ describe('Market', () => {
                 long: POSITION.div(2),
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -13846,16 +13879,16 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 4,
-                latestId: 3,
+                currentId: 3,
+                latestId: 2,
                 collateral: 0,
               })
-              expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_4.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 4), {
+              expectOrderEq(await market.pendingOrders(user.address, 3), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_5.timestamp,
                 collateral: shortfall.mul(-1),
@@ -13922,8 +13955,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL,
             })
             expectPositionEq(await market.positions(user.address), {
@@ -13931,17 +13964,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_4.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_5.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL,
             })
             expectPositionEq(await market.positions(userB.address), {
@@ -13949,17 +13985,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_4.timestamp,
               long: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_5.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: 0,
               oracleFee: 0,
               riskFee: 0,
@@ -13973,14 +14012,14 @@ describe('Market', () => {
               long: POSITION.div(2),
               short: POSITION,
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_5.timestamp,
-            })
-            expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
-              ...DEFAULT_VERSION,
-              price: oracleVersionHigherPrice_0.price,
-              liquidationFee: { _value: -riskParameter.liquidationFee },
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              longPos: POSITION.div(2),
+              shortPos: POSITION,
+              collateral: COLLATERAL.mul(3),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_VERSION,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -6468,7 +6468,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL,
               })
@@ -6477,16 +6477,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
               })
               expectPositionEq(await market.position(), {
@@ -6495,9 +6498,13 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 2,
+                makerPos: POSITION,
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
                 ...DEFAULT_VERSION,
@@ -6606,7 +6613,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL,
               })
@@ -6615,16 +6622,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_2.timestamp,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 2,
+                shortPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
               })
               expectPositionEq(await market.position(), {
@@ -6633,9 +6643,13 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_3.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 3,
+                makerPos: POSITION,
+                shortPos: POSITION,
+                collateral: COLLATERAL.mul(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
                 ...DEFAULT_VERSION,
@@ -6759,7 +6773,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
+                currentId: 2,
                 latestId: 2,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
               })
@@ -6768,16 +6782,18 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 3), {
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -6788,16 +6804,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
+                currentId: 2,
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -6811,9 +6830,11 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -6871,7 +6892,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
               })
@@ -6880,16 +6901,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_5.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -6900,16 +6924,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_5.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
               expectGlobalEq(await market.global(), {
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -6923,9 +6950,13 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_5.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 2,
+                makerPos: POSITION,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL.mul(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -6998,7 +7029,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
@@ -7010,16 +7041,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -7031,16 +7065,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123).add(TAKER_FEE_ONLY)
               expectGlobalEq(await market.global(), {
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
@@ -7054,9 +7091,13 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(2), {
+              expectOrderEq(await market.pendingOrder(1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 2,
+                makerPos: POSITION,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL.mul(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -7137,7 +7178,7 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
@@ -7150,16 +7191,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 2), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_5.timestamp,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 2,
+                currentId: 1,
                 latestId: 1,
                 collateral: COLLATERAL.add(
                   TAKER_OFFSET_MAKER.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)),
@@ -7170,16 +7214,19 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_4.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_5.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123).add(TAKER_FEE)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
+                currentId: 2,
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
@@ -7193,9 +7240,12 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_5.timestamp,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_VERSION,
@@ -7331,7 +7381,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
                 })
@@ -7339,16 +7389,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_3.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -7359,16 +7411,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
                 expectGlobalEq(await market.global(), {
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   protocolFee: totalFee.div(2).sub(3), // loss of precision
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -7381,9 +7436,11 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -7492,7 +7549,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
                 })
@@ -7500,16 +7557,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_3.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 2,
+                  shortNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -7520,16 +7579,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
                 expectGlobalEq(await market.global(), {
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   protocolFee: totalFee.div(2).sub(3), // loss of precision
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -7542,9 +7604,11 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 2,
+                  shortNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -7608,7 +7672,7 @@ describe('Market', () => {
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -7619,9 +7683,12 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_4.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -7701,7 +7768,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 4,
+                  currentId: 3,
                   latestId: 3,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                     .sub(EXPECTED_FUNDING_WITH_FEE_2_25_123)
@@ -7712,16 +7779,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_4.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 4), {
+                expectOrderEq(await market.pendingOrders(user.address, 3), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_4.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(4),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_FUNDING_WITHOUT_FEE_2_25_123)
@@ -7734,9 +7803,12 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -7745,7 +7817,7 @@ describe('Market', () => {
                   .add(EXPECTED_INTEREST_FEE_5_123)
                   .add(EXPECTED_INTEREST_FEE_25_123)
                 expectGlobalEq(await market.global(), {
-                  currentId: 4,
+                  currentId: 3,
                   latestId: 3,
                   protocolFee: totalFee.div(2).sub(1), // loss of precision
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -7758,9 +7830,11 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(4), {
+                expectOrderEq(await market.pendingOrder(3), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_4.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(4),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                   ...DEFAULT_VERSION,
@@ -7822,7 +7896,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123).sub(EXPECTED_INTEREST_5_123),
                 })
@@ -7830,16 +7904,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_4.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -7850,16 +7926,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
                 expectGlobalEq(await market.global(), {
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   protocolFee: totalFee.div(2).sub(3), // loss of precision
                   oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -7872,9 +7951,11 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_VERSION,
@@ -7936,7 +8017,7 @@ describe('Market', () => {
 
                 expectLocalEq(await market.locals(user.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                     .sub(EXPECTED_INTEREST_5_123)
@@ -7948,16 +8029,18 @@ describe('Market', () => {
                   ...DEFAULT_POSITION,
                   timestamp: ORACLE_VERSION_4.timestamp,
                 })
-                expectOrderEq(await market.pendingOrders(user.address, 3), {
+                expectOrderEq(await market.pendingOrders(user.address, 2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
                 })
                 expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
                 })
                 expectLocalEq(await market.locals(userB.address), {
                   ...DEFAULT_LOCAL,
-                  currentId: 2,
+                  currentId: 1,
                   latestId: 1,
                   collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                     .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -7969,9 +8052,12 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                expectOrderEq(await market.pendingOrders(userB.address, 1), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  makerPos: POSITION,
+                  collateral: COLLATERAL,
                 })
                 expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
                   ...DEFAULT_CHECKPOINT,
@@ -7983,7 +8069,7 @@ describe('Market', () => {
                 const EXPOSURE_BEFORE = BigNumber.from(0).sub(parse6decimal('2.46'))
                 const EXPOSURE_AFTER = BigNumber.from(0)
                 expectGlobalEq(await market.global(), {
-                  currentId: 3,
+                  currentId: 2,
                   latestId: 2,
                   protocolFee: totalFee.div(2).sub(3), // loss of precision
                   oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
@@ -7996,9 +8082,11 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_4.timestamp,
                   maker: POSITION,
                 })
-                expectOrderEq(await market.pendingOrder(3), {
+                expectOrderEq(await market.pendingOrder(2), {
                   ...DEFAULT_ORDER,
-                  timestamp: ORACLE_VERSION_5.timestamp,
+                  timestamp: ORACLE_VERSION_3.timestamp,
+                  orders: 1,
+                  shortNeg: POSITION.div(2),
                 })
                 expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
                   ...DEFAULT_VERSION,
@@ -8060,7 +8148,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL,
             })
@@ -8069,16 +8157,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 2), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_3.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
               collateral: COLLATERAL,
             })
@@ -8087,16 +8178,19 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 2), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_3.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
-              currentId: 2,
+              currentId: 1,
               latestId: 1,
             })
             expectPositionEq(await market.position(), {
@@ -8105,9 +8199,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(2), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_3.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL.mul(2),
             })
           })
 
@@ -8129,7 +8227,7 @@ describe('Market', () => {
             await expect(settle(market, user))
               .to.emit(market, 'PositionProcessed')
               .withArgs(
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionLowerPrice.timestamp },
                 {
                   ...DEFAULT_VERSION_ACCUMULATION_RESULT,
@@ -8148,7 +8246,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 user.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionLowerPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -8160,7 +8258,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 userB.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionLowerPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -8172,8 +8270,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                 .sub(EXPECTED_INTEREST_5_123),
@@ -8183,17 +8281,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_PNL)
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -8204,17 +8305,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
             expectGlobalEq(await market.global(), {
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -8227,9 +8331,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL.mul(2),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -8264,7 +8372,7 @@ describe('Market', () => {
             await expect(settle(market, user))
               .to.emit(market, 'PositionProcessed')
               .withArgs(
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionHigherPrice.timestamp },
                 {
                   ...DEFAULT_VERSION_ACCUMULATION_RESULT,
@@ -8283,7 +8391,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 user.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionHigherPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -8295,7 +8403,7 @@ describe('Market', () => {
               .to.emit(market, 'AccountPositionProcessed')
               .withArgs(
                 userB.address,
-                2,
+                1,
                 { ...DEFAULT_ORDER, timestamp: oracleVersionHigherPrice.timestamp },
                 {
                   ...DEFAULT_LOCAL_ACCUMULATION_RESULT,
@@ -8307,8 +8415,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_PNL)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                 .sub(EXPECTED_INTEREST_5_123),
@@ -8318,17 +8426,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL.add(EXPECTED_PNL)
                 .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                 .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
@@ -8339,17 +8450,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
             expectGlobalEq(await market.global(), {
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -8362,9 +8476,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL.mul(2),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,
@@ -8486,8 +8604,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123)).sub(
                   EXPECTED_FUNDING_WITH_FEE_2_5_96.add(EXPECTED_INTEREST_5_96),
                 ),
@@ -8497,31 +8615,37 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 5), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('390')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_5_96))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(20), // loss of precision
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_5.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 5), {
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -8530,8 +8654,8 @@ describe('Market', () => {
                 EXPECTED_FUNDING_FEE_2_5_96.add(EXPECTED_INTEREST_FEE_5_96),
               )
               expectGlobalEq(await market.global(), {
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(4), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -8543,9 +8667,11 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(5), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -8705,8 +8831,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_1)
                   .sub(EXPECTED_FUNDING_WITH_FEE_2_5_96)
@@ -8720,39 +8846,45 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 5), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('390')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_1).mul(4).div(5))
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_96.add(EXPECTED_INTEREST_WITHOUT_FEE_2).mul(4).div(5))
                   .sub(EXPECTED_LIQUIDATION_FEE)
                   .sub(17), // loss of precision
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_5.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 5), {
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userC.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(
                   EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_1).div(5),
                 )
@@ -8766,9 +8898,12 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 maker: POSITION.div(4),
               })
-              expectOrderEq(await market.pendingOrders(userC.address, 5), {
+              expectOrderEq(await market.pendingOrders(userC.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION.div(4),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -8777,8 +8912,8 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_FEE_2_5_96.add(EXPECTED_INTEREST_FEE_2))
                 .add(EXPECTED_FUNDING_FEE_3_25_123.add(EXPECTED_INTEREST_FEE_3))
               expectGlobalEq(await market.global(), {
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(5), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
@@ -8791,9 +8926,11 @@ describe('Market', () => {
                 maker: POSITION.div(4),
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(5), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                makerNeg: POSITION,
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -8905,8 +9042,8 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.sub(EXPECTED_FUNDING_WITH_FEE_1_5_123.add(EXPECTED_INTEREST_5_123)).add(
                   EXPECTED_PNL,
                 ),
@@ -8916,24 +9053,27 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 3), {
+              expectOrderEq(await market.pendingOrders(user.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                shortPos: POSITION.div(2),
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 collateral: parse6decimal('390')
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123.add(EXPECTED_INTEREST_WITHOUT_FEE_5_123))
                   .sub(EXPECTED_PNL)
                   .sub(8), // loss of precision
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
-              expectOrderEq(await market.pendingOrders(userB.address, 3), {
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -8945,8 +9085,8 @@ describe('Market', () => {
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -8959,7 +9099,7 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -9033,16 +9173,16 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 4,
-                latestId: 3,
+                currentId: 3,
+                latestId: 2,
                 collateral: 0,
               })
-              expect(await market.liquidators(userB.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(userB.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(userB.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_4.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 4), {
+              expectOrderEq(await market.pendingOrders(userB.address, 3), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_5.timestamp,
                 collateral: shortfall.mul(-1),
@@ -9151,8 +9291,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 collateral: parse6decimal('216')
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
@@ -9160,22 +9300,25 @@ describe('Market', () => {
                   .sub(EXPECTED_INTEREST_5_150)
                   .sub(EXPECTED_LIQUIDATION_FEE),
               })
-              expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_5.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 5), {
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                shortNeg: POSITION.div(2),
+                protection: 1,
               })
               expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 5,
-                latestId: 4,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .add(EXPECTED_FUNDING_WITHOUT_FEE_2_5_150)
@@ -9187,9 +9330,12 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 5), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
                 ...DEFAULT_CHECKPOINT,
@@ -9198,8 +9344,8 @@ describe('Market', () => {
                 .add(EXPECTED_FUNDING_FEE_2_5_150)
                 .add(EXPECTED_INTEREST_FEE_5_150)
               expectGlobalEq(await market.global(), {
-                currentId: 5,
-                latestId: 4,
+                currentId: 2,
+                latestId: 2,
                 protocolFee: totalFee.div(2).sub(1), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -9211,9 +9357,11 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_5.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrder(5), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_6.timestamp,
+                timestamp: ORACLE_VERSION_4.timestamp,
+                orders: 1,
+                shortNeg: POSITION.div(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,
@@ -9325,20 +9473,20 @@ describe('Market', () => {
 
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 collateral: parse6decimal('216')
                   .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123)
                   .sub(EXPECTED_INTEREST_5_123)
                   .sub(EXPECTED_PNL),
               })
-              expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_3.timestamp,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrders(user.address, 3), {
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -9350,8 +9498,8 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(userB.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 3,
-                latestId: 2,
+                currentId: 1,
+                latestId: 1,
                 collateral: COLLATERAL.add(EXPECTED_FUNDING_WITHOUT_FEE_1_5_123)
                   .add(EXPECTED_INTEREST_WITHOUT_FEE_5_123)
                   .add(EXPECTED_PNL)
@@ -9362,17 +9510,20 @@ describe('Market', () => {
                 timestamp: ORACLE_VERSION_3.timestamp,
                 maker: POSITION,
               })
-              expectOrderEq(await market.pendingOrders(userB.address, 3), {
+              expectOrderEq(await market.pendingOrders(userB.address, 1), {
                 ...DEFAULT_ORDER,
-                timestamp: ORACLE_VERSION_4.timestamp,
+                timestamp: ORACLE_VERSION_2.timestamp,
+                orders: 1,
+                makerPos: POSITION,
+                collateral: COLLATERAL,
               })
               expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
                 ...DEFAULT_CHECKPOINT,
               })
               const totalFee = EXPECTED_FUNDING_FEE_1_5_123.add(EXPECTED_INTEREST_FEE_5_123)
               expectGlobalEq(await market.global(), {
-                currentId: 3,
-                latestId: 2,
+                currentId: 2,
+                latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
@@ -9385,7 +9536,7 @@ describe('Market', () => {
                 maker: POSITION,
                 short: POSITION.div(2),
               })
-              expectOrderEq(await market.pendingOrder(3), {
+              expectOrderEq(await market.pendingOrder(2), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_4.timestamp,
                 orders: 1,
@@ -9459,16 +9610,16 @@ describe('Market', () => {
               })
               expectLocalEq(await market.locals(user.address), {
                 ...DEFAULT_LOCAL,
-                currentId: 4,
-                latestId: 3,
+                currentId: 3,
+                latestId: 2,
                 collateral: 0,
               })
-              expect(await market.liquidators(user.address, 3)).to.equal(liquidator.address)
+              expect(await market.liquidators(user.address, 2)).to.equal(liquidator.address)
               expectPositionEq(await market.positions(user.address), {
                 ...DEFAULT_POSITION,
                 timestamp: ORACLE_VERSION_4.timestamp,
               })
-              expectOrderEq(await market.pendingOrders(user.address, 4), {
+              expectOrderEq(await market.pendingOrders(user.address, 3), {
                 ...DEFAULT_ORDER,
                 timestamp: ORACLE_VERSION_5.timestamp,
                 collateral: shortfall.mul(-1),
@@ -9531,8 +9682,8 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL,
             })
             expectPositionEq(await market.positions(user.address), {
@@ -9540,17 +9691,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_4.timestamp,
               maker: POSITION,
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_5.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_5.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL,
             })
             expectPositionEq(await market.positions(userB.address), {
@@ -9558,17 +9712,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_4.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_5.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_5.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -9576,14 +9733,13 @@ describe('Market', () => {
               maker: POSITION,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_5.timestamp,
-            })
-            expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
-              ...DEFAULT_VERSION,
-              price: oracleVersionHigherPrice_0.price,
-              liquidationFee: { _value: -riskParameter.liquidationFee },
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL.mul(2),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_VERSION,
@@ -9643,7 +9799,7 @@ describe('Market', () => {
 
             expectLocalEq(await market.locals(user.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               collateral: COLLATERAL.sub(EXPECTED_SETTLEMENT_FEE).sub(EXPECTED_MAKER_FEE), // offset is returned to maker since it was previously in the pool
             })
@@ -9652,17 +9808,20 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               maker: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(user.address, 3), {
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
             })
             expectLocalEq(await market.locals(userB.address), {
               ...DEFAULT_LOCAL,
-              currentId: 3,
-              latestId: 2,
+              currentId: 1,
+              latestId: 1,
               collateral: COLLATERAL,
             })
             expectPositionEq(await market.positions(userB.address), {
@@ -9670,9 +9829,12 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrders(userB.address, 3), {
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -9687,7 +9849,7 @@ describe('Market', () => {
             const EXPOSURE_BEFORE = BigNumber.from(0)
             const EXPOSURE_AFTER = BigNumber.from(0).sub(parse6decimal('2.46'))
             expectGlobalEq(await market.global(), {
-              currentId: 3,
+              currentId: 2,
               latestId: 2,
               protocolFee: EXPECTED_MAKER_FEE.div(2),
               oracleFee: EXPECTED_MAKER_FEE.div(2).div(10).add(EXPECTED_SETTLEMENT_FEE),
@@ -9701,9 +9863,11 @@ describe('Market', () => {
               maker: POSITION.div(2),
               short: POSITION.div(2),
             })
-            expectOrderEq(await market.pendingOrder(3), {
+            expectOrderEq(await market.pendingOrder(2), {
               ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_4.timestamp,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              orders: 1,
+              makerNeg: POSITION.div(2),
             })
             expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
               ...DEFAULT_VERSION,

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -32,7 +32,6 @@ const DEFAULT_GLOBAL: GlobalStruct = {
     _value: 0,
     _skew: 0,
   },
-  latestPrice: 0,
   exposure: 0,
 }
 
@@ -100,7 +99,7 @@ function generateProtocolParameter(protocolFee: BigNumberish): ProtocolParameter
   }
 }
 
-describe('Global', () => {
+describe.only('Global', () => {
   let owner: SignerWithAddress
 
   let globalStorageLib: GlobalStorageLib
@@ -129,7 +128,6 @@ describe('Global', () => {
           _value: 6,
           _skew: 7,
         },
-        latestPrice: 9,
         exposure: 8,
       })
 
@@ -142,7 +140,6 @@ describe('Global', () => {
       expect(value.donation).to.equal(5)
       expect(value.pAccumulator._value).to.equal(6)
       expect(value.pAccumulator._skew).to.equal(7)
-      expect(value.latestPrice).to.equal(9)
       expect(value.exposure).to.equal(8)
     })
 
@@ -267,27 +264,6 @@ describe('Global', () => {
           global.store({
             ...DEFAULT_GLOBAL,
             donation: BigNumber.from(2).pow(STORAGE_SIZE),
-          }),
-        ).to.be.revertedWithCustomError(globalStorageLib, 'GlobalStorageInvalidError')
-      })
-    })
-
-    context('.latestPrice', async () => {
-      const STORAGE_SIZE = 63
-      it('saves if in range', async () => {
-        await global.store({
-          ...DEFAULT_GLOBAL,
-          latestPrice: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-        })
-        const value = await global.read()
-        expect(value.latestPrice).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-      })
-
-      it('reverts if latestPrice out of range', async () => {
-        await expect(
-          global.store({
-            ...DEFAULT_GLOBAL,
-            latestPrice: BigNumber.from(2).pow(STORAGE_SIZE),
           }),
         ).to.be.revertedWithCustomError(globalStorageLib, 'GlobalStorageInvalidError')
       })


### PR DESCRIPTION
- Removes `latestPrice` from `Global` in favor of directly using oracle price now that [all prices are available](https://github.com/equilibria-xyz/perennial-v2/pull/363).
- Removes a significant amount of special-casing in the invariant that supported settling via "no-op updates".

#### Invariant Simplification
 - `MarketInvalidProtectionError`
   - Require collateral change to be zero (could previously deposit, simplifies maintenance check)
   - Allow order position change of zero (removes the need for an additional position check on top of the "closes all" check)
 - `MarketStalePriceError`
   - Require for all updates (removes exception for zero position accounts and deposits)
 - `MarketProtectedError`
   - Require for all updates (removes exception for order position change of zero)
 - `MarketInsufficientCollateralError`
   - Require for all updates (removes exception allowing partial re-collateralization)

#### Migration Notes
- `latestPrice` must be valid prior to upgrading.
  - `Global.latestPrice` will not be read after upgrading, but the Oracle will not have lookback data yet prior to upgrade so we must of the `latestPrice` up-to-date (valid) at the time of upgrading.