### PR TITLE
Make oracle and risk fees independent

### DIFF
--- a/packages/perennial-oracle/contracts/types/OracleParameter.sol
+++ b/packages/perennial-oracle/contracts/types/OracleParameter.sol
@@ -15,13 +15,15 @@ struct OracleParameter {
     UFixed6 maxOracleFee;
 }
 struct StoredOracleParameter {
-    uint16 maxGranularity;
-    uint48 maxSettlementFee;
-    uint24 maxOracleFee;
+    /* slot 0 */
+    uint16 maxGranularity;      // <= 65k
+    uint48 maxSettlementFee;    // <= 281m
+    uint24 maxOracleFee;        // <= 100%
 }
 struct OracleParameterStorage { StoredOracleParameter value; }
 using OracleParameterStorageLib for OracleParameterStorage global;
 
+/// @dev (external-safe): this library is safe to externalize
 library OracleParameterStorageLib {
     // sig: 0xfc481d85
     error OracleParameterStorageInvalidError();
@@ -37,6 +39,7 @@ library OracleParameterStorageLib {
 
     function validate(OracleParameter memory newValue) private pure {
         if (newValue.maxGranularity < 1) revert OracleParameterStorageInvalidError();
+        if (newValue.maxOracleFee.gt(UFixed6Lib.ONE)) revert OracleParameterStorageInvalidError();
     }
 
     function store(OracleParameterStorage storage self, OracleParameter memory newValue) internal {

--- a/packages/perennial-oracle/test/unit/types/OracleParameter.ts
+++ b/packages/perennial-oracle/test/unit/types/OracleParameter.ts
@@ -87,21 +87,20 @@ describe('OracleParameter', () => {
     })
 
     context('.maxOracleFee', async () => {
-      const STORAGE_SIZE = 24
       it('saves if in range', async () => {
         await oracleParameter.store({
           ...DEFAULT_ORACLE_PARAMETER,
-          maxOracleFee: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          maxOracleFee: parse6decimal('1'),
         })
         const value = await oracleParameter.read()
-        expect(value.maxOracleFee).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        expect(value.maxOracleFee).to.equal(parse6decimal('1'))
       })
 
       it('reverts if maxOracleFee out of range', async () => {
         await expect(
           oracleParameter.store({
             ...DEFAULT_ORACLE_PARAMETER,
-            maxOracleFee: BigNumber.from(2).pow(STORAGE_SIZE),
+            maxOracleFee: parse6decimal('1').add(1),
           }),
         ).to.be.revertedWithCustomError(oracleParameter, 'OracleParameterStorageInvalidError')
       })

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -59,6 +59,12 @@ library GlobalLib {
     }
 
     /// @notice Increments the fees by `amount` using current parameters
+    /// @dev Computes the fees based on the current market parameters
+    ///      market fee -> trade fee + market's trade offset + funding fee + interest fee
+    ///        1. protocol fee taken out of market fee
+    ///        2. oracle fee taken out as a percentage of what's left of market fee
+    ///        3. risk fee taken out as a percentage of what's left of market fee
+    ///        4. donation is what's left of market fee
     /// @param self The Global object to update
     /// @param newLatestId The new latest position id
     /// @param accumulation The accumulation result
@@ -82,7 +88,7 @@ library GlobalLib {
         UFixed6 marketFeeAmount = marketFee.sub(protocolFeeAmount);
 
         UFixed6 oracleFeeAmount = marketFeeAmount.mul(oracleReceipt.oracleFee);
-        UFixed6 riskFeeAmount = marketFeeAmount.mul(marketParameter.riskFee);
+        UFixed6 riskFeeAmount = marketFeeAmount.sub(oracleFeeAmount).mul(marketParameter.riskFee);
         UFixed6 donationAmount = marketFeeAmount.sub(oracleFeeAmount).sub(riskFeeAmount);
 
         self.latestId = newLatestId;

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -63,8 +63,7 @@ const RISK_PARAMS = {
 const MARKET_PARAMS = {
   fundingFee: parse6decimal('0.1'),
   interestFee: parse6decimal('0.2'),
-  oracleFee: parse6decimal('0.3'),
-  riskFee: parse6decimal('0.4'),
+  riskFee: parse6decimal('0.571428'),
   makerFee: parse6decimal('0.05'),
   takerFee: parse6decimal('0.025'),
 }
@@ -171,8 +170,8 @@ describe('Fees', () => {
       // Check global post-settlement state
       const expectedProtocolFee = BigNumber.from('125271272') // = 250542544 * 1 * 0.5 (no existing makers so all fees go to protocol/market)
       const expectedOracleFee = BigNumber.from('37581381') // = (250542544 - 125271272) * 0.3
-      const expectedRiskFee = BigNumber.from('50108508') // = (250542544 - 125271272) * 0.4
-      const expectedDonation = BigNumber.from('37581383') // = 250542544 - 125271272 - 37581381 - 50108508
+      const expectedRiskFee = BigNumber.from('50108459') // = (250542544 - 125271272) * 0.4
+      const expectedDonation = BigNumber.from('37581432') // = 250542544 - 125271272 - 37581381 - 50108508
       expectGlobalEq(await market.global(), {
         currentId: 1,
         latestId: 1,
@@ -279,8 +278,8 @@ describe('Fees', () => {
       // Check global post-settlement state. Existing makers so protocol only gets 50% of fees
       const expectedProtocolFee = BigNumber.from('28470743') // = 56941487 * 0.5
       const expectedOracleFee = BigNumber.from('8541223') // = (56941487 - 28470743) * 0.3
-      const expectedRiskFee = BigNumber.from('11388297') // = (56941487 - 28470743) * 0.4
-      const expectedDonation = BigNumber.from('8541224') // = 56941487 - 28470743 - 8541223 - 11388297
+      const expectedRiskFee = BigNumber.from('11388286') // = (56941487 - 28470743) * 0.4
+      const expectedDonation = BigNumber.from('8541235') // = 56941487 - 28470743 - 8541223 - 11388297
       expectGlobalEq(await market.global(), {
         currentId: 2,
         latestId: 2,
@@ -378,8 +377,8 @@ describe('Fees', () => {
 
       const expectedProtocolFee = BigNumber.from('7687100') // = 15374200 / 2
       const expectedOracleFee = BigNumber.from('2306130') // = (15374200 - 7687100) * 0.3
-      const expectedRiskFee = BigNumber.from('3074840') // = (15374200 - 7687100) * 0.4
-      const expectedDonation = BigNumber.from('2306130') // = 15374200 - 7687100 - 2306130 - 3074840
+      const expectedRiskFee = BigNumber.from('3074836') // = (15374200 - 7687100) * 0.4
+      const expectedDonation = BigNumber.from('2306134') // = 15374200 - 7687100 - 2306130 - 3074840
 
       // Global State
       expectGlobalEq(await market.global(), {
@@ -866,8 +865,8 @@ describe('Fees', () => {
 
       const expectedProtocolFee = BigNumber.from('7687100') // = 15374200 / 2
       const expectedOracleFee = BigNumber.from('2306130') // = (15374200 - 7687100) * 0.3
-      const expectedRiskFee = BigNumber.from('3074840') // = (15374200 - 7687100) * 0.4
-      const expectedDonation = BigNumber.from('2306130') // = 15374200 - 7687100 - 2306130 - 3074840
+      const expectedRiskFee = BigNumber.from('3074836') // = (15374200 - 7687100) * 0.4
+      const expectedDonation = BigNumber.from('2306134') // = 15374200 - 7687100 - 2306130 - 3074840
 
       // Global State
       expectGlobalEq(await market.global(), {

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -490,7 +490,7 @@ describe('Market', () => {
     marketParameter = {
       fundingFee: parse6decimal('0.1'),
       interestFee: parse6decimal('0.1'),
-      riskFee: parse6decimal('0.1'),
+      riskFee: parse6decimal('0.111111'),
       makerFee: 0,
       takerFee: 0,
       maxPendingGlobal: 5,
@@ -987,8 +987,8 @@ describe('Market', () => {
           latestId: 2,
           protocolFee: totalFee.div(2),
           oracleFee: totalFee.div(2).div(10),
-          riskFee: totalFee.div(2).div(10),
-          donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
+          riskFee: totalFee.div(2).div(10).sub(1),
+          donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: 0,
         })
 
@@ -1009,8 +1009,8 @@ describe('Market', () => {
           latestId: 2,
           protocolFee: totalFee.div(2),
           oracleFee: totalFee.div(2).div(10),
-          riskFee: totalFee.div(2).div(10),
-          donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
+          riskFee: totalFee.div(2).div(10).sub(1),
+          donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
         })
 
@@ -1040,8 +1040,8 @@ describe('Market', () => {
           latestId: 2,
           protocolFee: totalFee.div(2).sub(1), // loss of precision
           oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
-          riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-          donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
+          riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+          donation: totalFee.div(2).mul(8).div(10).add(5), // loss of precision
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
         })
       })
@@ -1183,8 +1183,8 @@ describe('Market', () => {
           latestId: 2,
           protocolFee: totalFee.div(2),
           oracleFee: totalFee.div(2).div(10),
-          riskFee: totalFee.div(2).div(10),
-          donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
+          riskFee: totalFee.div(2).div(10).sub(1),
+          donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: 0,
         })
 
@@ -1207,8 +1207,8 @@ describe('Market', () => {
           latestId: 2,
           protocolFee: totalFee.div(2),
           oracleFee: totalFee.div(2).div(10),
-          riskFee: totalFee.div(2).div(10),
-          donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
+          riskFee: totalFee.div(2).div(10).sub(1),
+          donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
         })
 
@@ -1238,8 +1238,8 @@ describe('Market', () => {
           latestId: 2,
           protocolFee: totalFee.div(2).sub(1), // loss of precision
           oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
-          riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-          donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
+          riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+          donation: totalFee.div(2).mul(8).div(10).add(5), // loss of precision
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
         })
       })
@@ -2347,8 +2347,8 @@ describe('Market', () => {
               latestId: 1,
               protocolFee: MAKER_FEE.div(2),
               oracleFee: MAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE),
-              riskFee: MAKER_FEE.div(2).div(10),
-              donation: MAKER_FEE.div(2).mul(8).div(10),
+              riskFee: MAKER_FEE.div(2).div(10).sub(1),
+              donation: MAKER_FEE.div(2).mul(8).div(10).add(1),
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -2927,8 +2927,8 @@ describe('Market', () => {
                 latestId: 2,
                 protocolFee: MAKER_FEE.div(2),
                 oracleFee: MAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE),
-                riskFee: MAKER_FEE.div(2).div(10),
-                donation: MAKER_FEE.div(2).mul(8).div(10),
+                riskFee: MAKER_FEE.div(2).div(10).sub(1),
+                donation: MAKER_FEE.div(2).mul(8).div(10).add(1),
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3699,8 +3699,8 @@ describe('Market', () => {
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
-                riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -3851,8 +3851,8 @@ describe('Market', () => {
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
-                riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -5573,8 +5573,8 @@ describe('Market', () => {
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(2), // loss of precision
                 oracleFee: totalFee.div(2).div(10),
-                riskFee: totalFee.div(2).div(10),
-                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2),
+                donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -7195,8 +7195,8 @@ describe('Market', () => {
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
-                riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -7349,8 +7349,8 @@ describe('Market', () => {
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
-                riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -9077,8 +9077,8 @@ describe('Market', () => {
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(5), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(2), // loss of precision
-                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(3), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -10039,8 +10039,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: EXPECTED_MAKER_FEE.div(2),
               oracleFee: EXPECTED_MAKER_FEE.div(2).div(10).add(EXPECTED_SETTLEMENT_FEE),
-              riskFee: EXPECTED_MAKER_FEE.div(2).div(10),
-              donation: EXPECTED_MAKER_FEE.div(2).mul(8).div(10),
+              riskFee: EXPECTED_MAKER_FEE.div(2).div(10).sub(1),
+              donation: EXPECTED_MAKER_FEE.div(2).mul(8).div(10).add(1),
               exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
             })
             expectPositionEq(await market.position(), {
@@ -10897,8 +10897,8 @@ describe('Market', () => {
                 latestId: 1,
                 protocolFee: totalFee.div(2).sub(3), // loss of precision
                 oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
-                riskFee: totalFee.div(2).div(10), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -12888,8 +12888,8 @@ describe('Market', () => {
                 latestId: 2,
                 protocolFee: totalFee.div(2).sub(7), // loss of precision
                 oracleFee: totalFee.div(2).div(10).sub(1), // loss of precision
-                riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-                donation: totalFee.div(2).mul(8).div(10).sub(1), // loss of precision
+                riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+                donation: totalFee.div(2).mul(8).div(10), // loss of precision
                 exposure: 0,
               })
               expectPositionEq(await market.position(), {
@@ -16414,8 +16414,8 @@ describe('Market', () => {
             latestId: 3,
             protocolFee: TAKER_FEE.div(2),
             oracleFee: TAKER_FEE.div(2).div(10).add(SETTLEMENT_FEE.mul(2)),
-            riskFee: TAKER_FEE.div(2).div(10),
-            donation: TAKER_FEE.div(2).mul(8).div(10),
+            riskFee: TAKER_FEE.div(2).div(10).sub(1),
+            donation: TAKER_FEE.div(2).mul(8).div(10).add(1),
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -17004,8 +17004,8 @@ describe('Market', () => {
             latestId: 4,
             protocolFee: TAKER_FEE.div(2),
             oracleFee: TAKER_FEE.div(20).add(SETTLEMENT_FEE.mul(2)),
-            riskFee: TAKER_FEE.div(20),
-            donation: TAKER_FEE.mul(2).div(5),
+            riskFee: TAKER_FEE.div(20).sub(1),
+            donation: TAKER_FEE.mul(2).div(5).add(1),
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -17864,8 +17864,8 @@ describe('Market', () => {
             latestId: 1,
             protocolFee: totalFee.div(2), // loss of precision
             oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
-            riskFee: totalFee.div(2).div(10), // loss of precision
-            donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+            riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+            donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19674,8 +19674,8 @@ describe('Market', () => {
             latestId: 1,
             protocolFee: totalFee.div(2),
             oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE),
-            riskFee: totalFee.div(2).div(10),
-            donation: totalFee.div(2).mul(8).div(10),
+            riskFee: totalFee.div(2).div(10).sub(1),
+            donation: totalFee.div(2).mul(8).div(10).add(1),
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19827,8 +19827,8 @@ describe('Market', () => {
             latestId: 1,
             protocolFee: totalFee.div(2).sub(3), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
-            riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-            donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+            riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+            donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -19983,8 +19983,8 @@ describe('Market', () => {
             latestId: 1,
             protocolFee: totalFee.div(2).sub(3), // loss of precision
             oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE), // loss of precision
-            riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-            donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+            riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+            donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
             exposure: 0,
           })
           expectPositionEq(await market.position(), {
@@ -20229,8 +20229,8 @@ describe('Market', () => {
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
-              riskFee: totalFee.div(2).div(10), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -20470,8 +20470,8 @@ describe('Market', () => {
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
-              riskFee: totalFee.div(2).div(10), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -20711,8 +20711,8 @@ describe('Market', () => {
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
-              riskFee: totalFee.div(2).div(10), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -20951,8 +20951,8 @@ describe('Market', () => {
               latestId: 1,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE), // loss of precision
-              riskFee: totalFee.div(2).div(10), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -21208,8 +21208,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
-              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
             })
             expectPositionEq(await market.position(), {
@@ -21461,8 +21461,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
-              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
             })
             expectPositionEq(await market.position(), {
@@ -21716,8 +21716,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
-              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
             })
             expectPositionEq(await market.position(), {
@@ -21971,8 +21971,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: totalFee.div(2).sub(3), // loss of precision
               oracleFee: totalFee.div(2).div(10).sub(1).add(SETTLEMENT_FEE.mul(2)), // loss of precision
-              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
             })
             expectPositionEq(await market.position(), {
@@ -22232,8 +22232,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE.mul(2)), // loss of precision
-              riskFee: totalFee.div(2).div(10), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -22493,8 +22493,8 @@ describe('Market', () => {
               latestId: 2,
               protocolFee: totalFee.div(2), // loss of precision
               oracleFee: totalFee.div(2).div(10).add(SETTLEMENT_FEE.mul(2)), // loss of precision
-              riskFee: totalFee.div(2).div(10), // loss of precision
-              donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
+              riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
+              donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
             })
             expectPositionEq(await market.position(), {
@@ -22644,7 +22644,7 @@ describe('Market', () => {
       const PROTOCOL_FEE = FEE.div(2)
       const MARKET_FEE = FEE.sub(PROTOCOL_FEE)
       const ORACLE_FEE = MARKET_FEE.div(10)
-      const RISK_FEE = MARKET_FEE.div(5)
+      const RISK_FEE = MARKET_FEE.sub(ORACLE_FEE).div(5)
       const DONATION = MARKET_FEE.sub(ORACLE_FEE).sub(RISK_FEE)
 
       beforeEach(async () => {

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -70,7 +70,7 @@ function generateAccumulationResult(
   }
 }
 
-function generateOracleRecipt(oracleFee: BigNumberish): OracleReceiptStruct {
+function generateOracleReceipt(oracleFee: BigNumberish): OracleReceiptStruct {
   return {
     settlementFee: 0,
     oracleFee,
@@ -105,7 +105,7 @@ function generateProtocolParameter(protocolFee: BigNumberish): ProtocolParameter
   }
 }
 
-describe.only('Global', () => {
+describe('Global', () => {
   let owner: SignerWithAddress
 
   let globalStorageLib: GlobalStorageLib
@@ -407,7 +407,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(0),
           generateProtocolParameter(0),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -421,7 +421,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('0.1')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -435,7 +435,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.1')),
           generateProtocolParameter(0),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -449,7 +449,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(0),
           generateProtocolParameter(0),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -463,13 +463,13 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.3')),
           generateProtocolParameter(0),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
         expect(value.oracleFee).to.equal(12)
-        expect(value.riskFee).to.equal(36)
-        expect(value.donation).to.equal(75)
+        expect(value.riskFee).to.equal(33)
+        expect(value.donation).to.equal(78)
       })
 
       it('oracle / risk fee zero donation', async () => {
@@ -478,25 +478,28 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.9')),
           generateProtocolParameter(0),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
         expect(value.oracleFee).to.equal(12)
-        expect(value.riskFee).to.equal(110)
-        expect(value.donation).to.equal(1) // due to rounding
+        expect(value.riskFee).to.equal(99)
+        expect(value.donation).to.equal(12)
       })
 
-      it('oracle / risk fee over', async () => {
-        await expect(
-          global.update(
-            1,
-            generateAccumulationResult(123, 0, 0),
-            generateMarketParameter(parse6decimal('1.0')),
-            generateProtocolParameter(0),
-            generateOracleRecipt(parse6decimal('0.1')),
-          ),
-        ).revertedWithPanic(0x11)
+      it('oracle / risk fee total over 1.00 (legacy)', async () => {
+        await global.update(
+          1,
+          generateAccumulationResult(123, 0, 0),
+          generateMarketParameter(parse6decimal('1.0')),
+          generateProtocolParameter(0),
+          generateOracleReceipt(parse6decimal('0.1')),
+        )
+
+        const value = await global.read()
+        expect(value.oracleFee).to.equal(12)
+        expect(value.riskFee).to.equal(111)
+        expect(value.donation).to.equal(0)
       })
 
       it('protocol / risk fee', async () => {
@@ -505,7 +508,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -520,7 +523,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('1.0')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -535,7 +538,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('1.0')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -551,7 +554,7 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 0, 0),
             generateMarketParameter(parse6decimal('0.1')),
             generateProtocolParameter(parse6decimal('1.1')),
-            generateOracleRecipt(0),
+            generateOracleReceipt(0),
           ),
         ).revertedWithPanic(0x11)
       })
@@ -563,7 +566,7 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 0, 0),
             generateMarketParameter(parse6decimal('1.1')),
             generateProtocolParameter(parse6decimal('0.2')),
-            generateOracleRecipt(0),
+            generateOracleReceipt(0),
           ),
         ).revertedWithPanic(0x11)
       })
@@ -574,7 +577,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -589,7 +592,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('1.0')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -604,7 +607,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('1.0')),
+          generateOracleReceipt(parse6decimal('1.0')),
         )
 
         const value = await global.read()
@@ -620,19 +623,35 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 0, 0),
             generateMarketParameter(0),
             generateProtocolParameter(parse6decimal('1.1')),
-            generateOracleRecipt(parse6decimal('0.1')),
+            generateOracleReceipt(parse6decimal('0.1')),
           ),
         ).revertedWithPanic(0x11)
       })
 
-      it('protocol / oracle fee oracle over', async () => {
+      it('protocol / oracle fee zero donation', async () => {
+        await global.update(
+          1,
+          generateAccumulationResult(123, 0, 0),
+          generateMarketParameter(0),
+          generateProtocolParameter(parse6decimal('0.2')),
+          generateOracleReceipt(parse6decimal('1.0')),
+        )
+
+        const value = await global.read()
+        expect(value.protocolFee).to.equal(24)
+        expect(value.oracleFee).to.equal(99)
+        expect(value.riskFee).to.equal(0)
+        expect(value.donation).to.equal(0)
+      })
+
+      it('protocol / oracle fee oracle over 1.00 (legacy)', async () => {
         await expect(
           global.update(
             1,
             generateAccumulationResult(123, 0, 0),
             generateMarketParameter(0),
             generateProtocolParameter(parse6decimal('0.2')),
-            generateOracleRecipt(parse6decimal('1.1')),
+            generateOracleReceipt(parse6decimal('1.1')),
           ),
         ).revertedWithPanic(0x11)
       })
@@ -643,14 +662,14 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
         expect(value.protocolFee).to.equal(24)
         expect(value.oracleFee).to.equal(9)
-        expect(value.riskFee).to.equal(29)
-        expect(value.donation).to.equal(61)
+        expect(value.riskFee).to.equal(27)
+        expect(value.donation).to.equal(63)
       })
 
       it('protocol / oracle / risk fee zero marketFee', async () => {
@@ -659,7 +678,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 0, 0),
           generateMarketParameter(parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('1.0')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -669,29 +688,13 @@ describe.only('Global', () => {
         expect(value.donation).to.equal(0)
       })
 
-      it('protocol / oracle / risk fee zero donation', async () => {
-        await global.update(
-          1,
-          generateAccumulationResult(123, 0, 0),
-          generateMarketParameter(parse6decimal('0.9')),
-          generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
-        )
-
-        const value = await global.read()
-        expect(value.protocolFee).to.equal(24)
-        expect(value.oracleFee).to.equal(9)
-        expect(value.riskFee).to.equal(89)
-        expect(value.donation).to.equal(1) // due to rounding
-      })
-
       it('exposure', async () => {
         await global.update(
           1,
           generateAccumulationResult(0, 0, 123),
           generateMarketParameter(parse6decimal('0.9')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -705,21 +708,25 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 0, 0),
             generateMarketParameter(parse6decimal('0.3')),
             generateProtocolParameter(parse6decimal('1.1')),
-            generateOracleRecipt(parse6decimal('0.1')),
+            generateOracleReceipt(parse6decimal('0.1')),
           ),
         ).revertedWithPanic(0x11)
       })
 
-      it('protocol / oracle / risk fee oracle over', async () => {
-        await expect(
-          global.update(
-            1,
-            generateAccumulationResult(123, 0, 0),
-            generateMarketParameter(parse6decimal('1.0')),
-            generateProtocolParameter(parse6decimal('0.2')),
-            generateOracleRecipt(parse6decimal('0.1')),
-          ),
-        ).revertedWithPanic(0x11)
+      it('protocol / oracle / risk total fee oracle over (legacy)', async () => {
+        await global.update(
+          1,
+          generateAccumulationResult(123, 0, 0),
+          generateMarketParameter(parse6decimal('1.0')),
+          generateProtocolParameter(parse6decimal('0.2')),
+          generateOracleReceipt(parse6decimal('0.1')),
+        )
+
+        const value = await global.read()
+        expect(value.protocolFee).to.equal(24)
+        expect(value.oracleFee).to.equal(9)
+        expect(value.riskFee).to.equal(90)
+        expect(value.donation).to.equal(0)
       })
     })
 
@@ -730,7 +737,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(0),
           generateProtocolParameter(0),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -743,7 +750,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('0.1')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -757,7 +764,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('0.1')),
           generateProtocolParameter(0),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -771,7 +778,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(0),
           generateProtocolParameter(0),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -785,40 +792,28 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('0.3')),
           generateProtocolParameter(0),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
         expect(value.oracleFee).to.equal(468)
-        expect(value.riskFee).to.equal(36)
-        expect(value.donation).to.equal(75)
+        expect(value.riskFee).to.equal(33)
+        expect(value.donation).to.equal(78)
       })
 
-      it('oracle / risk fee zero donation', async () => {
+      it('oracle / risk total fee over (legacy)', async () => {
         await global.update(
           1,
           generateAccumulationResult(123, 456, 0),
-          generateMarketParameter(parse6decimal('0.9')),
+          generateMarketParameter(parse6decimal('1.0')),
           generateProtocolParameter(0),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
         expect(value.oracleFee).to.equal(468)
-        expect(value.riskFee).to.equal(110)
-        expect(value.donation).to.equal(1) // due to rounding
-      })
-
-      it('oracle / risk fee over', async () => {
-        await expect(
-          global.update(
-            1,
-            generateAccumulationResult(123, 456, 0),
-            generateMarketParameter(parse6decimal('1.0')),
-            generateProtocolParameter(0),
-            generateOracleRecipt(parse6decimal('0.1')),
-          ),
-        ).revertedWithPanic(0x11)
+        expect(value.riskFee).to.equal(111)
+        expect(value.donation).to.equal(0)
       })
 
       it('protocol / risk fee', async () => {
@@ -827,7 +822,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -843,7 +838,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('0.1')),
           generateProtocolParameter(parse6decimal('1.0')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -859,7 +854,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('1.0')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(0),
+          generateOracleReceipt(0),
         )
 
         const value = await global.read()
@@ -876,7 +871,7 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 456, 0),
             generateMarketParameter(parse6decimal('0.1')),
             generateProtocolParameter(parse6decimal('1.1')),
-            generateOracleRecipt(0),
+            generateOracleReceipt(0),
           ),
         ).revertedWithPanic(0x11)
       })
@@ -888,7 +883,7 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 456, 0),
             generateMarketParameter(parse6decimal('1.1')),
             generateProtocolParameter(parse6decimal('0.2')),
-            generateOracleRecipt(0),
+            generateOracleReceipt(0),
           ),
         ).revertedWithPanic(0x11)
       })
@@ -899,7 +894,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -914,7 +909,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('1.0')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -929,7 +924,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(0),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('1.0')),
+          generateOracleReceipt(parse6decimal('1.0')),
         )
 
         const value = await global.read()
@@ -945,9 +940,24 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 0, 0),
             generateMarketParameter(0),
             generateProtocolParameter(parse6decimal('1.1')),
-            generateOracleRecipt(parse6decimal('0.1')),
+            generateOracleReceipt(parse6decimal('0.1')),
           ),
         ).revertedWithPanic(0x11)
+      })
+
+      it('protocol / oracle fee zero donation', async () => {
+        await global.update(
+          1,
+          generateAccumulationResult(123, 456, 0),
+          generateMarketParameter(0),
+          generateProtocolParameter(parse6decimal('0.2')),
+          generateOracleReceipt(parse6decimal('1.0')),
+        )
+
+        const value = await global.read()
+        expect(value.protocolFee).to.equal(24)
+        expect(value.oracleFee).to.equal(555)
+        expect(value.donation).to.equal(0)
       })
 
       it('protocol / oracle fee oracle over', async () => {
@@ -957,7 +967,7 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 456, 0),
             generateMarketParameter(0),
             generateProtocolParameter(parse6decimal('0.2')),
-            generateOracleRecipt(parse6decimal('1.1')),
+            generateOracleReceipt(parse6decimal('1.1')),
           ),
         ).revertedWithPanic(0x11)
       })
@@ -968,14 +978,14 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
         expect(value.protocolFee).to.equal(24)
         expect(value.oracleFee).to.equal(465)
-        expect(value.riskFee).to.equal(29)
-        expect(value.donation).to.equal(61)
+        expect(value.riskFee).to.equal(27)
+        expect(value.donation).to.equal(63)
       })
 
       it('protocol / oracle / risk fee zero marketFee', async () => {
@@ -984,7 +994,7 @@ describe.only('Global', () => {
           generateAccumulationResult(123, 456, 0),
           generateMarketParameter(parse6decimal('0.3')),
           generateProtocolParameter(parse6decimal('1.0')),
-          generateOracleRecipt(parse6decimal('0.1')),
+          generateOracleReceipt(parse6decimal('0.1')),
         )
 
         const value = await global.read()
@@ -994,22 +1004,6 @@ describe.only('Global', () => {
         expect(value.donation).to.equal(0)
       })
 
-      it('protocol / oracle / risk fee zero donation', async () => {
-        await global.update(
-          1,
-          generateAccumulationResult(123, 456, 0),
-          generateMarketParameter(parse6decimal('0.9')),
-          generateProtocolParameter(parse6decimal('0.2')),
-          generateOracleRecipt(parse6decimal('0.1')),
-        )
-
-        const value = await global.read()
-        expect(value.protocolFee).to.equal(24)
-        expect(value.oracleFee).to.equal(465)
-        expect(value.riskFee).to.equal(89)
-        expect(value.donation).to.equal(1) // due to rounding
-      })
-
       it('protocol / oracle / risk fee protocol over', async () => {
         await expect(
           global.update(
@@ -1017,21 +1011,25 @@ describe.only('Global', () => {
             generateAccumulationResult(123, 456, 0),
             generateMarketParameter(parse6decimal('0.3')),
             generateProtocolParameter(parse6decimal('1.1')),
-            generateOracleRecipt(parse6decimal('0.1')),
+            generateOracleReceipt(parse6decimal('0.1')),
           ),
         ).revertedWithPanic(0x11)
       })
 
-      it('protocol / oracle / risk fee oracle over', async () => {
-        await expect(
-          global.update(
-            1,
-            generateAccumulationResult(123, 456, 0),
-            generateMarketParameter(parse6decimal('1.0')),
-            generateProtocolParameter(parse6decimal('0.2')),
-            generateOracleRecipt(parse6decimal('0.1')),
-          ),
-        ).revertedWithPanic(0x11)
+      it('protocol / oracle / risk fee zero donation', async () => {
+        await global.update(
+          1,
+          generateAccumulationResult(123, 456, 0),
+          generateMarketParameter(parse6decimal('1.0')),
+          generateProtocolParameter(parse6decimal('0.2')),
+          generateOracleReceipt(parse6decimal('0.1')),
+        )
+
+        const value = await global.read()
+        expect(value.protocolFee).to.equal(24)
+        expect(value.oracleFee).to.equal(465)
+        expect(value.riskFee).to.equal(90)
+        expect(value.donation).to.equal(0) // due to rounding
       })
     })
   })

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -62,7 +62,6 @@ const GLOBAL: GlobalStruct = {
     _value: 6,
     _skew: 7,
   },
-  latestPrice: 0,
   exposure: 0,
 }
 
@@ -2306,44 +2305,6 @@ describe('Version', () => {
 
         expect(nextGlobal.pAccumulator._value).to.equal(0)
         expect(nextGlobal.pAccumulator._skew).to.equal('-1000000')
-      })
-    })
-
-    describe('global latestPrice', () => {
-      it('returns updated global latestPrice values', async () => {
-        await version.store(DEFAULT_VERSION)
-
-        const { nextGlobal } = await accumulateWithReturn(
-          GLOBAL,
-          {
-            ...FROM_POSITION,
-            maker: parse6decimal('10'),
-            long: parse6decimal('2'),
-            short: parse6decimal('9'),
-          },
-          ORDER,
-          { ...DEFAULT_GUARANTEE },
-          ORACLE_VERSION_1,
-          ORACLE_VERSION_2,
-          DEFAULT_ORACLE_RECEIPT,
-          {
-            ...VALID_MARKET_PARAMETER,
-            interestFee: 0,
-            fundingFee: 0,
-          },
-          {
-            ...VALID_RISK_PARAMETER,
-            pController: { min: 0, max: 0, k: parse6decimal('999999') },
-            utilizationCurve: {
-              minRate: 0,
-              maxRate: 0,
-              targetRate: 0,
-              targetUtilization: parse6decimal('0.8'),
-            },
-          },
-        )
-
-        expect(nextGlobal.latestPrice).to.equal(ORACLE_VERSION_2.price)
       })
     })
   })


### PR DESCRIPTION
Previously, the oracle and risk fees were taken out of the market fee in parallel and therefore needed to total less than 100%.

Since oracle fee is now defined in the oracle layer, we want to decouple these. The PR changes the fee order to:
1. Take protocol fee out of market fee
2. Take oracle fee out of leftover market fee
3. Take risk fee out of leftover market fee
4. Remaining market fee is donation