### PR TITLE
Charge trade fee to signer

### DIFF
--- a/packages/perennial/contracts/test/GuaranteeTester.sol
+++ b/packages/perennial/contracts/test/GuaranteeTester.sol
@@ -8,8 +8,8 @@ abstract contract GuaranteeTester {
 
     function store(Guarantee memory newGuarantee) public virtual;
 
-    function from(Order memory order, Fixed6 price, UFixed6 referralFee, bool chargeFee) external {
-        Guarantee memory newGuarantee = GuaranteeLib.from(order, price, referralFee, chargeFee);
+    function from(Order memory order, Fixed6 price, UFixed6 referralFee, bool chargeSettlementFee, bool chargeTradeFee) external {
+        Guarantee memory newGuarantee = GuaranteeLib.from(order, price, referralFee, chargeSettlementFee, chargeTradeFee);
         store(newGuarantee);
     }
 }

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -51,20 +51,22 @@ library GuaranteeLib {
     /// @param order The order to create the guarantee from
     /// @param priceOverride The price override
     /// @param referralFee The referral fee percentage
-    /// @param chargeFee Whether the order will still be charged the fee
+    /// @param chargeSettlementFee Whether the order will still be charged the settlement fee
+    /// @param chargeTradeFee Whether the order will still be charged the trade fee
     /// @return newGuarantee The resulting guarantee
     function from(
         Order memory order,
         Fixed6 priceOverride,
         UFixed6 referralFee,
-        bool chargeFee
+        bool chargeSettlementFee,
+        bool chargeTradeFee
     ) internal pure returns (Guarantee memory newGuarantee) {
         // maker orders and one intent order per fill will be required to pay the settlement fee
-        if (!order.takerTotal().isZero() && !chargeFee) newGuarantee.orders = order.orders;
+        if (!order.takerTotal().isZero() && !chargeSettlementFee) newGuarantee.orders = order.orders;
 
         (newGuarantee.takerPos, newGuarantee.takerNeg) =
             (order.longPos.add(order.shortNeg), order.longNeg.add(order.shortPos));
-        newGuarantee.takerFee = chargeFee ? UFixed6Lib.ZERO : order.takerTotal();
+        newGuarantee.takerFee = chargeTradeFee ? UFixed6Lib.ZERO : order.takerTotal();
 
         newGuarantee.notional = taker(newGuarantee).mul(priceOverride);
         newGuarantee.referral = order.takerReferral.mul(referralFee);

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -236,6 +236,14 @@ const EXPECTED_INTEREST_FEE_10_123_EFF = EXPECTED_INTEREST_10_123_EFF.div(10)
 const EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF = EXPECTED_INTEREST_10_123_EFF.sub(EXPECTED_INTEREST_FEE_10_123_EFF)
 
 // rate * elapsed * utilization * min(maker, taker) * price
+// (0.1 / 365 / 24 / 60 / 60 ) * 3600 * 10 * 123 = 14040
+const EXPECTED_INTEREST_10_123_EFF_2 = BigNumber.from(14040)
+const EXPECTED_INTEREST_FEE_10_123_EFF_2 = EXPECTED_INTEREST_10_123_EFF_2.div(10)
+const EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF_2 = EXPECTED_INTEREST_10_123_EFF_2.sub(
+  EXPECTED_INTEREST_FEE_10_123_EFF_2,
+)
+
+// rate * elapsed * utilization * min(maker, taker) * price
 // (0.10 / 365 / 24 / 60 / 60 ) * 3600 * 5 * 123 = 7020
 const EXPECTED_INTEREST_5_123 = BigNumber.from(7020)
 const EXPECTED_INTEREST_FEE_5_123 = EXPECTED_INTEREST_5_123.div(10)
@@ -20244,6 +20252,7 @@ describe('Market', () => {
           dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
           dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
           dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userD.address, market.address, COLLATERAL.mul(1e12)).returns(true)
         })
 
         context('opens position', async () => {
@@ -20309,10 +20318,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -20333,18 +20338,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20354,19 +20360,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   shortPos: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
             oracle.at
               .whenCalledWith(ORACLE_VERSION_2.timestamp)
@@ -20386,7 +20391,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 1,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL).sub(TAKER_FEE),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -20398,6 +20403,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
@@ -20429,7 +20435,6 @@ describe('Market', () => {
               currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
-                .sub(TAKER_FEE)
                 .add(EXPECTED_PNL)
                 .sub(SETTLEMENT_FEE.div(2)),
             })
@@ -20443,7 +20448,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               shortPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
@@ -20557,10 +20561,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -20581,18 +20581,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20602,19 +20603,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -20635,7 +20635,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 1,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL).sub(TAKER_FEE),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -20647,6 +20647,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
@@ -20678,7 +20679,6 @@ describe('Market', () => {
               currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
-                .sub(TAKER_FEE)
                 .sub(EXPECTED_PNL)
                 .sub(SETTLEMENT_FEE.div(2)),
             })
@@ -20692,7 +20692,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
@@ -20806,10 +20805,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -20830,18 +20825,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(121),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20851,19 +20847,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   shortPos: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(121),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -20884,7 +20879,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 1,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL).sub(TAKER_FEE),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -20896,6 +20891,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
@@ -20927,7 +20923,6 @@ describe('Market', () => {
               currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
-                .sub(TAKER_FEE)
                 .sub(EXPECTED_PNL)
                 .sub(SETTLEMENT_FEE.div(2)),
             })
@@ -20941,7 +20936,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               shortPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
@@ -21055,10 +21049,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -21079,17 +21069,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(121),
-                  takerFee: POSITION.div(2),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21099,19 +21091,17 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_2.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(121),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -21132,7 +21122,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 1,
               latestId: 1,
-              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL).sub(TAKER_FEE),
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -21144,6 +21134,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
@@ -21175,7 +21166,6 @@ describe('Market', () => {
               currentId: 1,
               latestId: 1,
               collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
-                .sub(TAKER_FEE)
                 .add(EXPECTED_PNL)
                 .sub(SETTLEMENT_FEE.div(2)),
             })
