### PR TITLE
Remove newPrice request option

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -61,6 +61,7 @@ export interface Global {
   oracleFee: BigNumberish
   riskFee: BigNumberish
   donation: BigNumberish
+  latestPrice: BigNumberish
   exposure: BigNumberish
 }
 
@@ -136,6 +137,7 @@ export function expectGlobalEq(a: Global, b: Global): void {
   expect(a.oracleFee).to.equal(b.oracleFee, 'Global:OracleFee')
   expect(a.riskFee).to.equal(b.riskFee, 'Global:RiskFee')
   expect(a.donation).to.equal(b.donation, 'Global:Donation')
+  expect(a.latestPrice).to.equal(b.latestPrice, 'Global:LatestPrice')
   expect(a.exposure).to.equal(b.exposure, 'Global:Exposure')
 }
 
@@ -210,6 +212,7 @@ export const DEFAULT_GLOBAL: Global = {
   oracleFee: 0,
   riskFee: 0,
   donation: 0,
+  latestPrice: 0,
   exposure: 0,
 }
 

--- a/packages/perennial-oracle/contracts/Oracle.sol
+++ b/packages/perennial-oracle/contracts/Oracle.sol
@@ -43,13 +43,12 @@ contract Oracle is IOracle, Instance {
 
     /// @notice Requests a new version at the current timestamp
     /// @param account Original sender to optionally use for callbacks
-    /// @param newPrice Whether a new price should be requested
-    function request(IMarket, address account, bool newPrice) external onlyMarket {
+    function request(IMarket, address account) external onlyMarket {
         (OracleVersion memory latestVersion, uint256 currentTimestamp) = oracles[global.current].provider.status();
 
         oracles[
             (currentTimestamp > oracles[global.latest].timestamp) ? global.current : global.latest
-        ].provider.request(market, account, newPrice);
+        ].provider.request(market, account);
 
         oracles[global.current].timestamp = uint96(currentTimestamp);
         _updateLatest(latestVersion);

--- a/packages/perennial-oracle/contracts/interfaces/IKeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/interfaces/IKeeperOracle.sol
@@ -57,6 +57,5 @@ interface IKeeperOracle is IOracleProvider, IInstance {
     function oracle() external view returns (IOracle);
     function requests(uint256 index) external view returns (PriceRequest memory);
     function responses(uint256 timestamp) external view returns (PriceResponse memory);
-    function linkbacks(uint256 timestamp) external view returns (uint256);
     function global() external view returns (Global memory);
 }

--- a/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -1325,52 +1325,6 @@ testOracles.forEach(testOracle => {
         expect((await keeperOracle.global()).currentIndex).to.equal(1)
       })
 
-      it('can request a version (no new price)', async () => {
-        await includeAt(
-          async () =>
-            await market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                1,
-                0,
-                0,
-                parse6decimal('10'),
-                false,
-              ), // make request to oracle (new price)
-          STARTING_TIME,
-        )
-
-        // One requested version
-        expect((await keeperOracle.global()).currentIndex).to.equal(1)
-        await expect(
-          includeAt(
-            async () =>
-              await market
-                .connect(user)
-                ['update(address,uint256,uint256,uint256,int256,bool)'](
-                  user.address,
-                  1,
-                  0,
-                  0,
-                  parse6decimal('10'),
-                  false,
-                ), // make request to oracle (no new price)
-            STARTING_TIME + 10,
-          ),
-        )
-          .to.emit(keeperOracle, 'OracleProviderVersionRequested')
-          .withArgs('1686198991', false)
-
-        // Should link back to requested version
-        expect((await keeperOracle.requests(1)).timestamp).to.be.equal(STARTING_TIME)
-        expect((await keeperOracle.requests(1)).syncFee).to.be.equal(parse6decimal('1.0'))
-        expect((await keeperOracle.requests(1)).asyncFee).to.be.equal(parse6decimal('0.5'))
-        expect((await keeperOracle.requests(1)).oracleFee).to.be.equal(parse6decimal('0.1'))
-        expect(await keeperOracle.linkbacks(STARTING_TIME + 10)).to.equal(STARTING_TIME)
-        expect((await keeperOracle.global()).currentIndex).to.equal(1)
-      })
-
       it('can request a version w/ granularity', async () => {
         const parameter = await pythOracleFactory.parameter()
         await pythOracleFactory.updateParameter(
@@ -1405,7 +1359,7 @@ testOracles.forEach(testOracle => {
         const badSigner = await impersonateWithBalance(badInstance.address, utils.parseEther('10'))
 
         await expect(
-          keeperOracle.connect(badSigner).request(market.address, user.address, true),
+          keeperOracle.connect(badSigner).request(market.address, user.address),
         ).to.be.revertedWithCustomError(keeperOracle, 'KeeperOracleNotOracleError')
       })
 
@@ -1431,110 +1385,6 @@ testOracles.forEach(testOracle => {
         expect((await keeperOracle.requests(2)).syncFee).to.be.equal(0)
         expect((await keeperOracle.requests(2)).asyncFee).to.be.equal(0)
         expect((await keeperOracle.requests(2)).oracleFee).to.be.equal(0)
-      })
-
-      it('a version can only be requested once (no new, no new)', async () => {
-        await includeAt(
-          async () =>
-            await market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                1,
-                0,
-                0,
-                parse6decimal('10'),
-                false,
-              ), // make request to oracle (new price)
-          STARTING_TIME,
-        )
-
-        await includeAt(async () => {
-          await market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 1, 0, 0, parse6decimal('10'), false) // make request to oracle (no new price)
-          await market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 1, 0, 0, parse6decimal('10'), false) // make request to oracle (no new price)
-        }, STARTING_TIME + 10)
-
-        const currentTimestamp = await pythOracleFactory.current()
-        expect((await keeperOracle.requests(1)).timestamp).to.be.equal(STARTING_TIME)
-        expect((await keeperOracle.requests(1)).syncFee).to.be.equal(parse6decimal('1.0'))
-        expect((await keeperOracle.requests(1)).asyncFee).to.be.equal(parse6decimal('0.5'))
-        expect((await keeperOracle.requests(1)).oracleFee).to.be.equal(parse6decimal('0.1'))
-        expect(await keeperOracle.linkbacks(currentTimestamp)).to.equal(STARTING_TIME)
-        expect((await keeperOracle.requests(2)).timestamp).to.be.equal(0)
-        expect((await keeperOracle.requests(2)).syncFee).to.be.equal(0)
-        expect((await keeperOracle.requests(2)).asyncFee).to.be.equal(0)
-        expect((await keeperOracle.requests(2)).oracleFee).to.be.equal(0)
-        expect((await keeperOracle.global()).currentIndex).to.equal(1)
-      })
-
-      it('a version can only be requested once (new, no new)', async () => {
-        await ethers.provider.send('evm_setAutomine', [false])
-        await ethers.provider.send('evm_setIntervalMining', [0])
-
-        await market
-          .connect(user)
-          ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 1, 0, 0, parse6decimal('10'), false) // make request to oracle (new price)
-        await market
-          .connect(user)
-          ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 1, 0, 0, parse6decimal('10'), false) // make request to oracle (no new price)
-
-        await ethers.provider.send('evm_mine', [])
-
-        const currentTimestamp = await pythOracleFactory.current()
-        expect((await keeperOracle.requests(1)).timestamp).to.be.equal(currentTimestamp)
-        expect((await keeperOracle.requests(1)).syncFee).to.be.equal(parse6decimal('1.0'))
-        expect((await keeperOracle.requests(1)).asyncFee).to.be.equal(parse6decimal('0.5'))
-        expect((await keeperOracle.requests(1)).oracleFee).to.be.equal(parse6decimal('0.1'))
-        expect((await keeperOracle.requests(2)).timestamp).to.be.equal(0)
-        expect((await keeperOracle.requests(2)).syncFee).to.be.equal(0)
-        expect((await keeperOracle.requests(2)).asyncFee).to.be.equal(0)
-        expect((await keeperOracle.requests(2)).oracleFee).to.be.equal(0)
-        expect(await keeperOracle.linkbacks(currentTimestamp)).to.equal(0)
-      })
-
-      it('a new price request will overtake a previous no new price request', async () => {
-        await includeAt(
-          async () =>
-            await market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                1,
-                0,
-                0,
-                parse6decimal('10'),
-                false,
-              ), // make request to oracle (new price)
-          STARTING_TIME,
-        )
-
-        expect((await keeperOracle.global()).currentIndex).to.equal(1)
-
-        // One requested version
-        await includeAt(async () => {
-          await market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 1, 0, 0, parse6decimal('10'), false) // make request to oracle (no new price)
-          await market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 2, 0, 0, 0, false) // make request to oracle (new price)
-        }, STARTING_TIME + 10)
-
-        const currentTimestamp = await pythOracleFactory.current()
-        expect((await keeperOracle.requests(1)).timestamp).to.be.equal(currentTimestamp.sub(10))
-        expect((await keeperOracle.requests(1)).syncFee).to.be.equal(parse6decimal('1.0'))
-        expect((await keeperOracle.requests(1)).asyncFee).to.be.equal(parse6decimal('0.5'))
-        expect((await keeperOracle.requests(1)).oracleFee).to.be.equal(parse6decimal('0.1'))
-        expect((await keeperOracle.requests(2)).timestamp).to.be.equal(currentTimestamp)
-        expect((await keeperOracle.requests(2)).syncFee).to.be.equal(parse6decimal('1.0'))
-        expect((await keeperOracle.requests(2)).asyncFee).to.be.equal(parse6decimal('0.5'))
-        expect((await keeperOracle.requests(2)).oracleFee).to.be.equal(parse6decimal('0.1'))
-        expect(await keeperOracle.linkbacks(currentTimestamp)).to.equal(0)
-        expect(await keeperOracle.linkbacks(currentTimestamp)).to.equal(0)
       })
     })
 
