### PR TITLE
Re-add staleAfter exceptions

### DIFF
--- a/packages/perennial/contracts/libs/InvariantLib.sol
+++ b/packages/perennial/contracts/libs/InvariantLib.sol
@@ -37,8 +37,11 @@ library InvariantLib {
             !newOrder.collateral.eq(Fixed6Lib.ZERO)                                     // the order is modifying collateral
         )) revert IMarket.MarketInvalidProtectionError();
 
-        if (context.currentTimestamp - context.latestOracleVersion.timestamp >= context.riskParameter.staleAfter)
-            revert IMarket.MarketStalePriceError();
+        if (
+            !(updateContext.currentPositionLocal.magnitude().isZero() && context.latestPositionLocal.magnitude().isZero()) &&       // sender has no position
+            !(newOrder.isEmpty() && newOrder.collateral.gte(Fixed6Lib.ZERO)) &&                                                     // sender is depositing zero or more into account, without position change
+            (context.currentTimestamp - context.latestOracleVersion.timestamp >= context.riskParameter.staleAfter)                  // price is not stale
+        ) revert IMarket.MarketStalePriceError();
 
         if (context.marketParameter.closed && newOrder.increasesPosition())
             revert IMarket.MarketClosedError();

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -1725,6 +1725,116 @@ describe('Market', () => {
             liquidationFee: { _value: -riskParameter.liquidationFee },
           })
         })
