### PR TITLE
Add support for operator on claimFee

### DIFF
--- a/packages/common/testutil/time.ts
+++ b/packages/common/testutil/time.ts
@@ -35,8 +35,9 @@ export async function increaseTo(timestamp: number): Promise<void> {
     await time.increaseTo(timestamp)
   }
   const newTimestamp = await currentBlockTimestamp()
-  if (timestamp != newTimestamp)
-    console.log('[WARNING] increaseTo failed to reach timestamp (%s vs %s)', timestamp, newTimestamp)
+  if (timestamp != newTimestamp) {
+    await setNextBlockTimestamp(timestamp)
+  }
 }
 
 export async function reset(blockNumber?: number): Promise<void> {

--- a/packages/common/testutil/time.ts
+++ b/packages/common/testutil/time.ts
@@ -35,9 +35,8 @@ export async function increaseTo(timestamp: number): Promise<void> {
     await time.increaseTo(timestamp)
   }
   const newTimestamp = await currentBlockTimestamp()
-  if (timestamp != newTimestamp) {
+  if (timestamp != newTimestamp)
     console.log('[WARNING] increaseTo failed to reach timestamp (%s vs %s)', timestamp, newTimestamp)
-  }
 }
 
 export async function reset(blockNumber?: number): Promise<void> {

--- a/packages/common/testutil/time.ts
+++ b/packages/common/testutil/time.ts
@@ -36,7 +36,7 @@ export async function increaseTo(timestamp: number): Promise<void> {
   }
   const newTimestamp = await currentBlockTimestamp()
   if (timestamp != newTimestamp) {
-    await setNextBlockTimestamp(timestamp)
+    console.log('[WARNING] increaseTo failed to reach timestamp (%s vs %s)', timestamp, newTimestamp)
   }
 }
 