@@ -21189,7 +21179,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_2.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
               collateral: COLLATERAL,
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
@@ -21236,6 +21225,348 @@ describe('Market', () => {
               },
               longValue: { _value: EXPECTED_INTEREST_10_123_EFF.div(2).div(5).mul(-1) },
               shortValue: { _value: EXPECTED_INTEREST_10_123_EFF.div(2).div(5).mul(-1) },
+              price: PRICE,
+              liquidationFee: { _value: -riskParameter.liquidationFee },
+            })
+          })
+
+          it('fills multiple positions and settles later with fee', async () => {
+            factory.parameter.returns({
+              maxPendingIds: 5,
+              protocolFee: parse6decimal('0.50'),
+              maxFee: parse6decimal('0.01'),
+              maxFeeAbsolute: parse6decimal('1000'),
+              maxCut: parse6decimal('0.50'),
+              maxRate: parse6decimal('10.00'),
+              minMaintenance: parse6decimal('0.01'),
+              minEfficiency: parse6decimal('0.1'),
+              referralFee: parse6decimal('0.20'),
+              minScale: parse6decimal('0.001'),
+            })
+
+            const marketParameter = { ...(await market.parameter()) }
+            marketParameter.takerFee = parse6decimal('0.01')
+            await market.updateParameter(marketParameter)
+
+            const riskParameter = { ...(await market.riskParameter()) }
+            await market.updateRiskParameter({
+              ...riskParameter,
+              takerFee: {
+                ...riskParameter.takerFee,
+                linearFee: parse6decimal('0.001'),
+                proportionalFee: parse6decimal('0.002'),
+                adiabaticFee: parse6decimal('0.004'),
+              },
+            })
+
+            const EXPECTED_PNL = parse6decimal('10') // position * (125-123)
+            const TAKER_FEE = parse6decimal('6.15') // position * (0.01) * price
+            const SETTLEMENT_FEE = parse6decimal('0.50')
+
+            const intent1 = {
+              amount: POSITION.div(2),
+              price: parse6decimal('125'),
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
+              common: {
+                account: user.address,
+                signer: user.address,
+                domain: market.address,
+                nonce: 0,
+                group: 0,
+                expiry: 0,
+              },
+            }
+
+            const intent2 = {
+              amount: POSITION.div(2),
+              price: parse6decimal('125'),
+              fee: parse6decimal('0.5'),
+              originator: owner.address,
+              solver: liquidator.address,
+              common: {
+                account: userD.address,
+                signer: userD.address,
+                domain: market.address,
+                nonce: 0,
+                group: 0,
+                expiry: 0,
+              },
+            }
+
+            await market
+              .connect(userB)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+            await market
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+            await market
+              .connect(userD)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userD.address, 0, 0, 0, COLLATERAL, false)
+            await market
+              .connect(userC)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+            verifier.verifyIntent.returns()
+
+            // taker 1
+            factory.authorization
+              .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
+              .returns([false, true, parse6decimal('0.20')])
+            // taker 2
+            factory.authorization
+              .whenCalledWith(userD.address, userC.address, userD.address, owner.address)
+              .returns([false, true, parse6decimal('0.20')])
+
+            await expect(
+              market
+                .connect(userC)
+                [
+                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](intent1, DEFAULT_SIGNATURE),
+            )
+              .to.emit(market, 'OrderCreated')
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
+                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
+              )
+              .to.emit(market, 'OrderCreated')
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
+              )
+
+            await expect(
+              market
+                .connect(userC)
+                [
+                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](intent2, DEFAULT_SIGNATURE),
+            )
+              .to.emit(market, 'OrderCreated')
+              .withArgs(
+                userD.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
+                constants.AddressZero,
+                owner.address, // originator
+                liquidator.address, // solver
+              )
+              .to.emit(market, 'OrderCreated')
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
+              )
+
+            oracle.at
+              .whenCalledWith(ORACLE_VERSION_2.timestamp)
+              .returns([ORACLE_VERSION_2, { ...INITIALIZED_ORACLE_RECEIPT, settlementFee: SETTLEMENT_FEE }])
+
+            oracle.at
+              .whenCalledWith(ORACLE_VERSION_3.timestamp)
+              .returns([ORACLE_VERSION_3, { ...INITIALIZED_ORACLE_RECEIPT, settlementFee: SETTLEMENT_FEE }])
+            oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
+            oracle.request.whenCalledWith(user.address).returns()
+
+            await settle(market, user)
+            await settle(market, userB)
+            await settle(market, userC)
+            await settle(market, userD)
+
+            expectLocalEq(await market.locals(user.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF_2.div(4)).sub(EXPECTED_PNL).sub(TAKER_FEE),
+            })
+            expectPositionEq(await market.positions(user.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              long: POSITION.div(2),
+            })
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(userD.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF_2.div(4)).sub(EXPECTED_PNL).sub(TAKER_FEE),
+            })
+            expectPositionEq(await market.positions(userD.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              long: POSITION.div(2),
+            })
+            expectOrderEq(await market.pendingOrders(userD.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(userD.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(userB.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF_2).sub(SETTLEMENT_FEE.div(3)).sub(7), // loss of precision
+            })
+            expectPositionEq(await market.positions(userB.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              maker: POSITION,
+            })
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(userC.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF_2.div(2))
+                .add(EXPECTED_PNL.mul(2))
+                .sub(SETTLEMENT_FEE.mul(2).div(3))
+                .sub(11), // loss of precision
+            })
+            expectPositionEq(await market.positions(userC.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              short: POSITION,
+            })
+            expectOrderEq(await market.pendingOrders(userC.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 2,
+              shortPos: POSITION,
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(liquidator.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10), // solver + originator
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10), // solver + originator
+            })
+            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF_2.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)).mul(2))
+            expectGlobalEq(await market.global(), {
+              ...DEFAULT_GLOBAL,
+              currentId: 1,
+              latestId: 1,
+              protocolFee: totalFee.mul(8).div(10).add(2), // loss of precision
+              oracleFee: totalFee.div(10).add(SETTLEMENT_FEE), // loss of precision
+              riskFee: totalFee.div(10).sub(1), // loss of precision
+            })
+            expectPositionEq(await market.position(), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              maker: POSITION,
+              long: POSITION,
+              short: POSITION,
+            })
+            expectOrderEq(await market.pendingOrder(1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 5,
+              makerPos: POSITION,
+              shortPos: POSITION,
+              longPos: POSITION,
+              takerReferral: POSITION.div(2).mul(2).div(10).mul(2),
+              collateral: COLLATERAL.mul(4),
+            })
+            expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
+              ...DEFAULT_VERSION,
+              makerValue: {
+                _value: EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF_2.div(10),
+              },
+              longValue: { _value: EXPECTED_INTEREST_10_123_EFF_2.div(2).div(10).mul(-1) },
+              shortValue: { _value: EXPECTED_INTEREST_10_123_EFF_2.div(2).div(10).mul(-1).sub(1) },
               price: PRICE,
               liquidationFee: { _value: -riskParameter.liquidationFee },
             })
