### PR TITLE
Only settle in settle-only mode

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -693,6 +693,9 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             (nextOrder = _pendingOrders[context.account][context.local.latestId + 1].read()).ready(context.latestOracleVersion)
         ) _processOrderLocal(context, settlementContext, context.local.latestId + 1, nextOrder.timestamp, nextOrder);
 
+        // don't sync in settle-only mode
+        if (context.marketParameter.settle) return;
+
         // sync - advance position timestamps to the latest oracle version
         //      - latest versions are guaranteed to have present prices in the oracle, but could be stale
         if (context.latestOracleVersion.timestamp > context.latestPositionGlobal.timestamp)

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -1395,7 +1395,7 @@ describe('Market', () => {
         })
       })
 
-      it('settles when market is in settle-only mode', async () => {
+      it('settles when market is in settle-only mode, but doesnt sync', async () => {
         await expect(
           market
             .connect(user)
@@ -1427,7 +1427,8 @@ describe('Market', () => {
           )
 
         oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
-        oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+        oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns([ORACLE_VERSION_3, INITIALIZED_ORACLE_RECEIPT])
+        oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
         oracle.request.whenCalledWith(user.address).returns()
 
         const marketParameter = { ...(await market.parameter()) }


### PR DESCRIPTION
#### Background
During settle-only mode, new prices can still be committed un-requested causing a new version to cut via the sync-phase.

This makes it very hard to ensure all local accounts are synced up to the latest global during an async migration.

#### Changes
- When in settle-only mode, `settle()` will only run the settlement phase, and will skip the sync phase.

#### Migration Notes
While this makes migrations significantly safer, we still require the `makerValue`/`longValue`/`shortValue` to be continually backwards compatible in `Version`.