### PR TITLE
Decouple settle / sync

### DIFF
--- a/packages/perennial-account/test/integration/Controller.ts
+++ b/packages/perennial-account/test/integration/Controller.ts
@@ -84,7 +84,7 @@ describe('ControllerBase', () => {
     keeperOracle = ethKeeperOracle,
   ) {
     await advanceToPrice(keeperOracle, receiver, timestamp, price, TX_OVERRIDES)
-    await ethMarket.settle(user.address, TX_OVERRIDES)
+    await ethMarket.sync(user.address, TX_OVERRIDES)
   }
 
   // ensures user has expected amount of collateral in a market

--- a/packages/perennial-extensions/contracts/MultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/MultiInvoker.sol
@@ -391,7 +391,7 @@ contract MultiInvoker is IMultiInvoker, Kept {
             abi.encode(account, market, order.fee)
         );
 
-        _marketSettle(market, account);
+        market.sync(account);
 
         Order memory pending = market.pendings(account);
         Position memory currentPosition = market.positions(account);
@@ -462,13 +462,6 @@ contract MultiInvoker is IMultiInvoker, Kept {
     /// @param withdrawal Amount to withdraw
     function _marketWithdraw(IMarket market, address account, UFixed6 withdrawal) private {
         market.update(account, UFixed6Lib.MAX, UFixed6Lib.MAX, UFixed6Lib.MAX, Fixed6Lib.from(-1, withdrawal), false);
-    }
-
-    /// @notice Settles `account`'s `market` position
-    /// @param market Market to settle
-    /// @param account Account to settle
-    function _marketSettle(IMarket market, address account) private {
-        market.settle(account);
     }
 
     /// @notice Target market must be created by MarketFactory

--- a/packages/perennial-extensions/test/integration/core/Invoke.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Invoke.test.ts
@@ -441,7 +441,7 @@ describe('Invoke', () => {
           expect((await vault.accounts(user.address)).shares).to.eq(0)
 
           await updateVaultOracle()
-          await vault.settle(user.address)
+          await vault.sync(user.address)
 
           // redeem from vault
           await invoke(
@@ -460,7 +460,7 @@ describe('Invoke', () => {
           expect((await vault.accounts(user.address)).shares).to.eq(0)
 
           await updateVaultOracle()
-          await vault.settle(user.address)
+          await vault.sync(user.address)
 
           const funding = BigNumber.from('14352')
           // claim from vault

--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -182,7 +182,7 @@ contract KeeperOracle is IKeeperOracle, Instance {
         emit OracleProviderVersionFulfilled(version);
 
         IMarket market = oracle.market();
-        market.settle(address(0));
+        market.sync(address(0));
         oracle.claimFee(priceResponse.toOracleReceipt(_localCallbacks[version.timestamp].length()).settlementFee);
         market.token().push(receiver, UFixed18Lib.from(priceResponse.syncFee));
     }

--- a/packages/perennial-vault/contracts/interfaces/IVault.sol
+++ b/packages/perennial-vault/contracts/interfaces/IVault.sol
@@ -81,7 +81,7 @@ interface IVault is IInstance {
 
     function initialize(Token18 asset, IMarket initialMaker, UFixed6 initialAmount, string calldata name_) external;
     function name() external view returns (string memory);
-    function settle(address account) external;
+    function sync(address account) external;
     function rebalance(address account) external;
     function update(address account, UFixed6 depositAssets, UFixed6 redeemShares, UFixed6 claimAssets) external;
     function asset() external view returns (Token18);

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -149,6 +149,7 @@ interface IMarket is IInstance {
     function orderReferrers(address account, uint256 id) external view returns (address);
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
+    function sync(address account) external;
     function update(Intent calldata intent, bytes memory signature) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer) external;

--- a/packages/perennial/test/integration/core/closedProduct.test.ts
+++ b/packages/perennial/test/integration/core/closedProduct.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, sync } from '../helpers/setupHelpers'
 import { Market } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
@@ -33,7 +33,7 @@ describe('Closed Market', () => {
 
     // Settle the market with a new oracle version
     await chainlink.nextWithPriceModification(price => price.mul(10))
-    await settle(market, owner)
+    await sync(market, owner)
 
     await chainlink.next()
     const parameters = { ...(await market.parameter()) }
@@ -110,8 +110,8 @@ describe('Closed Market', () => {
     const parameters = { ...(await market.parameter()) }
     parameters.closed = true
     await market.updateParameter(parameters)
-    await settle(market, user)
-    await settle(market, userB)
+    await sync(market, user)
+    await sync(market, userB)
 
     const userCollateralBefore = (await market.locals(user.address)).collateral
     const userBCollateralBefore = (await market.locals(userB.address)).collateral
@@ -161,8 +161,8 @@ describe('Closed Market', () => {
     await market.updateParameter(parameters)
     await chainlink.next()
 
-    await settle(market, user)
-    await settle(market, userB)
+    await sync(market, user)
+    await sync(market, userB)
 
     expect((await market.position()).timestamp).to.eq(TIMESTAMP_3)
     expect((await market.pendingOrders(user.address, 2)).protection).to.eq(1)
@@ -177,7 +177,7 @@ describe('Closed Market', () => {
     await chainlink.nextWithPriceModification(price => price.mul(4))
 
     const LIQUIDATION_FEE = BigNumber.from('1000000000')
-    await settle(market, user)
+    await sync(market, user)
     await market.connect(userB)['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, true)
 
     expect((await market.locals(user.address)).collateral).to.equal(userCollateralBefore)

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants, ContractTransaction, utils } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, sync } from '../helpers/setupHelpers'
 import {
   DEFAULT_CHECKPOINT,
   DEFAULT_POSITION,
@@ -129,7 +129,7 @@ describe('Fees', () => {
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
-      const tx = await settle(market, user)
+      const tx = await sync(market, user)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -231,7 +231,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      await settle(market, user)
+      await sync(market, user)
 
       await market.updateRiskParameter(previousRiskParams)
       await market.updateParameter(previousMarketParams)
@@ -239,7 +239,7 @@ describe('Fees', () => {
 
       // Settle the market with a new oracle version
       await nextWithConstantPrice()
-      const tx = await settle(market, user)
+      const tx = await sync(market, user)
       const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -347,7 +347,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await sync(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -460,7 +460,7 @@ describe('Fees', () => {
 
       // Settle maker to give them portion of fees
       await nextWithConstantPrice()
-      await settle(market, user)
+      await sync(market, user)
 
       await expect(
         market
@@ -485,7 +485,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await sync(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -568,7 +568,7 @@ describe('Fees', () => {
         long: LONG_POSITION,
       })
 
-      const txMaker = await settle(market, user)
+      const txMaker = await sync(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -659,8 +659,8 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      await settle(market, userB)
-      await settle(market, user)
+      await sync(market, userB)
+      await sync(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
       await market.updateRiskParameter({
@@ -687,7 +687,7 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await sync(market, userB)
 
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
@@ -756,7 +756,7 @@ describe('Fees', () => {
         timestamp: TIMESTAMP_2,
       })
 
-      const txMaker = await settle(market, user)
+      const txMaker = await sync(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -835,7 +835,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await sync(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -948,7 +948,7 @@ describe('Fees', () => {
 
       // Settle maker to give them portion of fees
       await nextWithConstantPrice()
-      await settle(market, user)
+      await sync(market, user)
 
       await expect(
         market
@@ -973,7 +973,7 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await sync(market, userB)
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1054,7 +1054,7 @@ describe('Fees', () => {
         short: SHORT_POSITION,
       })
 
-      const txMaker = await settle(market, user)
+      const txMaker = await sync(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1145,8 +1145,8 @@ describe('Fees', () => {
         )
 
       await nextWithConstantPrice()
-      await settle(market, userB)
-      await settle(market, user)
+      await sync(market, userB)
+      await sync(market, user)
 
       // Re-enable fees for close, disable skew and impact for ease of calculation
       await market.updateRiskParameter({
@@ -1172,7 +1172,7 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false)
 
       await nextWithConstantPrice()
-      const txLong = await settle(market, userB)
+      const txLong = await sync(market, userB)
 
       const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
@@ -1241,7 +1241,7 @@ describe('Fees', () => {
         timestamp: TIMESTAMP_2,
       })
 
-      const txMaker = await settle(market, user)
+      const txMaker = await sync(market, user)
       const accountProcessEventMaker: AccountPositionProcessedEventObject = (await txMaker.wait()).events?.find(
         e => e.event === 'AccountPositionProcessed',
       )?.args as unknown as AccountPositionProcessedEventObject
@@ -1313,7 +1313,7 @@ describe('Fees', () => {
           .connect(user)
           ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, MAKER_POSITION, 0, 0, COLLATERAL, false)
         await nextWithConstantPrice()
-        await settle(market, user)
+        await sync(market, user)
       })
 
       it('charges skew fee for changing skew', async () => {
@@ -1332,7 +1332,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const txShort = await settle(market, userB)
+        const txShort = await sync(market, userB)
         const accountProcessEventShort: AccountPositionProcessedEventObject = (await txShort.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
         )?.args as unknown as AccountPositionProcessedEventObject
@@ -1361,7 +1361,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const txLong = await settle(market, userC)
+        const txLong = await sync(market, userC)
         const accountProcessEventLong: AccountPositionProcessedEventObject = (await txLong.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
         )?.args as unknown as AccountPositionProcessedEventObject
@@ -1422,7 +1422,7 @@ describe('Fees', () => {
           .connect(user)
           ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, MAKER_POSITION, 0, 0, COLLATERAL, false)
         await nextWithConstantPrice()
-        await settle(market, user)
+        await sync(market, user)
       })
 
       it('charges taker impact fee for changing skew (short)', async () => {
@@ -1441,7 +1441,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const tx = await settle(market, userB)
+        const tx = await sync(market, userB)
         const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
         )?.args as unknown as AccountPositionProcessedEventObject
@@ -1462,7 +1462,7 @@ describe('Fees', () => {
           ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, LONG_POSITION, 0, COLLATERAL, false)
 
         await nextWithConstantPrice()
-        const tx = await settle(market, userB)
+        const tx = await sync(market, userB)
         const accountProcessEventShort: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
         )?.args as unknown as AccountPositionProcessedEventObject
@@ -1490,7 +1490,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        await settle(market, userB)
+        await sync(market, userB)
 
         // Enable position fee to test refund
         const riskParams = await market.riskParameter()
@@ -1508,7 +1508,7 @@ describe('Fees', () => {
           ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, LONG_POSITION, 0, COLLATERAL, false)
 
         await nextWithConstantPrice()
-        const tx = await settle(market, userC)
+        const tx = await sync(market, userC)
         const accountProcessEventShort: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
         )?.args as unknown as AccountPositionProcessedEventObject
@@ -1539,7 +1539,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        await settle(market, userB)
+        await sync(market, userB)
 
         // Enable position fee to test refund
         const riskParams = await market.riskParameter()
@@ -1557,7 +1557,7 @@ describe('Fees', () => {
           ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, LONG_POSITION, 0, COLLATERAL, false)
 
         await nextWithConstantPrice()
-        const tx = await settle(market, userC)
+        const tx = await sync(market, userC)
         const accountProcessEventShort: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
         )?.args as unknown as AccountPositionProcessedEventObject
@@ -1612,7 +1612,7 @@ describe('Fees', () => {
           .connect(user)
           ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, MAKER_POSITION, 0, 0, COLLATERAL, false)
         await nextWithConstantPrice()
-        await settle(market, user)
+        await sync(market, user)
 
         await market.updateParameter({
           ...marketParams,
@@ -1635,7 +1635,7 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const tx = await settle(market, instanceVars.user)
+        const tx = await sync(market, instanceVars.user)
 
         const accountProcessEvent: AccountPositionProcessedEventObject = (await tx.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
@@ -1669,8 +1669,8 @@ describe('Fees', () => {
           )
 
         await nextWithConstantPrice()
-        const txB = await settle(market, userB)
-        const txC = await settle(market, userC)
+        const txB = await sync(market, userB)
+        const txC = await sync(market, userC)
 
         const accountProcessEventB: AccountPositionProcessedEventObject = (await txB.wait()).events?.find(
           e => e.event === 'AccountPositionProcessed',
@@ -1732,7 +1732,7 @@ describe('Fees', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, MAKER_POSITION, 0, 0, COLLATERAL, false)
       await nextWithConstantPrice()
-      await settle(market, user)
+      await sync(market, user)
     })
 
     it('charges interest fee for long position', async () => {
@@ -1743,13 +1743,13 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, LONG_POSITION, 0, COLLATERAL, false)
 
       await nextWithConstantPrice()
-      await settle(market, userB)
+      await sync(market, userB)
 
       await nextWithConstantPrice()
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await sync(market, userB)
       const [accountProcessEvents, positionProcessEvents] = await getOrderProcessingEvents(tx)
 
       // payoffPrice = 3374.655169**2 * 0.00001 = 113.882975
@@ -1781,13 +1781,13 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, SHORT_POSITION, COLLATERAL, false)
 
       await nextWithConstantPrice()
-      await settle(market, userB)
+      await sync(market, userB)
 
       await nextWithConstantPrice()
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await sync(market, userB)
       const [accountProcessEvents, positionProcessEvents] = await getOrderProcessingEvents(tx)
 
       // payoffPrice = 3374.655169**2 * 0.00001 = 113.882975
@@ -1850,7 +1850,7 @@ describe('Fees', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, MAKER_POSITION, 0, 0, COLLATERAL, false)
       await nextWithConstantPrice()
-      await settle(market, user)
+      await sync(market, user)
     })
 
     it('charges funding fee for long position', async () => {
@@ -1861,13 +1861,13 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, LONG_POSITION, 0, COLLATERAL, false)
 
       await nextWithConstantPrice()
-      await settle(market, userB)
+      await sync(market, userB)
 
       await nextWithConstantPrice()
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await sync(market, userB)
       const [accountProcessEvents, positionProcessEvents] = await getOrderProcessingEvents(tx)
 
       const expectedFunding = BigNumber.from('21259')
@@ -1899,13 +1899,13 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, SHORT_POSITION, COLLATERAL, false)
 
       await nextWithConstantPrice()
-      await settle(market, userB)
+      await sync(market, userB)
 
       await nextWithConstantPrice()
       await nextWithConstantPrice()
       await nextWithConstantPrice()
 
-      const tx = await settle(market, userB)
+      const tx = await sync(market, userB)
       const [accountProcessEvents, positionProcessEvents] = await getOrderProcessingEvents(tx)
 
       const expectedFunding = BigNumber.from('21259')
@@ -1982,8 +1982,8 @@ describe('Fees', () => {
         makerReferral: expectedReferral,
       })
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userB)
+      await sync(market, user)
+      await sync(market, userB)
 
       // ensure the proper amount of the base fee is claimable by the referrer
       // makerFee = position * makerFee * price = 3 * 0.05 * 113.882975 = 17.082446
@@ -2038,9 +2038,9 @@ describe('Fees', () => {
         takerReferral: expectedReferral,
       })
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userB)
-      await settle(market, userC)
+      await sync(market, user)
+      await sync(market, userB)
+      await sync(market, userC)
 
       // ensure the proper amount of the base fee is claimable by the referrer
       // takerFee = position * takerFee * price = 3 * 0.025 * 113.882975 = 8.541223
@@ -2087,8 +2087,8 @@ describe('Fees', () => {
         makerReferral: expectedReferral,
       })
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userB)
+      await sync(market, user)
+      await sync(market, userB)
 
       // ensure the proper amount of the base fee is claimable by the referrer
       // makerFee = position * makerFee * price = 3 * 0.05 * 113.882975 = 17.082446
@@ -2145,9 +2145,9 @@ describe('Fees', () => {
 
       // settle all users
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userB)
-      await settle(market, userC)
+      await sync(market, user)
+      await sync(market, userB)
+      await sync(market, userC)
 
       // userB claims the maker referral fee at the default rate
       // makerFee = position * makerFee * price = 6 * 0.05 * 113.882975 = 34.164892
@@ -2198,8 +2198,8 @@ describe('Fees', () => {
 
       // settle relevant users
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userD)
+      await sync(market, user)
+      await sync(market, userD)
 
       // user claims both taker referral fees
       // takerFee = position * takerFee * price = 2 * 0.025 * 113.882975 = 5.694148
@@ -2249,9 +2249,9 @@ describe('Fees', () => {
         takerReferral: expectedReferral,
       })
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userB)
-      await settle(market, userC) // update userC to clear values
+      await sync(market, user)
+      await sync(market, userB)
+      await sync(market, userC) // update userC to clear values
       expect(await market.orderReferrers(userC.address, currentId)).to.equal(userB.address)
       expect((await market.locals(userC.address)).currentId).to.equal(currentId)
 
@@ -2275,9 +2275,9 @@ describe('Fees', () => {
         ['update(address,uint256,uint256,uint256,int256,bool,address)'](userC.address, 0, 0, 0, 0, false, user.address)
 
       await nextWithConstantPrice()
-      await settle(market, user)
-      await settle(market, userB)
-      await settle(market, userC)
+      await sync(market, user)
+      await sync(market, userB)
+      await sync(market, userC)
 
       // ensure the proper amount of the base fee is claimable by the referrer
       // takerFee = position * linearFee * price = 3 * 0.025 * 113.882975 = 8.541223

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -3,7 +3,7 @@ import 'hardhat'
 import { BigNumber, constants } from 'ethers'
 const { AddressZero } = constants
 
-import { InstanceVars, deployProtocol, createMarket, settle } from '../helpers/setupHelpers'
+import { InstanceVars, deployProtocol, createMarket, sync } from '../helpers/setupHelpers'
 import {
   DEFAULT_ORDER,
   DEFAULT_POSITION,
@@ -188,7 +188,7 @@ describe('Happy Path', () => {
 
     // Settle the market with a new oracle version
     await chainlink.next()
-    await settle(market, user)
+    await sync(market, user)
 
     // check user state
     expectLocalEq(await market.locals(user.address), {
@@ -306,7 +306,7 @@ describe('Happy Path', () => {
 
     // Settle the market with a new oracle version
     await chainlink.next()
-    await settle(market, user)
+    await sync(market, user)
 
     // check user state
     expectLocalEq(await market.locals(user.address), {
@@ -619,7 +619,7 @@ describe('Happy Path', () => {
 
     // Another round
     await chainlink.next()
-    await settle(market, userB)
+    await sync(market, userB)
 
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
@@ -757,7 +757,7 @@ describe('Happy Path', () => {
 
     // Another round
     await chainlink.next()
-    await settle(market, userB)
+    await sync(market, userB)
 
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
@@ -989,8 +989,8 @@ describe('Happy Path', () => {
 
     const market = await createMarket(instanceVars)
 
-    await settle(market, user)
-    await settle(market, user)
+    await sync(market, user)
+    await sync(market, user)
   })
 
   it('disables actions when paused', async () => {
@@ -1003,7 +1003,7 @@ describe('Happy Path', () => {
         .connect(user)
         ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, parse6decimal('1000'), false),
     ).to.be.revertedWithCustomError(market, 'InstancePausedError')
-    await expect(settle(market, user)).to.be.revertedWithCustomError(market, 'InstancePausedError')
+    await expect(sync(market, user)).to.be.revertedWithCustomError(market, 'InstancePausedError')
   })
 
   it('opens a long position and settles after max funding', async () => {
@@ -1046,12 +1046,12 @@ describe('Happy Path', () => {
     for (let i = 0; i < 50; i++) {
       await chainlink.next()
     }
-    await settle(market, userB)
+    await sync(market, userB)
     expect((await market.global()).pAccumulator._value).to.eq(parse6decimal('1.20'))
 
     // one more round
     await chainlink.next()
-    await settle(market, userB)
+    await sync(market, userB)
     expect((await market.global()).pAccumulator._value).to.eq(parse6decimal('1.20'))
   })
 
@@ -1095,12 +1095,12 @@ describe('Happy Path', () => {
     for (let i = 0; i < 50; i++) {
       await chainlink.next()
     }
-    await settle(market, userB)
+    await sync(market, userB)
     expect((await market.global()).pAccumulator._value).to.eq(parse6decimal('-1.20'))
 
     // one more round
     await chainlink.next()
-    await settle(market, userB)
+    await sync(market, userB)
     expect((await market.global()).pAccumulator._value).to.eq(parse6decimal('-1.20'))
   })
 

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -281,6 +281,6 @@ export async function createMarket(
   return market
 }
 
-export async function settle(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
-  return market.connect(account).settle(account.address)
+export async function sync(market: IMarket, account: SignerWithAddress): Promise<ContractTransaction> {
+  return market.connect(account).sync(account.address)
 }


### PR DESCRIPTION
#### Background
During settle-only mode, new prices can still be committed un-requested causing a new version to cut via `sync()`.

This makes it very hard to ensure all local accounts are synced up to the latest global during an sync migration.

#### Changes
- Splits settle() and sync()
  - `settle()` only settles up to latest order
  - `sync()` settles and then syncs up to the latest timestamp
- Make settle-only mode only allow settle()

#### Migration Notes
While this makes migrations significantly safer, we still require the `makerValue`/`longValue`/`shortValue` to be continually backwards compatible in `Version`.