### PR TITLE
Decouple settle / sync

### DIFF
--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -140,7 +140,7 @@ export async function createMarket(
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
     closed: false,
-    settle: false,
+    syncOnly: false,
     ...marketParamOverrides,
   }
   const marketAddress = await marketFactory.callStatic.create(definition)

--- a/packages/perennial-deploy/tasks/changeMarketsMode.ts
+++ b/packages/perennial-deploy/tasks/changeMarketsMode.ts
@@ -21,7 +21,7 @@ export default task('change-markets-mode', 'Opens or closes all markets; must be
     const owner = await marketFactory.owner()
     const signer = await ethers.getSigner(owner)
 
-    if (args.open && args.settle) {
+    if (args.open && args.syncOnly) {
       console.error('Markets may either be opened or closed; not both')
       return 1
     }
@@ -42,12 +42,12 @@ export default task('change-markets-mode', 'Opens or closes all markets; must be
 
       let parameter = await market.parameter()
       console.log(
-        `[Change Markets Mode]    Found market ${marketAddress} beneficiary ${beneficiary} coordinator ${coordinator}. Current state: closed: ${parameter.closed}, settle: ${parameter.settle}`,
+        `[Change Markets Mode]    Found market ${marketAddress} beneficiary ${beneficiary} coordinator ${coordinator}. Current state: closed: ${parameter.closed}, syncOnly: ${parameter.syncOnly}`,
       )
 
       console.log('[Change Markets Mode]    Updating market parameter')
 
-      parameter = { ...parameter, closed: false, settle: args.settle }
+      parameter = { ...parameter, closed: false, syncOnly: args.syncOnly }
       if (args.dry || args.timelock) {
         await market.connect(owner).callStatic.updateParameter(beneficiary, coordinator, parameter)
         console.log('[Change Markets Mode]  Dry run successful')

--- a/packages/perennial-deploy/util/constants.ts
+++ b/packages/perennial-deploy/util/constants.ts
@@ -26,7 +26,7 @@ export const DEFAULT_MARKET_PARAMETER = {
   makerCloseAlways: false,
   takerCloseAlways: true,
   closed: false,
-  settle: false,
+  syncOnly: false,
 }
 
 export const DEFAULT_RISK_PARAMETERS = {

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -319,7 +319,7 @@ export async function createMarket(
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
     closed: false,
-    settle: false,
+    syncOnly: false,
     ...marketParamOverrides,
   }
 

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -376,7 +376,7 @@ testOracles.forEach(testOracle => {
         maxPendingLocal: 8,
         settlementFee: 0,
         closed: false,
-        settle: false,
+        syncOnly: false,
       }
       market = Market__factory.connect(
         await marketFactory.callStatic.create({

--- a/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -328,7 +328,7 @@ testOracles.forEach(testOracle => {
         maxPendingLocal: 8,
         settlementFee: 0,
         closed: false,
-        settle: false,
+        syncOnly: false,
       }
       market = Market__factory.connect(
         await marketFactory.callStatic.create({

--- a/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -355,7 +355,7 @@ testOracles.forEach(testOracle => {
         maxPendingLocal: 8,
         settlementFee: 0,
         closed: false,
-        settle: false,
+        syncOnly: false,
       }
       market = Market__factory.connect(
         await marketFactory.callStatic.create({

--- a/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
@@ -85,7 +85,7 @@ export async function deployProductOnMainnetFork({
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
     closed: false,
-    settle: false,
+    syncOnly: false,
   }
   const marketDefinition: IMarket.MarketDefinitionStruct = {
     token: token.address,

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -572,7 +572,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         Guarantee memory newGuarantee,
         address orderReferrer,
         address guaranteeReferrer
-    ) private notSettleOnly(context) {
+    ) private notSyncOnly(context) {
         // advance to next id if applicable
         if (context.currentTimestamp > updateContext.orderLocal.timestamp) {
             updateContext.orderLocal.next(context.currentTimestamp);
@@ -714,7 +714,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     ///      - Latest versions are guaranteed to have present prices in the oracle, but could be stale
     /// @param context The context to use
     /// @param settlementContext The settlement context to use
-    function _settle(Context memory context, SettlementContext memory settlementContext) private notSettleOnly(context) {
+    function _settle(Context memory context, SettlementContext memory settlementContext) private notSyncOnly(context) {
         if (context.latestOracleVersion.timestamp > context.latestPositionGlobal.timestamp)
             _processOrderGlobal(
                 context,
@@ -890,9 +890,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         _;
     }
 
-    /// @notice Only when the market is not in settle-only mode
-    modifier notSettleOnly(Context memory context) {
-        if (context.marketParameter.settle) revert MarketSettleOnlyError();
+    /// @notice Only when the market is not in sync-only mode
+    modifier notSyncOnly(Context memory context) {
+        if (context.marketParameter.syncOnly) revert MarketSettleOnlyError();
         _;
     }
 }

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -109,12 +109,24 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         oracle = definition_.oracle;
     }
 
+
+    /// @notice Syncs the account's position and collateral
+    /// @param account The account to operate on
+    function sync(address account) external nonReentrant whenNotPaused {
+        Context memory context = _loadContext(account);
+
+        _sync(context);
+
+        _storeContext(context);
+    }
+
     /// @notice Settles the account's position and collateral
     /// @param account The account to operate on
     function settle(address account) external nonReentrant whenNotPaused {
         Context memory context = _loadContext(account);
 
-        _settle(context);
+        SettlementContext memory settlementContext = _sync(context);
+        _settle(context, settlementContext);
 
         _storeContext(context);
     }
@@ -172,7 +184,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     ) private {
         // settle market & account
         Context memory context = _loadContext(account);
-        _settle(context);
+        SettlementContext memory settlementContext = _sync(context);
+        _settle(context, settlementContext);
 
         // load update context
         UpdateContext memory updateContext = _loadUpdateContext(context, signer, orderReferrer, guaranteeReferralFee);
@@ -234,7 +247,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     ) public nonReentrant whenNotPaused {
         // settle market & account
         Context memory context = _loadContext(account);
-        _settle(context);
+        SettlementContext memory settlementContext = _sync(context);
+        _settle(context, settlementContext);
 
         // load update context
         UpdateContext memory updateContext = _loadUpdateContext(context, address(0), referrer, UFixed6Lib.ZERO);
@@ -674,15 +688,15 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         (settlementContext.orderOracleVersion, ) = oracle.at(context.latestPositionGlobal.timestamp);
     }
 
-    /// @notice Settles the account position up to the latest version
+    /// @notice Syncs the account position up to the latest order
+    /// @dev - Process orders whose requested prices are now available from oracle
+    ///      - All requested prices are guaranteed to be present in the oracle, but could be stale
     /// @param context The context to use
-    function _settle(Context memory context) private {
-        SettlementContext memory settlementContext = _loadSettlementContext(context);
-
+    /// @return settlementContext The settlement context
+    function _sync(Context memory context) private returns (SettlementContext memory settlementContext) {
+        settlementContext = _loadSettlementContext(context);
         Order memory nextOrder;
 
-        // settle - process orders whose requested prices are now available from oracle
-        //        - all requested prices are guaranteed to be present in the oracle, but could be stale
         while (
             context.global.currentId != context.global.latestId &&
             (nextOrder = _pendingOrder[context.global.latestId + 1].read()).ready(context.latestOracleVersion)
@@ -692,9 +706,15 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             context.local.currentId != context.local.latestId &&
             (nextOrder = _pendingOrders[context.account][context.local.latestId + 1].read()).ready(context.latestOracleVersion)
         ) _processOrderLocal(context, settlementContext, context.local.latestId + 1, nextOrder.timestamp, nextOrder);
+    }
 
-        // sync - advance position timestamps to the latest oracle version
-        //      - latest versions are guaranteed to have present prices in the oracle, but could be stale
+    /// @notice Settles the account position up to the latest timestamp
+    /// @dev - Assumes that _sync has been called prior to this function
+    ///      - Advance position timestamps to the latest oracle version
+    ///      - Latest versions are guaranteed to have present prices in the oracle, but could be stale
+    /// @param context The context to use
+    /// @param settlementContext The settlement context to use
+    function _settle(Context memory context, SettlementContext memory settlementContext) private notSettleOnly(context) {
         if (context.latestOracleVersion.timestamp > context.latestPositionGlobal.timestamp)
             _processOrderGlobal(
                 context,
@@ -703,7 +723,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
                 context.latestOracleVersion.timestamp,
                 _pendingOrder[context.global.latestId].read()
             );
-
         if (context.latestOracleVersion.timestamp > context.latestPositionLocal.timestamp)
             _processOrderLocal(
                 context,

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -148,6 +148,7 @@ interface IMarket is IInstance {
     function liquidators(address account, uint256 id) external view returns (address);
     function orderReferrers(address account, uint256 id) external view returns (address);
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
+    function sync(address account) external;
     function settle(address account) external;
     function update(Intent calldata intent, bytes memory signature) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;

--- a/packages/perennial/contracts/types/MarketParameter.sol
+++ b/packages/perennial/contracts/types/MarketParameter.sol
@@ -31,8 +31,8 @@ struct MarketParameter {
     /// @dev Whether the market is in close-only mode
     bool closed;
 
-     /// @dev Whether the market is in settle-only mode
-    bool settle;
+     /// @dev Whether the market is in sync-only mode
+    bool syncOnly;
 }
 struct MarketParameterStorage { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using MarketParameterStorageLib for MarketParameterStorage global;
@@ -101,7 +101,7 @@ library MarketParameterStorageLib {
 
     function _store(MarketParameterStorage storage self, MarketParameter memory newValue) private {
         uint256 flags = (newValue.closed ? 0x04 : 0x00) |
-            (newValue.settle ? 0x08 : 0x00);
+            (newValue.syncOnly ? 0x08 : 0x00);
 
         uint256 encoded0 =
             uint256(UFixed6.unwrap(newValue.fundingFee) << (256 - 24)) >> (256 - 24) |

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -104,7 +104,7 @@ describe('Happy Path', () => {
       maxPendingLocal: 8,
       settlementFee: 0,
       closed: false,
-      settle: false,
+      syncOnly: false,
     }
     const marketAddress = await marketFactory.callStatic.create(definition)
     await expect(marketFactory.create(definition)).to.emit(marketFactory, 'MarketCreated')
@@ -1156,7 +1156,7 @@ describe('Happy Path', () => {
       makerFee: positionFeesOn ? parse6decimal('0.2') : 0,
       takerFee: positionFeesOn ? parse6decimal('0.1') : 0,
       closed: false,
-      settle: false,
+      syncOnly: false,
     }
 
     const market = await createMarket(instanceVars)
@@ -1319,7 +1319,7 @@ describe('Happy Path', () => {
       makerFee: positionFeesOn ? parse6decimal('0.2') : 0,
       takerFee: positionFeesOn ? parse6decimal('0.1') : 0,
       closed: false,
-      settle: false,
+      syncOnly: false,
     }
 
     const market = await createMarket(instanceVars)

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -265,7 +265,7 @@ export async function createMarket(
     maxPendingLocal: 8,
     settlementFee: 0,
     closed: false,
-    settle: false,
+    syncOnly: false,
     ...marketParamOverrides,
   }
   const marketAddress = await marketFactory.callStatic.create(definition)

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -1266,6 +1266,264 @@ describe('Market', () => {
       })
     })
 
+    describe('#sync', async () => {
+      beforeEach(async () => {
+        await market.connect(owner).updateCoordinator(coordinator.address)
+        await market.connect(owner).updateBeneficiary(beneficiary.address)
+        await market.connect(owner).updateParameter(marketParameter)
+
+        oracle.at.whenCalledWith(ORACLE_VERSION_0.timestamp).returns([ORACLE_VERSION_0, INITIALIZED_ORACLE_RECEIPT])
+        oracle.at.whenCalledWith(ORACLE_VERSION_1.timestamp).returns([ORACLE_VERSION_1, INITIALIZED_ORACLE_RECEIPT])
+
+        oracle.status.returns([ORACLE_VERSION_1, ORACLE_VERSION_2.timestamp])
+        oracle.request.whenCalledWith(user.address).returns()
+
+        dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+      })
+
+      it('opens the position and syncs', async () => {
+        await expect(
+          market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
+        )
+          .to.emit(market, 'PositionProcessed')
+          .withArgs(0, { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp }, DEFAULT_VERSION_ACCUMULATION_RESULT)
+          .to.emit(market, 'AccountPositionProcessed')
+          .withArgs(
+            user.address,
+            0,
+            { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp },
+            DEFAULT_LOCAL_ACCUMULATION_RESULT,
+          )
+          .to.emit(market, 'OrderCreated')
+          .withArgs(
+            user.address,
+            {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
+            },
+            { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
+          )
+
+        oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
+        oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+        oracle.request.whenCalledWith(user.address).returns()
+
+        await expect(await market.sync(user.address))
+          .to.emit(market, 'PositionProcessed')
+          .withArgs(
+            1,
+            {
+              ...DEFAULT_ORDER,
+              orders: 1,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              collateral: COLLATERAL,
+              makerPos: POSITION,
+            },
+            DEFAULT_VERSION_ACCUMULATION_RESULT,
+          )
+          .to.emit(market, 'AccountPositionProcessed')
+          .withArgs(
+            user.address,
+            1,
+            {
+              ...DEFAULT_ORDER,
+              orders: 1,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              collateral: COLLATERAL,
+              makerPos: POSITION,
+            },
+            DEFAULT_LOCAL_ACCUMULATION_RESULT,
+          )
+
+        expectLocalEq(await market.locals(user.address), {
+          ...DEFAULT_LOCAL,
+          currentId: 1,
+          latestId: 1,
+          collateral: COLLATERAL,
+        })
+        expectPositionEq(await market.positions(user.address), {
+          ...DEFAULT_POSITION,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          maker: POSITION,
+        })
+        expectOrderEq(await market.pendingOrders(user.address, 1), {
+          ...DEFAULT_ORDER,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          orders: 1,
+          makerPos: POSITION,
+          collateral: COLLATERAL,
+        })
+        expectOrderEq(await market.pendingOrders(user.address, 2), {
+          ...DEFAULT_ORDER,
+        })
+        expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
+          ...DEFAULT_CHECKPOINT,
+        })
+        expectGlobalEq(await market.global(), {
+          ...DEFAULT_GLOBAL,
+          ...DEFAULT_GLOBAL,
+          currentId: 1,
+          latestId: 1,
+        })
+        expectPositionEq(await market.position(), {
+          ...DEFAULT_POSITION,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          maker: POSITION,
+        })
+        expectOrderEq(await market.pendingOrder(1), {
+          ...DEFAULT_ORDER,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          orders: 1,
+          makerPos: POSITION,
+          collateral: COLLATERAL,
+        })
+        expectOrderEq(await market.pendingOrder(2), {
+          ...DEFAULT_ORDER,
+        })
+        expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
+          ...DEFAULT_VERSION,
+          price: PRICE,
+          liquidationFee: { _value: -riskParameter.liquidationFee },
+        })
+      })
+
+      it('syncs when market is in settle-only mode', async () => {
+        await expect(
+          market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
+        )
+          .to.emit(market, 'PositionProcessed')
+          .withArgs(0, { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp }, DEFAULT_VERSION_ACCUMULATION_RESULT)
+          .to.emit(market, 'AccountPositionProcessed')
+          .withArgs(
+            user.address,
+            0,
+            { ...DEFAULT_ORDER, timestamp: ORACLE_VERSION_1.timestamp },
+            DEFAULT_LOCAL_ACCUMULATION_RESULT,
+          )
+          .to.emit(market, 'OrderCreated')
+          .withArgs(
+            user.address,
+            {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
+            },
+            { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
+          )
+
+        oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
+        oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+        oracle.request.whenCalledWith(user.address).returns()
+
+        const marketParameter = { ...(await market.parameter()) }
+        marketParameter.settle = true
+        await market.connect(owner).updateParameter(marketParameter)
+
+        await expect(await market.sync(user.address))
+          .to.emit(market, 'PositionProcessed')
+          .withArgs(
+            1,
+            {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              collateral: COLLATERAL,
+              makerPos: POSITION,
+            },
+            DEFAULT_VERSION_ACCUMULATION_RESULT,
+          )
+          .to.emit(market, 'AccountPositionProcessed')
+          .withArgs(
+            user.address,
+            1,
+            {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              collateral: COLLATERAL,
+              makerPos: POSITION,
+            },
+            DEFAULT_LOCAL_ACCUMULATION_RESULT,
+          )
+
+        expectLocalEq(await market.locals(user.address), {
+          ...DEFAULT_LOCAL,
+          currentId: 1,
+          latestId: 1,
+          collateral: COLLATERAL,
+        })
+        expectPositionEq(await market.positions(user.address), {
+          ...DEFAULT_POSITION,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          maker: POSITION,
+        })
+        expectOrderEq(await market.pendingOrders(user.address, 1), {
+          ...DEFAULT_ORDER,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          orders: 1,
+          makerPos: POSITION,
+          collateral: COLLATERAL,
+        })
+        expectOrderEq(await market.pendingOrders(user.address, 2), {
+          ...DEFAULT_ORDER,
+        })
+        expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
+          ...DEFAULT_CHECKPOINT,
+        })
+        expectGlobalEq(await market.global(), {
+          ...DEFAULT_GLOBAL,
+          ...DEFAULT_GLOBAL,
+          currentId: 1,
+          latestId: 1,
+        })
+        expectPositionEq(await market.position(), {
+          ...DEFAULT_POSITION,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          maker: POSITION,
+        })
+        expectOrderEq(await market.pendingOrder(1), {
+          ...DEFAULT_ORDER,
+          timestamp: ORACLE_VERSION_2.timestamp,
+          orders: 1,
+          makerPos: POSITION,
+          collateral: COLLATERAL,
+        })
+        expectOrderEq(await market.pendingOrder(2), {
+          ...DEFAULT_ORDER,
+        })
+        expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
+          ...DEFAULT_VERSION,
+          price: PRICE,
+          liquidationFee: { _value: -riskParameter.liquidationFee },
+        })
+      })
+
+      it('reverts when paused', async () => {
+        factory.paused.returns(true)
+
+        await expect(
+          market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
+        ).to.revertedWithCustomError(market, 'InstancePausedError')
+      })
+    })
+
     describe('#settle', async () => {
       beforeEach(async () => {
         await market.connect(owner).updateCoordinator(coordinator.address)
@@ -1369,7 +1627,6 @@ describe('Market', () => {
         })
         expectGlobalEq(await market.global(), {
           ...DEFAULT_GLOBAL,
-          ...DEFAULT_GLOBAL,
           currentId: 1,
           latestId: 1,
         })
@@ -1395,7 +1652,7 @@ describe('Market', () => {
         })
       })
 
-      it('settles when market is in settle-only mode', async () => {
+      it('doesnt settle when market is in sync-only mode', async () => {
         await expect(
           market
             .connect(user)
@@ -1434,93 +1691,7 @@ describe('Market', () => {
         marketParameter.settle = true
         await market.connect(owner).updateParameter(marketParameter)
 
-        await expect(await market.settle(user.address))
-          .to.emit(market, 'PositionProcessed')
-          .withArgs(
-            1,
-            {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              collateral: COLLATERAL,
-              makerPos: POSITION,
-            },
-            DEFAULT_VERSION_ACCUMULATION_RESULT,
-          )
-          .to.emit(market, 'AccountPositionProcessed')
-          .withArgs(
-            user.address,
-            1,
-            {
-              ...DEFAULT_ORDER,
-              timestamp: ORACLE_VERSION_2.timestamp,
-              orders: 1,
-              collateral: COLLATERAL,
-              makerPos: POSITION,
-            },
-            DEFAULT_LOCAL_ACCUMULATION_RESULT,
-          )
-
-        expectLocalEq(await market.locals(user.address), {
-          ...DEFAULT_LOCAL,
-          currentId: 1,
-          latestId: 1,
-          collateral: COLLATERAL,
-        })
-        expectPositionEq(await market.positions(user.address), {
-          ...DEFAULT_POSITION,
-          timestamp: ORACLE_VERSION_2.timestamp,
-          maker: POSITION,
-        })
-        expectOrderEq(await market.pendingOrders(user.address, 1), {
-          ...DEFAULT_ORDER,
-          timestamp: ORACLE_VERSION_2.timestamp,
-          orders: 1,
-          makerPos: POSITION,
-          collateral: COLLATERAL,
-        })
-        expectOrderEq(await market.pendingOrders(user.address, 2), {
-          ...DEFAULT_ORDER,
-        })
-        expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_3.timestamp), {
-          ...DEFAULT_CHECKPOINT,
-        })
-        expectGlobalEq(await market.global(), {
-          ...DEFAULT_GLOBAL,
-          ...DEFAULT_GLOBAL,
-          currentId: 1,
-          latestId: 1,
-        })
-        expectPositionEq(await market.position(), {
-          ...DEFAULT_POSITION,
-          timestamp: ORACLE_VERSION_2.timestamp,
-          maker: POSITION,
-        })
-        expectOrderEq(await market.pendingOrder(1), {
-          ...DEFAULT_ORDER,
-          timestamp: ORACLE_VERSION_2.timestamp,
-          orders: 1,
-          makerPos: POSITION,
-          collateral: COLLATERAL,
-        })
-        expectOrderEq(await market.pendingOrder(2), {
-          ...DEFAULT_ORDER,
-        })
-        expectVersionEq(await market.versions(ORACLE_VERSION_2.timestamp), {
-          ...DEFAULT_VERSION,
-          price: PRICE,
-          liquidationFee: { _value: -riskParameter.liquidationFee },
-        })
-      })
-
-      it('reverts when paused', async () => {
-        factory.paused.returns(true)
-
-        await expect(
-          market
-            .connect(user)
-            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, POSITION, 0, 0, COLLATERAL, false),
-        ).to.revertedWithCustomError(market, 'InstancePausedError')
+        await expect(market.settle(user.address)).to.revertedWithCustomError(market, 'MarketSettleOnlyError')
       })
     })
 

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -496,7 +496,7 @@ describe('Market', () => {
       maxPendingGlobal: 5,
       maxPendingLocal: 3,
       closed: false,
-      settle: false,
+      syncOnly: false,
     }
     market = await new Market__factory(
       {
@@ -657,7 +657,7 @@ describe('Market', () => {
         maxPendingGlobal: 5,
         maxPendingLocal: 3,
         closed: true,
-        settle: true,
+        syncOnly: true,
       }
 
       it('updates the parameters', async () => {
@@ -673,7 +673,7 @@ describe('Market', () => {
         expect(marketParameter.maxPendingGlobal).to.equal(defaultMarketParameter.maxPendingGlobal)
         expect(marketParameter.maxPendingLocal).to.equal(defaultMarketParameter.maxPendingLocal)
         expect(marketParameter.closed).to.equal(defaultMarketParameter.closed)
-        expect(marketParameter.settle).to.equal(defaultMarketParameter.settle)
+        expect(marketParameter.syncOnly).to.equal(defaultMarketParameter.syncOnly)
       })
 
       it('reverts if not owner (user)', async () => {
@@ -1431,7 +1431,7 @@ describe('Market', () => {
         oracle.request.whenCalledWith(user.address).returns()
 
         const marketParameter = { ...(await market.parameter()) }
-        marketParameter.settle = true
+        marketParameter.syncOnly = true
         await market.connect(owner).updateParameter(marketParameter)
 
         await expect(await market.sync(user.address))
@@ -15643,7 +15643,7 @@ describe('Market', () => {
       context('settle only', async () => {
         it('reverts if update during settle-only', async () => {
           const marketParameter = { ...(await market.parameter()) }
-          marketParameter.settle = true
+          marketParameter.syncOnly = true
           await market.updateParameter(marketParameter)
 
           dsu.transferFrom.whenCalledWith(user.address, market.address, utils.parseEther('500')).returns(true)

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -73,7 +73,7 @@ function generateMarketParameter(riskFee: BigNumberish): MarketParameterStruct {
     maxPendingLocal: 0,
     riskFee,
     closed: false,
-    settle: false,
+    syncOnly: false,
   }
 }
 

--- a/packages/perennial/test/unit/types/MarketParameter.test.ts
+++ b/packages/perennial/test/unit/types/MarketParameter.test.ts
@@ -26,7 +26,7 @@ export const VALID_MARKET_PARAMETER: MarketParameterStruct = {
   maxPendingGlobal: 10,
   maxPendingLocal: 11,
   closed: false,
-  settle: false,
+  syncOnly: false,
 }
 
 const PROTOCOL_PARAMETER: ProtocolParameterStruct = {
@@ -72,7 +72,7 @@ describe('MarketParameter', () => {
       expect(value.maxPendingGlobal).to.equal(10)
       expect(value.maxPendingLocal).to.equal(11)
       expect(value.closed).to.equal(false)
-      expect(value.settle).to.equal(false)
+      expect(value.syncOnly).to.equal(false)
     })
 
     context('.fundingFee', async () => {
@@ -282,16 +282,16 @@ describe('MarketParameter', () => {
         expect(value.closed).to.equal(true)
       })
 
-      it('saves settle', async () => {
+      it('saves syncOnly', async () => {
         await marketParameter.validateAndStore(
           {
             ...VALID_MARKET_PARAMETER,
-            settle: true,
+            syncOnly: true,
           },
           PROTOCOL_PARAMETER,
         )
         const value = await marketParameter.read()
-        expect(value.settle).to.equal(true)
+        expect(value.syncOnly).to.equal(true)
       })
     })
   })


### PR DESCRIPTION
#### Background
During settle-only mode, new prices can still be committed un-requested causing a new version to cut via `sync()`.

This makes it very hard to ensure all local accounts are synced up to the latest global during an async migration.

#### Changes
- Splits settle() and sync() / flips naming to ensure backwards compatibility
  - `sync()` only settles up to latest order
  - `settle()` settles up to latest order and then up to the latest timestamp
- Rename settle-only to sync-only, make sync-only mode only allow `sync()`

#### Migration Notes
While this makes migrations significantly safer, we still require the `makerValue`/`longValue`/`shortValue` to be continually backwards compatible in `Version`.