+
+        it('deposits and withdraws (next - stale)', async () => {
+          dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          await expect(
+            market
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false),
+          )
+            .to.emit(market, 'OrderCreated')
+            .withArgs(
+              user.address,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_2.timestamp, collateral: COLLATERAL },
+              { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
+            )
+
+          expectLocalEq(await market.locals(user.address), {
+            ...DEFAULT_LOCAL,
+            currentId: 1,
+            collateral: COLLATERAL,
+          })
+          expectPositionEq(await market.positions(user.address), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_1.timestamp,
+          })
+          expectOrderEq(await market.pendingOrders(user.address, 1), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            collateral: COLLATERAL,
+          })
+          expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_2.timestamp), {
+            ...DEFAULT_CHECKPOINT,
+          })
+          expectGlobalEq(await market.global(), {
+            ...DEFAULT_GLOBAL,
+            currentId: 1,
+          })
+          expectPositionEq(await market.position(), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_1.timestamp,
+          })
+          expectOrderEq(await market.pendingOrder(1), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_2.timestamp,
+            collateral: COLLATERAL,
+          })
+          expectVersionEq(await market.versions(ORACLE_VERSION_1.timestamp), {
+            ...DEFAULT_VERSION,
+            price: PRICE,
+            liquidationFee: { _value: -riskParameter.liquidationFee },
+          })
+
+          oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
+          oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_6.timestamp])
+          oracle.request.whenCalledWith(user.address).returns()
+
+          await settle(market, user)
+
+          dsu.transfer.whenCalledWith(user.address, COLLATERAL.mul(1e12)).returns(true)
+          await expect(
+            market
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL.mul(-1), false),
+          )
+            .to.emit(market, 'OrderCreated')
+            .withArgs(
+              user.address,
+              { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_6.timestamp, collateral: COLLATERAL.mul(-1) },
+              { ...DEFAULT_GUARANTEE },
+              constants.AddressZero,
+              constants.AddressZero,
+              constants.AddressZero,
+            )
+
+          expectLocalEq(await market.locals(user.address), {
+            ...DEFAULT_LOCAL,
+            currentId: 2,
+            latestId: 1,
+          })
+          expectPositionEq(await market.positions(user.address), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_2.timestamp,
+          })
+          expectOrderEq(await market.pendingOrders(user.address, 2), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_6.timestamp,
+            collateral: -COLLATERAL,
+          })
+          expectGlobalEq(await market.global(), {
+            ...DEFAULT_GLOBAL,
+            currentId: 2,
+            latestId: 1,
+          })
+          expectPositionEq(await market.position(), {
+            ...DEFAULT_POSITION,
+            timestamp: ORACLE_VERSION_2.timestamp,
+          })
+          expectOrderEq(await market.pendingOrder(2), {
+            ...DEFAULT_ORDER,
+            timestamp: ORACLE_VERSION_6.timestamp,
+            collateral: -COLLATERAL,
+          })
+          expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
+            ...DEFAULT_VERSION,
+            price: PRICE,
+            liquidationFee: { _value: -riskParameter.liquidationFee },
+          })
+        })
       })
 
       context('make position', async () => {
@@ -11327,6 +11437,139 @@ describe('Market', () => {
                 longPos: POSITION.div(2),
                 shortPos: POSITION,
                 collateral: COLLATERAL.mul(3),
+              })
+              expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
+                ...DEFAULT_VERSION,
+                makerValue: {
+                  _value: EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)
+                    .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
+                    .div(10)
+                    .sub(1), // loss of precision
+                },
+                longValue: {
+                  _value: EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)
+                    .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3))
+                    .div(5)
+                    .sub(1), // loss of precision
+                },
+                shortValue: {
+                  _value: EXPECTED_FUNDING_WITH_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_10_67_123_ALL.mul(2).div(3))
+                    .div(10)
+                    .mul(-1)
+                    .sub(1), // loss of precision
+                },
+                price: PRICE,
+                liquidationFee: { _value: -riskParameter.liquidationFee },
+              })
+            })
+
+            it('opens the position and deposits later from different account while stale', async () => {
+              await expect(
+                market
+                  .connect(user)
+                  ['update(address,uint256,uint256,uint256,int256,bool)'](
+                    user.address,
+                    0,
+                    POSITION.div(2),
+                    0,
+                    COLLATERAL,
+                    false,
+                  ),
+              )
+                .to.emit(market, 'OrderCreated')
+                .withArgs(
+                  user.address,
+                  {
+                    ...DEFAULT_ORDER,
+                    timestamp: ORACLE_VERSION_2.timestamp,
+                    orders: 1,
+                    longPos: POSITION.div(2),
+                    collateral: COLLATERAL,
+                  },
+                  { ...DEFAULT_GUARANTEE },
+                  constants.AddressZero,
+                  constants.AddressZero,
+                  constants.AddressZero,
+                )
+
+              oracle.at
+                .whenCalledWith(ORACLE_VERSION_2.timestamp)
+                .returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
+
+              oracle.at
+                .whenCalledWith(ORACLE_VERSION_3.timestamp)
+                .returns([ORACLE_VERSION_3, INITIALIZED_ORACLE_RECEIPT])
+              oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_6.timestamp])
+              oracle.request.returns()
+
+              await deposit(market, COLLATERAL, user, userB)
+              await deposit(market, COLLATERAL, userB, user)
+
+              expectLocalEq(await market.locals(user.address), {
+                ...DEFAULT_LOCAL,
+                currentId: 2,
+                latestId: 1,
+                collateral: COLLATERAL.add(COLLATERAL)
+                  .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2)) // 50% to long, 50% to maker
+                  .sub(EXPECTED_INTEREST_10_67_123_ALL.div(3)) // 33% from long, 67% from short
+                  .sub(2), // loss of precision
+              })
+              expectPositionEq(await market.positions(user.address), {
+                ...DEFAULT_POSITION,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                long: POSITION.div(2),
+              })
+              expectOrderEq(await market.pendingOrders(user.address, 2), {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_6.timestamp,
+                collateral: COLLATERAL,
+              })
+              expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_6.timestamp), {
+                ...DEFAULT_CHECKPOINT,
+              })
+              expectLocalEq(await market.locals(userB.address), {
+                ...DEFAULT_LOCAL,
+                currentId: 2,
+                latestId: 1,
+                collateral: COLLATERAL.add(COLLATERAL)
+                  .add(EXPECTED_FUNDING_WITHOUT_FEE_1_10_123_ALL.div(2))
+                  .add(EXPECTED_INTEREST_WITHOUT_FEE_10_67_123_ALL)
+                  .sub(13), // loss of precision
+              })
+              expectPositionEq(await market.positions(userB.address), {
+                ...DEFAULT_POSITION,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                maker: POSITION,
+              })
+              expectOrderEq(await market.pendingOrders(userB.address, 2), {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_6.timestamp,
+                collateral: COLLATERAL,
+              })
+              expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_6.timestamp), {
+                ...DEFAULT_CHECKPOINT,
+              })
+              const totalFee = EXPECTED_FUNDING_FEE_1_10_123_ALL.add(EXPECTED_INTEREST_FEE_10_67_123_ALL)
+              expectGlobalEq(await market.global(), {
+                currentId: 2,
+                latestId: 1,
+                protocolFee: totalFee.div(2).sub(3), // loss of precision
+                oracleFee: totalFee.div(2).div(10),
+                riskFee: totalFee.div(2).div(10),
+                donation: totalFee.div(2).mul(8).div(10),
+                exposure: 0,
+              })
+              expectPositionEq(await market.position(), {
+                ...DEFAULT_POSITION,
+                timestamp: ORACLE_VERSION_3.timestamp,
+                maker: POSITION,
+                long: POSITION.div(2),
+                short: POSITION,
+              })
+              expectOrderEq(await market.pendingOrder(2), {
+                ...DEFAULT_ORDER,
+                timestamp: ORACLE_VERSION_6.timestamp,
+                collateral: COLLATERAL.mul(2),
               })
               expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
                 ...DEFAULT_VERSION,


### PR DESCRIPTION
Re-adds UX-based exceptions to the stale price check in the invairant:
 - No longer need a fresh price for deposits
 - No longer need a fresh price for withdrawals when there is no position in the account