@@ -21320,10 +21651,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -21344,18 +21671,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   longNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21365,19 +21693,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -21398,7 +21725,8 @@ describe('Market', () => {
                 .sub(SETTLEMENT_FEE.div(2)) // open
                 .sub(EXPECTED_INTEREST_5_123)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123) // while open
-                .add(EXPECTED_PNL), // close
+                .add(EXPECTED_PNL)
+                .sub(TAKER_FEE), // close
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -21409,6 +21737,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               longNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21441,7 +21770,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 2,
-              collateral: COLLATERAL.sub(TAKER_FEE).sub(SETTLEMENT_FEE).sub(EXPECTED_PNL), // open
+              collateral: COLLATERAL.sub(SETTLEMENT_FEE).sub(EXPECTED_PNL), // open
             })
             expectPositionEq(await market.positions(userC.address), {
               ...DEFAULT_POSITION,
@@ -21453,7 +21782,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21582,10 +21910,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -21606,18 +21930,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   shortNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21627,19 +21952,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   shortPos: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -21660,7 +21984,8 @@ describe('Market', () => {
                 .sub(SETTLEMENT_FEE.div(2)) // open
                 .sub(EXPECTED_INTEREST_5_123)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123) // while open
-                .sub(EXPECTED_PNL), // close
+                .sub(EXPECTED_PNL)
+                .sub(TAKER_FEE), // close
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -21671,6 +21996,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21703,7 +22029,7 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 2,
-              collateral: COLLATERAL.sub(TAKER_FEE).sub(SETTLEMENT_FEE).add(EXPECTED_PNL), // open
+              collateral: COLLATERAL.sub(SETTLEMENT_FEE).add(EXPECTED_PNL), // open
             })
             expectPositionEq(await market.positions(userC.address), {
               ...DEFAULT_POSITION,
@@ -21715,7 +22041,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               shortPos: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21844,10 +22169,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -21868,18 +22189,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21889,19 +22211,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   shortNeg: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -21918,7 +22239,8 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 2,
-              collateral: COLLATERAL.add(EXPECTED_PNL), // open
+              collateral: COLLATERAL.add(EXPECTED_PNL) // open
+                .sub(TAKER_FEE), // close
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -21930,6 +22252,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -21966,7 +22289,6 @@ describe('Market', () => {
                 .sub(SETTLEMENT_FEE.div(2)) // open
                 .sub(EXPECTED_INTEREST_5_123)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123) // while open
-                .sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE)
                 .sub(EXPECTED_PNL), // close
             })
@@ -21979,7 +22301,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               shortNeg: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22108,10 +22429,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -22132,18 +22449,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   longPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -22153,19 +22471,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   longNeg: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -22182,7 +22499,8 @@ describe('Market', () => {
               ...DEFAULT_LOCAL,
               currentId: 2,
               latestId: 2,
-              collateral: COLLATERAL.sub(EXPECTED_PNL), // open
+              collateral: COLLATERAL.sub(EXPECTED_PNL) // open
+                .sub(TAKER_FEE), // close
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -22194,6 +22512,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22230,7 +22549,6 @@ describe('Market', () => {
                 .sub(SETTLEMENT_FEE.div(2)) // open
                 .sub(EXPECTED_INTEREST_5_123)
                 .sub(EXPECTED_FUNDING_WITH_FEE_1_5_123) // while open
-                .sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE)
                 .add(EXPECTED_PNL), // close
             })
@@ -22243,7 +22561,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               longNeg: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22378,10 +22695,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -22402,18 +22715,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   longNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -22423,19 +22737,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   shortNeg: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -22455,7 +22768,8 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(3).add(1)) // open
                 .sub(EXPECTED_INTEREST_10_123_EFF.div(2)) // while open
-                .add(EXPECTED_PNL), // close
+                .add(EXPECTED_PNL)
+                .sub(TAKER_FEE), // close
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -22466,6 +22780,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               longNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22500,7 +22815,6 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(3).add(1))
                 .sub(TAKER_FEE) // open
                 .sub(EXPECTED_INTEREST_10_123_EFF.div(2)) // while open