@@ -1805,113 +1655,6 @@ testOracles.forEach(testOracle => {
         })
         const version = await keeperOracle.connect(user).at(STARTING_TIME + 1)
         expect(version[0].price).to.equal('1838167031')
-        expect(version[0].valid).to.equal(true)
-        expect(version[1].settlementFee).to.equal(parse6decimal('1.5'))
-        expect(version[1].oracleFee).to.equal(parse6decimal('0.1'))
-      })
-
-      it('returns the receipt w/ no new price', async () => {
-        const parameter = await pythOracleFactory.parameter()
-        await pythOracleFactory
-          .connect(owner)
-          .updateParameter(
-            1,
-            parse6decimal('1.0'),
-            parse6decimal('0.5'),
-            parse6decimal('0.1'),
-            parameter.validFrom,
-            parameter.validTo,
-          )
-        await includeAt(
-          async () =>
-            await market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                1,
-                0,
-                0,
-                parse6decimal('10'),
-                false,
-              ), // make request to oracle (new price)
-          STARTING_TIME + 1,
-        )
-
-        await includeAt(
-          async () =>
-            await market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                1,
-                0,
-                0,
-                parse6decimal('10'),
-                false,
-              ), // make request to oracle (no new price)
-          STARTING_TIME + 3,
-        )
-
-        await pythOracleFactory.connect(owner).updateParameter(1, 0, 0, 0, parameter.validFrom, parameter.validTo)
-        await pythOracleFactory.connect(user).commit([PYTH_ETH_USD_PRICE_FEED], STARTING_TIME + 1, VAA, {
-          value: 1,
-        })
-        const version = await keeperOracle.connect(user).at(STARTING_TIME + 3)
-        expect(version[0].price).to.equal('1838167031')
-        expect(version[0].valid).to.equal(true)
-        expect(version[1].settlementFee).to.equal(0)
-        expect(version[1].oracleFee).to.equal(0)
-      })
-
-      it('returns the receipt w/ new price after no new price', async () => {
-        const parameter = await pythOracleFactory.parameter()
-        await pythOracleFactory
-          .connect(owner)
-          .updateParameter(
-            3,
-            parse6decimal('1.0'),
-            parse6decimal('0.5'),
-            parse6decimal('0.1'),
-            parameter.validFrom,
-            parameter.validTo,
-          )
-        await includeAt(
-          async () =>
-            await market
-              .connect(user)
-              ['update(address,uint256,uint256,uint256,int256,bool)'](
-                user.address,
-                1,
-                0,
-                0,
-                parse6decimal('10'),
-                false,
-              ), // make request to oracle (new price)
-          STARTING_TIME + 3,
-        )
-
-        await pythOracleFactory.connect(user).commit([PYTH_ETH_USD_PRICE_FEED], STARTING_TIME + 3, OTHER_VAA, {
-          value: 1,
-        })
-
-        // get both requests in the same version
-        await includeAt(async () => {
-          await market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 1, 0, 0, parse6decimal('10'), false) // make request to oracle (no new price)
-          await market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 2, 0, 0, 0, false) // make request to oracle (new price)
-        }, STARTING_TIME + 57)
-
-        await pythOracleFactory.connect(owner).updateParameter(1, 0, 0, 0, parameter.validFrom, parameter.validTo)
-        await pythOracleFactory
-          .connect(user)
-          .commit([PYTH_ETH_USD_PRICE_FEED], STARTING_TIME + 57, VAA_AFTER_EXPIRATION, {
-            value: 1,
-          })
-        const version = await keeperOracle.connect(user).at(STARTING_TIME + 57)
-        expect(version[0].price).to.equal('1837350000')
         expect(version[0].valid).to.equal(true)
         expect(version[1].settlementFee).to.equal(parse6decimal('1.5'))
         expect(version[1].oracleFee).to.equal(parse6decimal('0.1'))