--- a/packages/perennial-extensions/contracts/Coordinator.sol
+++ b/packages/perennial-extensions/contracts/Coordinator.sol
@@ -36,7 +36,7 @@ contract Coordinator is ICoordinator, Ownable {
     /// @param market The market to claim the fee for
     function claimFee(IMarket market) external {
         if (msg.sender != comptroller) revert NotComptroller();
-        market.claimFee(msg.sender);
+        market.claimFee(comptroller);
         market.token().push(comptroller);
     }
 

--- a/packages/perennial-extensions/contracts/Coordinator.sol
+++ b/packages/perennial-extensions/contracts/Coordinator.sol
@@ -36,7 +36,7 @@ contract Coordinator is ICoordinator, Ownable {
     /// @param market The market to claim the fee for
     function claimFee(IMarket market) external {
         if (msg.sender != comptroller) revert NotComptroller();
-        market.claimFee(comptroller);
+        market.claimFee(msg.sender);
         market.token().push(comptroller);
     }
 

--- a/packages/perennial-extensions/contracts/Coordinator.sol
+++ b/packages/perennial-extensions/contracts/Coordinator.sol
@@ -36,7 +36,7 @@ contract Coordinator is ICoordinator, Ownable {
     /// @param market The market to claim the fee for
     function claimFee(IMarket market) external {
         if (msg.sender != comptroller) revert NotComptroller();
-        market.claimFee();
+        market.claimFee(msg.sender);
         market.token().push(comptroller);
     }
 

--- a/packages/perennial-extensions/test/unit/Coordinator/Coordinator.test.ts
+++ b/packages/perennial-extensions/test/unit/Coordinator/Coordinator.test.ts
@@ -1,5 +1,5 @@
 import { smock, FakeContract } from '@defi-wonderland/smock'
-import { constants } from 'ethers'
+import { constants, utils } from 'ethers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect, use } from 'chai'
 import HRE from 'hardhat'
@@ -110,8 +110,8 @@ describe('Coordinator', () => {
     it('should call claimFee on the market', async () => {
       await coordinatorContract.setComptroller(comptroller.address)
       await coordinatorContract.connect(comptroller).claimFee(market.address)
-      expect(market.claimFee).to.have.been.called
-      expect(token.transfer).to.have.been.called
+      expect(market.claimFee).to.have.been.calledWith(comptroller.address)
+      expect(token.transfer).to.have.been.calledWith(comptroller.address, 0)
     })
   })
 

--- a/packages/perennial-oracle/contracts/Oracle.sol
+++ b/packages/perennial-oracle/contracts/Oracle.sol
@@ -113,7 +113,7 @@ contract Oracle is IOracle, Instance {
     /// @param settlementFeeRequested The fixed settmentment fee requested by the oracle
     function claimFee(UFixed6 settlementFeeRequested) external onlySubOracle {
         // claim the fee from the market
-        UFixed6 feeReceived = market.claimFee(msg.sender);
+        UFixed6 feeReceived = market.claimFee(address(this));
 
         // return the settlement fee portion to the sub oracle's factory
         market.token().push(msg.sender, UFixed18Lib.from(settlementFeeRequested));

--- a/packages/perennial-oracle/contracts/Oracle.sol
+++ b/packages/perennial-oracle/contracts/Oracle.sol
@@ -95,7 +95,7 @@ contract Oracle is IOracle, Instance {
     /// @param settlementFeeRequested The fixed settmentment fee requested by the oracle
     function claimFee(UFixed6 settlementFeeRequested) external onlySubOracle {
         // claim the fee from the market
-        UFixed6 feeReceived = market.claimFee();
+        UFixed6 feeReceived = market.claimFee(msg.sender);
 
         // return the settlement fee portion to the sub oracle's factory
         market.token().push(msg.sender, UFixed18Lib.from(settlementFeeRequested));

--- a/packages/perennial-vault/test/integration/vault/Vault.test.ts
+++ b/packages/perennial-vault/test/integration/vault/Vault.test.ts
@@ -1986,7 +1986,7 @@ describe('Vault', () => {
           // We should now be able to deposit.
           await updateOracle()
           await btcMarket.settle(vault.address)
-          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
+          await btcMarket.connect(user).claimFee(user.address) // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()
@@ -2023,7 +2023,7 @@ describe('Vault', () => {
           // We should now be able to deposit.
           await updateOracle()
           await btcMarket.settle(vault.address)
-          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
+          await btcMarket.connect(user).claimFee(user.address) // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()
@@ -2099,7 +2099,7 @@ describe('Vault', () => {
           // We should now be able to deposit.
           await updateOracle()
           await btcMarket.settle(vault.address)
-          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
+          await btcMarket.connect(user).claimFee(user.address) // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()
@@ -2136,7 +2136,7 @@ describe('Vault', () => {
           // We should now be able to deposit.
           await updateOracle()
           await btcMarket.settle(vault.address)
-          await btcMarket.connect(user).claimFee() // claim liquidation fee to pay for deposit
+          await btcMarket.connect(user).claimFee(user.address) // claim liquidation fee to pay for deposit
           await vault.connect(user).update(user.address, 2, 0, 0)
 
           await updateOracle()

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -349,7 +349,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         if (!feeReceived.isZero()) {
             token.push(msg.sender, UFixed18Lib.from(feeReceived));
-            emit FeeClaimed(msg.sender, feeReceived);
+            emit FeeClaimed(account, msg.sender, feeReceived);
         }
     }
 
@@ -889,7 +889,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
     /// @notice Only the account or an operator can call
     modifier onlyOperator(address account) {
-        if (msg.sender != account || IMarketFactory(address(factory())).operators(account, msg.sender))
+        if (msg.sender != account && !IMarketFactory(address(factory())).operators(account, msg.sender))
             revert MarketNotOperatorError();
         _;
     }

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -66,7 +66,11 @@ interface IMarket is IInstance {
     event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
     event BeneficiaryUpdated(address newBeneficiary);
     event CoordinatorUpdated(address newCoordinator);
-    event FeeClaimed(address indexed account, UFixed6 amount);
+    /// @notice Fee earned by an account was transferred from market to a receiver
+    /// @param account User who earned the fee
+    /// @param receiver Delegated operator of the account, or the account itself
+    /// @param amount Collateral transferred from market to receiver
+    event FeeClaimed(address indexed account, address indexed receiver, UFixed6 amount);
     event ExposureClaimed(address indexed account, Fixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -97,6 +97,9 @@ interface IMarket is IInstance {
     error MarketNotCoordinatorError();
     // sig: 0xb602d086
     error MarketNotBeneficiaryError();
+    // sig: 0x3222db45
+    /// @custom:error Transaction sender is not authorized to operate the account
+    error MarketNotOperatorError();
     // sig: 0x534f7fe6
     error MarketInvalidProtectionError();
     // sig: 0xab1e3a00
@@ -158,5 +161,5 @@ interface IMarket is IInstance {
     function updateCoordinator(address newCoordinator) external;
     function updateParameter(MarketParameter memory newParameter) external;
     function updateRiskParameter(RiskParameter memory newRiskParameter) external;
-    function claimFee() external returns (UFixed6);
+    function claimFee(address account) external returns (UFixed6);
 }

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -102,7 +102,7 @@ interface IMarket is IInstance {
     // sig: 0xb602d086
     error MarketNotBeneficiaryError();
     // sig: 0x3222db45
-    /// @custom:error Transaction sender is not authorized to operate the account
+    /// @custom:error Sender is not authorized to interact with markets on behalf of the account
     error MarketNotOperatorError();
     // sig: 0x534f7fe6
     error MarketInvalidProtectionError();

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1997,7 +1997,7 @@ describe('Fees', () => {
       })
       await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(user.address, expectedClaimable)
+        .withArgs(user.address, user.address, expectedClaimable)
     })
 
     it('charges default referral fee for taker position', async () => {
@@ -2054,7 +2054,7 @@ describe('Fees', () => {
       })
       await expect(market.connect(userB).claimFee(userB.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(userB.address, expectedClaimable)
+        .withArgs(userB.address, userB.address, expectedClaimable)
     })
 
     it('handles a change in user referral fee', async () => {
@@ -2102,7 +2102,7 @@ describe('Fees', () => {
       })
       await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(user.address, expectedClaimable)
+        .withArgs(user.address, user.address, expectedClaimable)
     })
 
     it('handles referral fee for multiple orders', async () => {
@@ -2161,7 +2161,7 @@ describe('Fees', () => {
       })
       await expect(market.connect(userB).claimFee(userB.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(userB.address, expectedClaimableMakerReferral)
+        .withArgs(userB.address, userB.address, expectedClaimableMakerReferral)
 
       // user should be able to claim the taker referral fee at the user rate
       // takerFee = position * takerFee * price = 3 * 0.025 * 113.882975 = 8.541223
@@ -2207,7 +2207,7 @@ describe('Fees', () => {
       expectedClaimableTakerReferral = expectedClaimableTakerReferral.add(parse6decimal('0.854122'))
       await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(user.address, expectedClaimableTakerReferral)
+        .withArgs(user.address, user.address, expectedClaimableTakerReferral)
     })
 
     it('allows for a new referrer on new orders', async () => {
@@ -2267,7 +2267,7 @@ describe('Fees', () => {
       })
       await expect(market.connect(userB).claimFee(userB.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(userB.address, expectedClaimable)
+        .withArgs(userB.address, userB.address, expectedClaimable)
 
       // userC closes a short position referred by user
       await market
@@ -2292,7 +2292,7 @@ describe('Fees', () => {
       })
       await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
-        .withArgs(user.address, expectedCloseClaimable)
+        .withArgs(user.address, user.address, expectedCloseClaimable)
       expect(await market.orderReferrers(userC.address, currentId.add(1))).to.equal(user.address)
 
       await nextWithConstantPrice()

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -1995,7 +1995,7 @@ describe('Fees', () => {
         latestId: 0,
         claimable: expectedClaimable,
       })
-      await expect(market.connect(user).claimFee())
+      await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(user.address, expectedClaimable)
     })
@@ -2052,7 +2052,7 @@ describe('Fees', () => {
         latestId: 0,
         claimable: expectedClaimable,
       })
-      await expect(market.connect(userB).claimFee())
+      await expect(market.connect(userB).claimFee(userB.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(userB.address, expectedClaimable)
     })
@@ -2100,7 +2100,7 @@ describe('Fees', () => {
         latestId: 0,
         claimable: expectedClaimable,
       })
-      await expect(market.connect(user).claimFee())
+      await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(user.address, expectedClaimable)
     })
@@ -2159,7 +2159,7 @@ describe('Fees', () => {
         latestId: 0,
         claimable: expectedClaimableMakerReferral,
       })
-      await expect(market.connect(userB).claimFee())
+      await expect(market.connect(userB).claimFee(userB.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(userB.address, expectedClaimableMakerReferral)
 
@@ -2205,7 +2205,7 @@ describe('Fees', () => {
       // takerFee = position * takerFee * price = 2 * 0.025 * 113.882975 = 5.694148
       // referralFee = takerFee * referral / takerPos =  5.694148 * 0.30 / 2 = 0.854122
       expectedClaimableTakerReferral = expectedClaimableTakerReferral.add(parse6decimal('0.854122'))
-      await expect(market.connect(user).claimFee())
+      await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(user.address, expectedClaimableTakerReferral)
     })
@@ -2265,7 +2265,7 @@ describe('Fees', () => {
         latestId: 0,
         claimable: expectedClaimable,
       })
-      await expect(market.connect(userB).claimFee())
+      await expect(market.connect(userB).claimFee(userB.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(userB.address, expectedClaimable)
 
@@ -2290,7 +2290,7 @@ describe('Fees', () => {
         collateral: '1150119246',
         claimable: expectedCloseClaimable,
       })
-      await expect(market.connect(user).claimFee())
+      await expect(market.connect(user).claimFee(user.address))
         .to.emit(market, 'FeeClaimed')
         .withArgs(user.address, expectedCloseClaimable)
       expect(await market.orderReferrers(userC.address, currentId.add(1))).to.equal(user.address)

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -53,7 +53,7 @@ describe('Liquidate', () => {
     await chainlink.next()
     await market.connect(user)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false) // settle
     expect((await market.locals(userB.address)).claimable).to.equal(parse6decimal('10'))
-    await market.connect(userB).claimFee() // liquidator withdrawal
+    await market.connect(userB).claimFee(userB.address) // liquidator withdrawal
 
     expect(await dsu.balanceOf(userB.address)).to.equal(utils.parseEther('200010')) // Original 200000 + fee
     expect((await market.locals(user.address)).collateral).to.equal(parse6decimal('1000').sub(parse6decimal('10')))
@@ -312,7 +312,7 @@ describe('Liquidate', () => {
 
     // userC claims their fee
     expect((await market.locals(userC.address)).claimable).to.equal(parse6decimal('10'))
-    await market.connect(userC).claimFee() // liquidator withdrawal
+    await market.connect(userC).claimFee(userC.address) // liquidator withdrawal
     expect(await dsu.balanceOf(market.address)).to.equal(utils.parseEther('1500').sub(utils.parseEther('10')))
   })
 
@@ -380,7 +380,7 @@ describe('Liquidate', () => {
     await chainlink.next()
     await market.connect(user)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, false) // settle
     expect((await market.locals(userB.address)).claimable).to.equal(parse6decimal('10'))
-    await market.connect(userB).claimFee() // liquidator withdrawal
+    await market.connect(userB).claimFee(userB.address) // liquidator withdrawal
 
     const expectedClaimable = parse6decimal('6.902775')
     await settle(market, userC)

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -15776,7 +15776,7 @@ describe('Market', () => {
           })
 
           dsu.transfer.whenCalledWith(liquidator.address, EXPECTED_LIQUIDATION_FEE.mul(1e12)).returns(true)
-          await expect(market.connect(liquidator).claimFee())
+          await expect(market.connect(liquidator).claimFee(liquidator.address))
             .to.emit(market, 'FeeClaimed')
             .withArgs(liquidator.address, EXPECTED_LIQUIDATION_FEE)
 
@@ -16051,7 +16051,7 @@ describe('Market', () => {
           })
 
           dsu.transfer.whenCalledWith(liquidator.address, EXPECTED_LIQUIDATION_FEE.mul(1e12)).returns(true)
-          await expect(market.connect(liquidator).claimFee())
+          await expect(market.connect(liquidator).claimFee(liquidator.address))
             .to.emit(market, 'FeeClaimed')
             .withArgs(liquidator.address, EXPECTED_LIQUIDATION_FEE)
 
@@ -22968,7 +22968,7 @@ describe('Market', () => {
       it('claims fee (protocol)', async () => {
         dsu.transfer.whenCalledWith(owner.address, PROTOCOL_FEE.mul(1e12)).returns(true)
 
-        await expect(market.connect(owner).claimFee())
+        await expect(market.connect(owner).claimFee(owner.address))
           .to.emit(market, 'FeeClaimed')
           .withArgs(owner.address, PROTOCOL_FEE)
 
@@ -22981,7 +22981,7 @@ describe('Market', () => {
       it('claims fee (oracle)', async () => {
         dsu.transfer.whenCalledWith(oracleSigner.address, ORACLE_FEE.mul(1e12)).returns(true)
 
-        await expect(market.connect(oracleSigner).claimFee())
+        await expect(market.connect(oracleSigner).claimFee(oracleSigner.address))
           .to.emit(market, 'FeeClaimed')
           .withArgs(oracleSigner.address, ORACLE_FEE)
 
@@ -22994,7 +22994,7 @@ describe('Market', () => {
       it('claims fee (risk)', async () => {
         dsu.transfer.whenCalledWith(coordinator.address, RISK_FEE.mul(1e12)).returns(true)
 
-        await expect(market.connect(coordinator).claimFee())
+        await expect(market.connect(coordinator).claimFee(coordinator.address))
           .to.emit(market, 'FeeClaimed')
           .withArgs(coordinator.address, RISK_FEE)
 
@@ -23007,7 +23007,7 @@ describe('Market', () => {
       it('claims fee (donation)', async () => {
         dsu.transfer.whenCalledWith(beneficiary.address, DONATION.mul(1e12)).returns(true)
 
-        await expect(market.connect(beneficiary).claimFee())
+        await expect(market.connect(beneficiary).claimFee(beneficiary.address))
           .to.emit(market, 'FeeClaimed')
           .withArgs(beneficiary.address, DONATION)
 
@@ -23018,13 +23018,15 @@ describe('Market', () => {
       })
 
       it('claims fee (none)', async () => {
-        await market.connect(user).claimFee()
+        await market.connect(user).claimFee(user.address)
 
         expect((await market.global()).protocolFee).to.equal(PROTOCOL_FEE)
         expect((await market.global()).oracleFee).to.equal(ORACLE_FEE)
         expect((await market.global()).riskFee).to.equal(RISK_FEE)
         expect((await market.global()).donation).to.equal(DONATION)
       })
+
+      // TODO: claimFee as operator, negative test for claiming fee as non-operator
     })
   })
 })


### PR DESCRIPTION
## Changes
- add `account` parameter to `IMarket.claimFee`
- introduce `onlyOperator` modifier
- update `FeeClaimed` event to show both who earned the fee and who claimed it

## TODO
- [x] update extensions which use `claimFee`
- [x] get CI running cleanly
- [x] resolve merge conflicts