-                .sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE)
                 .sub(EXPECTED_PNL), // close
             })
@@ -22513,7 +22827,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               shortNeg: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22648,10 +22961,6 @@ describe('Market', () => {
 
             verifier.verifyIntent.returns()
 
-            // maker
-            factory.authorization
-              .whenCalledWith(userC.address, userC.address, constants.AddressZero, liquidator.address)
-              .returns([false, true, parse6decimal('0.20')])
             // taker
             factory.authorization
               .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
@@ -22672,18 +22981,19 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   shortNeg: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 1,
                   takerPos: POSITION.div(2),
                   notional: POSITION.div(2).mul(125),
-                  takerFee: POSITION.div(2),
-                  referral: 0,
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
                 },
                 constants.AddressZero,
-                constants.AddressZero,
-                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
               )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -22693,19 +23003,18 @@ describe('Market', () => {
                   timestamp: ORACLE_VERSION_3.timestamp,
                   orders: 1,
                   longNeg: POSITION.div(2),
-                  takerReferral: POSITION.div(2).mul(2).div(10),
                 },
                 {
                   ...DEFAULT_GUARANTEE,
                   orders: 0,
                   takerNeg: POSITION.div(2),
                   notional: -POSITION.div(2).mul(125),
-                  takerFee: 0,
-                  referral: POSITION.div(2).div(10),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
                 },
                 constants.AddressZero,
-                liquidator.address, // originator
-                owner.address, // solver
+                constants.AddressZero,
+                constants.AddressZero,
               )
 
             oracle.at