--- a/packages/perennial-oracle/test/unit/chainlink/ChainlinkFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/chainlink/ChainlinkFactory.test.ts
@@ -154,7 +154,7 @@ describe('ChainlinkFactory', () => {
   })
 
   it('parses Chainlink report correctly', async () => {
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
 
     const report = listify(
       overwriteTimestamp(
@@ -176,7 +176,7 @@ describe('ChainlinkFactory', () => {
   })
 
   it('commit reverts if msg.value is too low', async () => {
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
 
     const report = listify(
       overwriteTimestamp(

--- a/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/KeeperOracle.test.ts
@@ -185,12 +185,6 @@ describe('KeeperOracle', () => {
     ).to.be.revertedWithCustomError(keeperOracle, 'KeeperOracleVersionOutsideRangeError')
   })
 
-  it('reverts requesting no new price before a new price', async () => {
-    await expect(
-      keeperOracle.connect(oracleSigner).request(market.address, user.address, false),
-    ).to.revertedWithCustomError(keeperOracle, 'KeeperOracleNoPriorRequestsError')
-  })
-
   it('discards expired prices', async () => {
     // establish an initial valid version
     const startTime = await currentBlockTimestamp()
@@ -199,7 +193,7 @@ describe('KeeperOracle', () => {
 
     // request a version
     await increase(10)
-    const tx = await keeperOracle.connect(oracleSigner).request(market.address, user.address, true, {
+    const tx = await keeperOracle.connect(oracleSigner).request(market.address, user.address, {
       maxFeePerGas: 100000000,
     })
     // TODO: weaponize this transaction-to-blocktime facility into a utility function

--- a/packages/perennial-oracle/test/unit/oracle/Oracle.test.ts
+++ b/packages/perennial-oracle/test/unit/oracle/Oracle.test.ts
@@ -240,7 +240,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687230000)
         expect(latestVersion.price).to.equal(parse6decimal('1000'))
@@ -297,7 +297,7 @@ describe('Oracle', () => {
           },
           1687230905,
         )
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
         await expect(oracle.connect(oracleFactorySigner).update(underlying1.address))
           .to.emit(oracle, 'OracleUpdated')
           .withArgs(underlying1.address)
@@ -344,7 +344,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687230005)
         expect(latestVersion.price).to.equal(parse6decimal('1001'))
@@ -396,7 +396,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687230605)
         expect(latestVersion.price).to.equal(parse6decimal('1006'))
@@ -448,7 +448,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687230905)
         expect(latestVersion.price).to.equal(parse6decimal('1006'))
@@ -511,7 +511,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687230905)
         expect(latestVersion.price).to.equal(parse6decimal('1006'))
@@ -563,7 +563,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687230955)
         expect(latestVersion.price).to.equal(parse6decimal('1007'))
@@ -609,7 +609,7 @@ describe('Oracle', () => {
           },
           1687231005,
         )
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         mockVersion(
           underlying1,
@@ -630,7 +630,7 @@ describe('Oracle', () => {
 
         const [latestVersionDirect, currentTimestampDirect] = [await oracle.latest(), await oracle.current()]
         const [latestVersion, currentTimestamp] = await oracle.status()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect(latestVersion.timestamp).to.equal(1687235000)
         expect(latestVersion.price).to.equal(parse6decimal('1015'))
@@ -680,7 +680,7 @@ describe('Oracle', () => {
         underlying0.request.reset()
         underlying1.request.reset()
 
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect((await oracle.at(0))[0].timestamp).to.equal(0)
         expect((await oracle.at(0))[0].price).to.equal(parse6decimal('0'))
@@ -748,7 +748,7 @@ describe('Oracle', () => {
           },
           1687230905,
         )
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         mockVersion(
           underlying0,
@@ -847,7 +847,7 @@ describe('Oracle', () => {
         )
         underlying1.request.reset()
         underlying2.request.reset()
-        await oracle.connect(marketSigner).request(market.address, user.address, true)
+        await oracle.connect(marketSigner).request(market.address, user.address)
 
         expect((await oracle.global()).latest).to.equal(2)
         expect((await oracle.oracles(1)).timestamp).to.equal(0)
@@ -934,7 +934,7 @@ describe('Oracle', () => {
     })
 
     it('reverts when not the authorized', async () => {
-      await expect(oracle.connect(user).request(market.address, user.address, true)).to.revertedWithCustomError(
+      await expect(oracle.connect(user).request(market.address, user.address)).to.revertedWithCustomError(
         oracle,
         'OracleNotMarketError',
       )

--- a/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
@@ -131,7 +131,7 @@ describe('PythOracleFactory', () => {
 
   it('parses Pyth exponents correctly', async () => {
     const minDelay = (await pythOracleFactory.parameter()).validFrom
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
     await pythOracleFactory
       .connect(user)
       .commit(
@@ -144,7 +144,7 @@ describe('PythOracleFactory', () => {
       )
     expect((await keeperOracle.callStatic.latest()).price).to.equal(ethers.utils.parseUnits('1000', 6))
 
-    await keeperOracle.connect(oracleSigner).request(market.address, user.address, true)
+    await keeperOracle.connect(oracleSigner).request(market.address, user.address)
     await pythOracleFactory
       .connect(user)
       .commit(

--- a/packages/perennial/contracts/interfaces/IOracleProvider.sol
+++ b/packages/perennial/contracts/interfaces/IOracleProvider.sol
@@ -22,7 +22,7 @@ interface IOracleProvider {
     event OracleProviderVersionRequested(uint256 indexed version, bool newPrice);
     event OracleProviderVersionFulfilled(OracleVersion version);
 
-    function request(IMarket market, address account, bool newPrice) external;
+    function request(IMarket market, address account) external;
     function status() external view returns (OracleVersion memory, uint256);
     function latest() external view returns (OracleVersion memory);
     function current() external view returns (uint256);

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -110,6 +110,7 @@ library VersionLib {
 
         // record oracle version
         (next.valid, next.price) = (context.toOracleVersion.valid, context.toOracleVersion.price);
+        context.global.latestPrice = context.toOracleVersion.price;
 
         // accumulate settlement fee
         result.settlementFee = _accumulateSettlementFee(next, context);

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -26,6 +26,9 @@ struct Global {
     /// @dev The accrued donation
     UFixed6 donation;
 
+    /// @dev The latest valid price in the market
+    Fixed6 latestPrice;
+
     /// @dev The accumulated market exposure
     Fixed6 exposure;
 
@@ -45,16 +48,14 @@ library GlobalLib {
     /// @param latestRiskParameter The latest risk parameter configuration
     /// @param newRiskParameter The new risk parameter configuration
     /// @param latestPosition The latest position
-    /// @param latestPrice The latest price
     function update(
         Global memory self,
         RiskParameter memory latestRiskParameter,
         RiskParameter memory newRiskParameter,
-        Position memory latestPosition,
-        Fixed6 latestPrice
+        Position memory latestPosition
     ) internal pure {
         Fixed6 exposureChange = latestRiskParameter.takerFee
-            .exposure(newRiskParameter.takerFee, latestPosition.skew(), latestPrice.abs());
+            .exposure(newRiskParameter.takerFee, latestPosition.skew(), self.latestPrice.abs());
         self.exposure = self.exposure.sub(exposureChange);
     }
 
@@ -98,6 +99,13 @@ library GlobalLib {
         self.donation = self.donation.add(donationAmount);
         self.exposure = self.exposure.add(accumulation.adiabaticExposureMarket);
     }
+
+    /// @notice Overrides the price of the oracle with the latest global version if it is empty
+    /// @param self The Global object to read from
+    /// @param oracleVersion The oracle version to update
+    function overrideIfZero(Global memory self, OracleVersion memory oracleVersion) internal pure {
+        if (oracleVersion.price.isZero()) oracleVersion.price = self.latestPrice;
+    }
 }
 
 /// @dev Manually encodes and decodes the Global struct into storage.
@@ -115,7 +123,7 @@ library GlobalLib {
 ///         /* slot 1 */
 ///         int32 pAccumulator.value;   // <= 214000%
 ///         int24 pAccumulator.skew;    // <= 838%
-///         int64 __UNSAFE___;          // <= 9.22t (deprecated in v2.3, unsafe to reuse until reset)
+///         int64 latestPrice;          // <= 9.22t
 ///         int64 exposure;             // <= 9.22t
 ///     }
 ///
@@ -132,6 +140,7 @@ library GlobalStorageLib {
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 48 - 48)) >> (256 - 48)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 48 - 48 - 48)) >> (256 - 48)),
             UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 48 - 48 - 48 - 48)) >> (256 - 48)),
+            Fixed6.wrap(int256(slot1 << (256 - 32 - 24 - 64)) >> (256 - 64)),
             Fixed6.wrap(int256(slot1 << (256 - 32 - 24 - 64 - 64)) >> (256 - 64)),
             PAccumulator6(
                 Fixed6.wrap(int256(slot1 << (256 - 32)) >> (256 - 32)),
@@ -147,6 +156,8 @@ library GlobalStorageLib {
         if (newValue.oracleFee.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
         if (newValue.riskFee.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
         if (newValue.donation.gt(UFixed6.wrap(type(uint48).max))) revert GlobalStorageInvalidError();
+        if (newValue.latestPrice.gt(Fixed6.wrap(type(int64).max))) revert GlobalStorageInvalidError();
+        if (newValue.latestPrice.lt(Fixed6.wrap(type(int64).min))) revert GlobalStorageInvalidError();
         if (newValue.exposure.gt(Fixed6.wrap(type(int64).max))) revert GlobalStorageInvalidError();
         if (newValue.exposure.lt(Fixed6.wrap(type(int64).min))) revert GlobalStorageInvalidError();
         if (newValue.pAccumulator._value.gt(Fixed6.wrap(type(int32).max))) revert GlobalStorageInvalidError();
@@ -165,6 +176,7 @@ library GlobalStorageLib {
         uint256 encoded1 =
             uint256(Fixed6.unwrap(newValue.pAccumulator._value) << (256 - 32)) >> (256 - 32) |
             uint256(Fixed6.unwrap(newValue.pAccumulator._skew) << (256 - 24)) >> (256 - 32 - 24) |
+            uint256(Fixed6.unwrap(newValue.latestPrice) << (256 - 64)) >> (256 - 32 - 24 - 64) |
             uint256(Fixed6.unwrap(newValue.exposure) << (256 - 64)) >> (256 - 32 - 24 - 64 - 64);
 
         assembly {

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1657,6 +1657,7 @@ describe('Fees', () => {
           currentId: 2,
           latestId: 2,
           oracleFee: expectedSettlementFee,
+          latestPrice: PRICE,
         })
       })
 
@@ -1696,6 +1697,7 @@ describe('Fees', () => {
           currentId: 2,
           latestId: 2,
           oracleFee: expectedSettlementFee,
+          latestPrice: PRICE,
         })
       })
     })

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -179,6 +179,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(1), {
@@ -287,6 +288,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -388,6 +390,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(1), {
@@ -524,6 +527,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -716,6 +720,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -876,6 +881,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(1), {
@@ -1012,6 +1018,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {
@@ -1201,6 +1208,7 @@ describe('Fees', () => {
         riskFee: expectedRiskFee,
         oracleFee: expectedOracleFee,
         donation: expectedDonation,
+        latestPrice: PRICE,
         exposure: 0,
       })
       expectOrderEq(await market.pendingOrder(2), {

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -1412,6 +1412,7 @@ describe('Happy Path', () => {
       riskFee: (await market.global()).riskFee,
       oracleFee: (await market.global()).oracleFee,
       donation: (await market.global()).donation,
+      latestPrice: PRICE,
       exposure: 0,
     })
     expectOrderEq(await market.pendingOrder(delay + 1), {

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -33,11 +33,9 @@ export const TIMESTAMP_3 = 1631114005
 export const TIMESTAMP_4 = 1631115371
 export const TIMESTAMP_5 = 1631118731
 
-export const PRICE = parse6decimal('1')
 export const PRICE_0 = parse6decimal('113.882975')
 export const PRICE_1 = parse6decimal('113.796498')
-export const PRICE_2 = parse6decimal('113.796498')
-export const PRICE_3 = parse6decimal('115.046259')
+export const PRICE_2 = parse6decimal('115.046259')
 export const PRICE_4 = parse6decimal('117.462552')
 
 describe('Happy Path', () => {
@@ -168,6 +166,7 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
+      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -219,6 +218,7 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 1,
       latestId: 1,
+      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -286,6 +286,7 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
+      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -337,6 +338,7 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 1,
       latestId: 1,
+      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -411,6 +413,7 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
+      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -487,6 +490,7 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
+      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -595,6 +599,7 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
+      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -627,6 +632,7 @@ describe('Happy Path', () => {
       latestId: 1,
       protocolFee: '18',
       donation: '18',
+      latestPrice: PRICE_2,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -733,6 +739,7 @@ describe('Happy Path', () => {
     expectGlobalEq(await market.global(), {
       ...DEFAULT_GLOBAL,
       currentId: 1,
+      latestPrice: PRICE_0,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -765,6 +772,7 @@ describe('Happy Path', () => {
       latestId: 1,
       protocolFee: '18',
       donation: '18',
+      latestPrice: PRICE_2,
     })
     expectOrderEq(await market.pendingOrder(1), {
       ...DEFAULT_ORDER,
@@ -873,6 +881,7 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
+      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -964,6 +973,7 @@ describe('Happy Path', () => {
       ...DEFAULT_GLOBAL,
       currentId: 2,
       latestId: 1,
+      latestPrice: PRICE_1,
     })
     expectOrderEq(await market.pendingOrder(2), {
       ...DEFAULT_ORDER,
@@ -1234,6 +1244,7 @@ describe('Happy Path', () => {
       latestId: 2,
       protocolFee: '86263589',
       donation: '86263590',
+      latestPrice: PRICE_4,
     })
     expectOrderEq(await market.pendingOrder(3), {
       ...DEFAULT_ORDER,
@@ -1412,7 +1423,7 @@ describe('Happy Path', () => {
       riskFee: (await market.global()).riskFee,
       oracleFee: (await market.global()).oracleFee,
       donation: (await market.global()).donation,
-      latestPrice: PRICE,
+      latestPrice: PRICE_0,
       exposure: 0,
     })
     expectOrderEq(await market.pendingOrder(delay + 1), {

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -1014,7 +1014,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(1),
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
-          latestPrice: PRICE,
+          latestPrice: parse6decimal('45'),
         })
 
         // settle after another oracle price update to ensure exposure changes as expected
@@ -1046,7 +1046,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
           donation: totalFee.div(2).mul(8).div(10).add(5), // loss of precision
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
-          latestPrice: PRICE,
+          latestPrice: parse6decimal('62'),
         })
       })
 
@@ -1215,7 +1215,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(1),
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
-          latestPrice: PRICE,
+          latestPrice: parse6decimal('45'),
         })
 
         // settle after another oracle price update to ensure exposure changes as expected
@@ -1247,7 +1247,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
           donation: totalFee.div(2).mul(8).div(10).add(5), // loss of precision
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
-          latestPrice: PRICE,
+          latestPrice: parse6decimal('62'),
         })
       })
 
@@ -11661,6 +11661,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -16294,7 +16295,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10),
             exposure: 0,
-            latestPrice: parse6decimal('121'),
+            latestPrice: parse6decimal('96'),
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -821,6 +821,7 @@ describe('Market', () => {
           currentId: 1,
           latestId: 1,
           exposure: BigNumber.from(0).sub(parse6decimal('0.369')),
+          latestPrice: PRICE,
         })
 
         const riskParameter = await market.riskParameter()
@@ -990,6 +991,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(1),
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: 0,
+          latestPrice: parse6decimal('45'),
         })
 
         // update risk parameters, introducing exposure
@@ -1012,6 +1014,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(1),
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
+          latestPrice: PRICE,
         })
 
         // settle after another oracle price update to ensure exposure changes as expected
@@ -1043,6 +1046,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
           donation: totalFee.div(2).mul(8).div(10).add(5), // loss of precision
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
+          latestPrice: PRICE,
         })
       })
 
@@ -1186,6 +1190,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(1),
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: 0,
+          latestPrice: parse6decimal('45'),
         })
 
         // update risk parameters, introducing exposure
@@ -1210,6 +1215,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(1),
           donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
           exposure: EXPOSURE_BEFORE_2.add(EXPOSURE_AFTER_2),
+          latestPrice: PRICE,
         })
 
         // settle after another oracle price update to ensure exposure changes as expected
@@ -1241,6 +1247,7 @@ describe('Market', () => {
           riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
           donation: totalFee.div(2).mul(8).div(10).add(5), // loss of precision
           exposure: EXPOSURE_BEFORE_3.add(EXPOSURE_AFTER_3),
+          latestPrice: PRICE,
         })
       })
 
@@ -1357,6 +1364,7 @@ describe('Market', () => {
           ...DEFAULT_GLOBAL,
           currentId: 1,
           latestId: 1,
+          latestPrice: PRICE,
         })
         expectPositionEq(await market.position(), {
           ...DEFAULT_POSITION,
@@ -1474,6 +1482,7 @@ describe('Market', () => {
           ...DEFAULT_GLOBAL,
           currentId: 1,
           latestId: 1,
+          latestPrice: PRICE,
         })
         expectPositionEq(await market.position(), {
           ...DEFAULT_POSITION,
@@ -1559,6 +1568,7 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1610,6 +1620,7 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1663,6 +1674,7 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1719,6 +1731,7 @@ describe('Market', () => {
             ...DEFAULT_GLOBAL,
             currentId: 2,
             latestId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1794,6 +1807,7 @@ describe('Market', () => {
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
               currentId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -1911,6 +1925,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -1973,6 +1988,7 @@ describe('Market', () => {
             expectGlobalEq(await market.global(), {
               ...DEFAULT_GLOBAL,
               currentId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2038,6 +2054,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2106,6 +2123,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2179,6 +2197,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 2,
               latestId: 2,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2261,6 +2280,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2360,6 +2380,7 @@ describe('Market', () => {
               riskFee: MAKER_FEE.div(2).div(10).sub(1),
               donation: MAKER_FEE.div(2).mul(8).div(10).add(1),
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -2440,6 +2461,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2506,6 +2528,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 2,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2568,6 +2591,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2638,6 +2662,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 2,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2706,6 +2731,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 3,
                 latestId: 2,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2782,6 +2808,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 3,
                 latestId: 3,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2851,6 +2878,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 2,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -2940,6 +2968,7 @@ describe('Market', () => {
                 riskFee: MAKER_FEE.div(2).div(10).sub(1),
                 donation: MAKER_FEE.div(2).mul(8).div(10).add(1),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3034,6 +3063,7 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3116,6 +3146,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3187,6 +3218,7 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3262,6 +3294,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3341,6 +3374,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3455,6 +3489,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3574,6 +3609,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3712,6 +3748,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3864,6 +3901,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -3968,6 +4006,7 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4064,6 +4103,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4133,6 +4173,7 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4233,6 +4274,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4339,6 +4381,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4465,6 +4508,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4588,6 +4632,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4720,6 +4765,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -4837,6 +4883,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -4971,6 +5018,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: 0,
+              latestPrice: parse6decimal('121'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -5116,6 +5164,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: 0,
+              latestPrice: parse6decimal('125'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -5316,6 +5365,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('150'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -5586,6 +5636,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2),
                 donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('150'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -5776,6 +5827,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('203'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6045,6 +6097,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: parse6decimal('96'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6223,6 +6276,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('43'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6424,6 +6478,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: parse6decimal('128'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -6521,6 +6576,7 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6603,6 +6659,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6675,6 +6732,7 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6750,6 +6808,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6829,6 +6888,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -6943,6 +7003,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -7067,6 +7128,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -7208,6 +7270,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -7362,6 +7425,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -7467,6 +7531,7 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7563,6 +7628,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7633,6 +7699,7 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7733,6 +7800,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7839,6 +7907,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -7966,6 +8035,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -8091,6 +8161,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -8225,6 +8296,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                   exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -8343,6 +8415,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -8477,6 +8550,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: 0,
+              latestPrice: parse6decimal('121'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -8624,6 +8698,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
               exposure: 0,
+              latestPrice: parse6decimal('125'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -8824,6 +8899,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: parse6decimal('96'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9090,6 +9166,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(3), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('96'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9267,6 +9344,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('43'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9536,6 +9614,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('150'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9718,6 +9797,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('203'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -9921,6 +10001,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: parse6decimal('118'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -10052,6 +10133,7 @@ describe('Market', () => {
               riskFee: EXPECTED_MAKER_FEE.div(2).div(10).sub(1),
               donation: EXPECTED_MAKER_FEE.div(2).mul(8).div(10).add(1),
               exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -10170,6 +10252,7 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10253,6 +10336,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10327,6 +10411,7 @@ describe('Market', () => {
               expectGlobalEq(await market.global(), {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10403,6 +10488,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 1,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10484,6 +10570,7 @@ describe('Market', () => {
                 ...DEFAULT_GLOBAL,
                 currentId: 2,
                 latestId: 1,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10601,6 +10688,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10737,6 +10825,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -10910,6 +10999,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -11049,6 +11139,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -11186,6 +11277,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -11321,6 +11413,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -11453,6 +11546,7 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11552,6 +11646,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10),
                   donation: totalFee.div(2).mul(8).div(10),
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11634,6 +11729,7 @@ describe('Market', () => {
                   ...DEFAULT_GLOBAL,
                   currentId: 2,
                   latestId: 1,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11737,6 +11833,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10),
                   donation: totalFee.div(2).mul(8).div(10),
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11858,6 +11955,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10),
                   donation: totalFee.div(2).mul(8).div(10),
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -11991,6 +12089,7 @@ describe('Market', () => {
                   riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                   donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
                   exposure: 0,
+                  latestPrice: PRICE,
                 })
                 expectPositionEq(await market.position(), {
                   ...DEFAULT_POSITION,
@@ -12362,6 +12461,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -12505,6 +12605,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10),
               exposure: 0,
+              latestPrice: parse6decimal('121'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -12672,6 +12773,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10),
               exposure: 0,
+              latestPrice: parse6decimal('125'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -12901,6 +13003,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('45'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -13123,6 +13226,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
                 exposure: EXPOSURE_BEFORE.add(EXPOSURE_AFTER),
+                latestPrice: PRICE,
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -13318,6 +13422,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10).sub(2), // loss of precision
                 exposure: 0,
+                latestPrice: parse6decimal('45'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -13537,6 +13642,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: parse6decimal('33'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -13848,6 +13954,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: parse6decimal('96'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -14078,6 +14185,7 @@ describe('Market', () => {
                 riskFee: totalFee.div(2).div(10),
                 donation: totalFee.div(2).mul(8).div(10),
                 exposure: 0,
+                latestPrice: parse6decimal('43'),
               })
               expectPositionEq(await market.position(), {
                 ...DEFAULT_POSITION,
@@ -14295,11 +14403,7 @@ describe('Market', () => {
               ...DEFAULT_GLOBAL,
               currentId: 1,
               latestId: 1,
-              protocolFee: 0,
-              oracleFee: 0,
-              riskFee: 0,
-              donation: 0,
-              exposure: 0,
+              latestPrice: parse6decimal('128'),
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -15370,6 +15474,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
             exposure: 0,
+            latestPrice: parse6decimal('43'),
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -15736,6 +15841,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(4), // loss of precision
             exposure: 0,
+            latestPrice: parse6decimal('150'),
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -15945,6 +16051,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10),
             exposure: 0,
+            latestPrice: parse6decimal('121'),
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -16275,6 +16382,7 @@ describe('Market', () => {
             currentId: 2,
             latestId: 2,
             oracleFee: SETTLEMENT_FEE,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -16454,6 +16562,7 @@ describe('Market', () => {
             riskFee: TAKER_FEE.div(2).div(10).sub(1),
             donation: TAKER_FEE.div(2).mul(8).div(10).add(1),
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -16641,6 +16750,7 @@ describe('Market', () => {
             currentId: 3,
             latestId: 3,
             oracleFee: SETTLEMENT_FEE.mul(2),
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -16816,6 +16926,7 @@ describe('Market', () => {
             currentId: 3,
             latestId: 3,
             oracleFee: SETTLEMENT_FEE,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17044,6 +17155,7 @@ describe('Market', () => {
             riskFee: TAKER_FEE.div(20).sub(1),
             donation: TAKER_FEE.mul(2).div(5).add(1),
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17190,6 +17302,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17343,6 +17456,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17488,6 +17602,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(1), // loss of precision
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17575,6 +17690,7 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17656,6 +17772,7 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -17904,6 +18021,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -19152,6 +19270,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -19291,6 +19410,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10),
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -19714,6 +19834,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(1),
             donation: totalFee.div(2).mul(8).div(10).add(1),
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -19867,6 +19988,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -20023,6 +20145,7 @@ describe('Market', () => {
             riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
             donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
             exposure: 0,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -20269,6 +20392,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20510,6 +20634,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20751,6 +20876,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -20991,6 +21117,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21248,6 +21375,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21501,6 +21629,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -21756,6 +21885,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -22011,6 +22141,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(2), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(2), // loss of precision
               exposure: -EXPECTED_EXPOSURE, // turning on offset params
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -22272,6 +22403,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,
@@ -22533,6 +22665,7 @@ describe('Market', () => {
               riskFee: totalFee.div(2).div(10).sub(1), // loss of precision
               donation: totalFee.div(2).mul(8).div(10).add(3), // loss of precision
               exposure: 0,
+              latestPrice: PRICE,
             })
             expectPositionEq(await market.position(), {
               ...DEFAULT_POSITION,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -1786,6 +1786,7 @@ describe('Market', () => {
           expectGlobalEq(await market.global(), {
             ...DEFAULT_GLOBAL,
             currentId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,
@@ -1842,6 +1843,7 @@ describe('Market', () => {
             ...DEFAULT_GLOBAL,
             currentId: 2,
             latestId: 1,
+            latestPrice: PRICE,
           })
           expectPositionEq(await market.position(), {
             ...DEFAULT_POSITION,

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -33,6 +33,7 @@ const DEFAULT_GLOBAL: GlobalStruct = {
     _value: 0,
     _skew: 0,
   },
+  latestPrice: 0,
   exposure: 0,
 }
 
@@ -134,6 +135,7 @@ describe('Global', () => {
           _value: 6,
           _skew: 7,
         },
+        latestPrice: 9,
         exposure: 8,
       })
 
@@ -146,6 +148,7 @@ describe('Global', () => {
       expect(value.donation).to.equal(5)
       expect(value.pAccumulator._value).to.equal(6)
       expect(value.pAccumulator._skew).to.equal(7)
+      expect(value.latestPrice).to.equal(9)
       expect(value.exposure).to.equal(8)
     })
 
@@ -270,6 +273,27 @@ describe('Global', () => {
           global.store({
             ...DEFAULT_GLOBAL,
             donation: BigNumber.from(2).pow(STORAGE_SIZE),
+          }),
+        ).to.be.revertedWithCustomError(globalStorageLib, 'GlobalStorageInvalidError')
+      })
+    })
+
+    context('.latestPrice', async () => {
+      const STORAGE_SIZE = 63
+      it('saves if in range', async () => {
+        await global.store({
+          ...DEFAULT_GLOBAL,
+          latestPrice: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+        })
+        const value = await global.read()
+        expect(value.latestPrice).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('reverts if latestPrice out of range', async () => {
+        await expect(
+          global.store({
+            ...DEFAULT_GLOBAL,
+            latestPrice: BigNumber.from(2).pow(STORAGE_SIZE),
           }),
         ).to.be.revertedWithCustomError(globalStorageLib, 'GlobalStorageInvalidError')
       })

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -62,6 +62,7 @@ const GLOBAL: GlobalStruct = {
     _value: 6,
     _skew: 7,
   },
+  latestPrice: 9,
   exposure: 0,
 }
 
@@ -2305,6 +2306,42 @@ describe('Version', () => {
 
         expect(nextGlobal.pAccumulator._value).to.equal(0)
         expect(nextGlobal.pAccumulator._skew).to.equal('-1000000')
+      })
+
+      it('updates latestPrice', async () => {
+        await version.store(DEFAULT_VERSION)
+
+        const { nextGlobal } = await accumulateWithReturn(
+          GLOBAL,
+          {
+            ...FROM_POSITION,
+            maker: parse6decimal('10'),
+            long: parse6decimal('2'),
+            short: parse6decimal('9'),
+          },
+          ORDER,
+          { ...DEFAULT_GUARANTEE },
+          ORACLE_VERSION_1,
+          { ...ORACLE_VERSION_2, price: parse6decimal('125') },
+          DEFAULT_ORACLE_RECEIPT,
+          {
+            ...VALID_MARKET_PARAMETER,
+            interestFee: 0,
+            fundingFee: 0,
+          },
+          {
+            ...VALID_RISK_PARAMETER,
+            pController: { min: 0, max: 0, k: parse6decimal('999999') },
+            utilizationCurve: {
+              minRate: 0,
+              maxRate: 0,
+              targetRate: 0,
+              targetUtilization: parse6decimal('0.8'),
+            },
+          },
+        )
+
+        expect(nextGlobal.latestPrice).to.equal(parse6decimal('125'))
       })
     })
   })


### PR DESCRIPTION
There doesn't seem to be a good way to consolidate both no-new-version requests with unrequested versions without causing ordering conflicts when prices are later committed.

For now we'll remove the `newPrice` flag and re-add the `latestPrice` field to `Global`.