@@ -22725,7 +23034,8 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE.div(3).add(1)) // open
                 .sub(EXPECTED_INTEREST_10_123_EFF.div(2)) // while open
-                .sub(EXPECTED_PNL), // close
+                .sub(EXPECTED_PNL)
+                .sub(TAKER_FEE), // close
             })
             expectPositionEq(await market.positions(user.address), {
               ...DEFAULT_POSITION,
@@ -22736,6 +23046,7 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               shortNeg: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,
@@ -22770,7 +23081,6 @@ describe('Market', () => {
               collateral: COLLATERAL.sub(SETTLEMENT_FEE.div(3).add(1))
                 .sub(TAKER_FEE) // open
                 .sub(EXPECTED_INTEREST_10_123_EFF.div(2)) // while open
-                .sub(TAKER_FEE)
                 .sub(SETTLEMENT_FEE)
                 .add(EXPECTED_PNL), // close
             })
@@ -22783,7 +23093,6 @@ describe('Market', () => {
               timestamp: ORACLE_VERSION_3.timestamp,
               orders: 1,
               longNeg: POSITION.div(2),
-              takerReferral: POSITION.div(2).mul(2).div(10),
             })
             expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
               ...DEFAULT_CHECKPOINT,


### PR DESCRIPTION
Currently the trade fee is being charged to the sender of an intent update (the solver).

This is great for UX, but has the unintended side effect of causing conflicts with referral addresses. If two orders are being filled by the same solver in the same version, but have two different referrers (either interface or solver), the second will revert since the referrer addresses are stored on the side of the trade that is getting charged.

This PR flips the trade fee and all referral information to apply the signer (trader) side of the trade instead. This follows the same UX restriction as market orders where a trader must use the same (or none) referral address per version, but is otherwise unrestricted.