### PR TITLE
Add operator to intent update

### DIFF
--- a/packages/perennial-extensions/contracts/MultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/MultiInvoker.sol
@@ -157,6 +157,10 @@ contract MultiInvoker is IMultiInvoker, Kept {
                 ) = abi.decode(invocation.args, (IMarket, UFixed6, UFixed6, UFixed6, Fixed6, bool, InterfaceFee, InterfaceFee));
 
                 _update(account, market, newMaker, newLong, newShort, collateral, wrap, interfaceFee1, interfaceFee2);
+            } else if (invocation.action == PerennialAction.UPDATE_INTENT) {
+                (IMarket market, Intent memory intent, bytes memory signature) = abi.decode(invocation.args, (IMarket, Intent, bytes));
+
+                _updateIntent(account, market, intent, signature);
             } else if (invocation.action == PerennialAction.UPDATE_VAULT) {
                 (IVault vault, UFixed6 depositAssets, UFixed6 redeemShares, UFixed6 claimAssets, bool wrap)
                     = abi.decode(invocation.args, (IVault, UFixed6, UFixed6, UFixed6, bool));
@@ -232,6 +236,19 @@ contract MultiInvoker is IMultiInvoker, Kept {
         // charge interface fee
         _chargeFee(account, market, interfaceFee1);
         _chargeFee(account, market, interfaceFee2);
+    }
+
+    /// @notice Fills an intent update on behalf of account
+    /// @param account Address of account to update
+    /// @param intent The intent that is being filled
+    /// @param signature The signature of the intent that is being filled
+    function _updateIntent(
+        address account,
+        IMarket market,
+        Intent memory intent,
+        bytes memory signature
+    ) internal isMarketInstance(market) {
+        market.update(account, intent, signature);
     }
 
     /// @notice Update vault on behalf of account

--- a/packages/perennial-extensions/contracts/interfaces/IMultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/interfaces/IMultiInvoker.sol
@@ -29,7 +29,8 @@ interface IMultiInvoker {
         EXEC_ORDER,      // 5
         COMMIT_PRICE,    // 6
         __LIQUIDATE__DEPRECATED,
-        APPROVE          // 8
+        APPROVE,         // 8
+        UPDATE_INTENT    // 9
     }
 
     struct Invocation {

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -54,7 +54,10 @@ import {
   ProxyAdmin,
   ProxyAdmin__factory,
   TransparentUpgradeableProxy__factory,
+  IVerifier,
+  IVerifier__factory,
 } from '@equilibria/perennial-v2/types/generated'
+import { Verifier__factory } from '../../../../perennial-verifier/types/generated'
 
 const { ethers } = HRE
 
@@ -81,6 +84,7 @@ export interface InstanceVars {
   proxyAdmin: ProxyAdmin
   oracleFactory: OracleFactory
   marketFactory: MarketFactory
+  verifier: IVerifier
   payoff: IPayoffProvider
   dsu: IERC20Metadata
   usdc: IERC20Metadata
@@ -119,12 +123,13 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
   )
   const oracleFactory = new OracleFactory__factory(owner).attach(oracleFactoryProxy.address)
 
-  const verifierImpl = await new VersionStorageLib__factory(owner).deploy()
+  const verifierImpl = await new Verifier__factory(owner).deploy()
   const verifierProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
     verifierImpl.address,
     proxyAdmin.address,
     [],
   )
+  const verifier = IVerifier__factory.connect(verifierProxy.address, owner)
 
   const marketImpl = await new Market__factory(
     {
@@ -219,6 +224,7 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
     proxyAdmin,
     oracleFactory,
     marketFactory,
+    verifier,
     chainlink,
     payoff,
     dsu,

--- a/packages/perennial-verifier/test/helpers/erc712.ts
+++ b/packages/perennial-verifier/test/helpers/erc712.ts
@@ -11,7 +11,7 @@ import {
 import { IVerifier, Verifier } from '../../types/generated'
 import { FakeContract } from '@defi-wonderland/smock'
 
-export function erc721Domain(verifier: Verifier | FakeContract<IVerifier>) {
+export function erc721Domain(verifier: IVerifier | Verifier | FakeContract<IVerifier>) {
   return {
     name: 'Perennial',
     version: '1.0.0',
@@ -22,7 +22,7 @@ export function erc721Domain(verifier: Verifier | FakeContract<IVerifier>) {
 
 export async function signCommon(
   signer: SignerWithAddress,
-  verifier: Verifier | FakeContract<IVerifier>,
+  verifier: IVerifier | Verifier | FakeContract<IVerifier>,
   common: CommonStruct,
 ): Promise<string> {
   const types = {
@@ -41,7 +41,7 @@ export async function signCommon(
 
 export async function signIntent(
   signer: SignerWithAddress,
-  verifier: Verifier | FakeContract<IVerifier>,
+  verifier: IVerifier | Verifier | FakeContract<IVerifier>,
   intent: IntentStruct,
 ): Promise<string> {
   const types = {
@@ -68,7 +68,7 @@ export async function signIntent(
 
 export async function signFill(
   signer: SignerWithAddress,
-  verifier: Verifier | FakeContract<IVerifier>,
+  verifier: IVerifier | Verifier | FakeContract<IVerifier>,
   fill: FillStruct,
 ): Promise<string> {
   const types = {

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -122,15 +122,16 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @notice Updates both the long and short positions of an intent order
     /// @dev - One side is specified in the signed intent, while the sender is assumed to be the counterparty
     ///      - The sender is charged the settlement fee
+    /// @param account The account that is filling this intent (maker)
     /// @param intent The intent that is being filled
     /// @param signature The signature of the intent that is being filled
-    function update(Intent calldata intent, bytes memory signature) external nonReentrant whenNotPaused {
+    function update(address account, Intent calldata intent, bytes memory signature) external nonReentrant whenNotPaused {
         if (intent.fee.gt(UFixed6Lib.ONE)) revert MarketInvalidIntentFeeError();
 
         verifier.verifyIntent(intent, signature);
 
         _updateIntent(
-            msg.sender,
+            account,
             address(0),
             intent.amount.mul(Fixed6Lib.NEG_ONE),
             intent.price,
@@ -138,7 +139,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             intent.solver,
             intent.fee,
             true
-        ); // sender
+        ); // account
         _updateIntent(
             intent.common.account,
             intent.common.signer,
@@ -524,6 +525,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         // load factory metadata
         (updateContext.operator, updateContext.signer, updateContext.orderReferralFee) =
             IMarketFactory(address(factory())).authorization(context.account, msg.sender, signer, orderReferrer);
+
         updateContext.guaranteeReferralFee = guaranteeReferralFee;
     }
 

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -156,7 +156,7 @@ interface IMarket is IInstance {
     function orderReferrers(address account, uint256 id) external view returns (address);
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
-    function update(Intent calldata intent, bytes memory signature) external;
+    function update(address account, Intent calldata intent, bytes memory signature) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer) external;
     function parameter() external view returns (MarketParameter memory);

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14730,8 +14730,8 @@ describe('Market', () => {
             market
               .connect(user)
               [
-                'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-              ](intent, '0x'),
+                'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](user.address, intent, '0x'),
           ).to.be.revertedWithCustomError(market, 'InstancePausedError')
         })
 
@@ -18058,8 +18058,8 @@ describe('Market', () => {
             market
               .connect(userC)
               [
-                'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-              ](intent, DEFAULT_SIGNATURE),
+                'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE),
           )
             .to.emit(market, 'OrderCreated')
             .withArgs(
@@ -18276,8 +18276,8 @@ describe('Market', () => {
             market
               .connect(userC)
               [
-                'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-              ](intent, DEFAULT_SIGNATURE),
+                'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE),
           ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
         })
       })
@@ -20453,8 +20453,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20702,8 +20702,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -20952,8 +20952,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21202,8 +21202,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21375,6 +21375,255 @@ describe('Market', () => {
               liquidationFee: { _value: -riskParameter.liquidationFee },
             })
           })
+
+          it('fills the positions and settles later (operator)', async () => {
+            factory.parameter.returns({
+              maxPendingIds: 5,
+              protocolFee: parse6decimal('0.50'),
+              maxFee: parse6decimal('0.01'),
+              maxFeeAbsolute: parse6decimal('1000'),
+              maxCut: parse6decimal('0.50'),
+              maxRate: parse6decimal('10.00'),
+              minMaintenance: parse6decimal('0.01'),
+              minEfficiency: parse6decimal('0.1'),
+              referralFee: parse6decimal('0.20'),
+              minScale: parse6decimal('0.001'),
+            })
+
+            const marketParameter = { ...(await market.parameter()) }
+            marketParameter.takerFee = parse6decimal('0.01')
+            await market.updateParameter(marketParameter)
+
+            const riskParameter = { ...(await market.riskParameter()) }
+            await market.updateRiskParameter({
+              ...riskParameter,
+              takerFee: {
+                ...riskParameter.takerFee,
+                linearFee: parse6decimal('0.001'),
+                proportionalFee: parse6decimal('0.002'),
+                adiabaticFee: parse6decimal('0.004'),
+              },
+            })
+
+            const EXPECTED_PNL = parse6decimal('10') // position * (125-123)
+            const TAKER_FEE = parse6decimal('6.15') // position * (0.01) * price
+            const SETTLEMENT_FEE = parse6decimal('0.50')
+
+            const intent = {
+              amount: POSITION.div(2),
+              price: parse6decimal('125'),
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
+              common: {
+                account: user.address,
+                signer: user.address,
+                domain: market.address,
+                nonce: 0,
+                group: 0,
+                expiry: 0,
+              },
+            }
+
+            await market
+              .connect(userB)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+            await market
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+            await market
+              .connect(userC)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+            verifier.verifyIntent.returns()
+
+            // maker
+            factory.authorization
+              .whenCalledWith(userC.address, userD.address, constants.AddressZero, liquidator.address) // userD is operator of userC
+              .returns([true, false, parse6decimal('0.20')])
+            // taker
+            factory.authorization
+              .whenCalledWith(user.address, userD.address, user.address, liquidator.address)
+              .returns([false, true, parse6decimal('0.20')])
+
+            await expect(
+              market
+                .connect(userD)
+                [
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
+            )
+              .to.emit(market, 'OrderCreated')
+              .withArgs(
+                user.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  longPos: POSITION.div(2),
+                },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 1,
+                  takerPos: POSITION.div(2),
+                  notional: POSITION.div(2).mul(125),
+                  takerFee: POSITION.div(2),
+                  referral: 0,
+                },
+                constants.AddressZero,
+                constants.AddressZero,
+                constants.AddressZero,
+              )
+              .to.emit(market, 'OrderCreated')
+              .withArgs(
+                userC.address,
+                {
+                  ...DEFAULT_ORDER,
+                  timestamp: ORACLE_VERSION_2.timestamp,
+                  orders: 1,
+                  shortPos: POSITION.div(2),
+                  takerReferral: POSITION.div(2).mul(2).div(10),
+                },
+                {
+                  ...DEFAULT_GUARANTEE,
+                  orders: 0,
+                  takerNeg: POSITION.div(2),
+                  notional: -POSITION.div(2).mul(125),
+                  takerFee: 0,
+                  referral: POSITION.div(2).div(10),
+                },
+                constants.AddressZero,
+                liquidator.address, // originator
+                owner.address, // solver
+              )
+            oracle.at
+              .whenCalledWith(ORACLE_VERSION_2.timestamp)
+              .returns([ORACLE_VERSION_2, { ...INITIALIZED_ORACLE_RECEIPT, settlementFee: SETTLEMENT_FEE }])
+
+            oracle.at
+              .whenCalledWith(ORACLE_VERSION_3.timestamp)
+              .returns([ORACLE_VERSION_3, { ...INITIALIZED_ORACLE_RECEIPT, settlementFee: SETTLEMENT_FEE }])
+            oracle.status.returns([ORACLE_VERSION_3, ORACLE_VERSION_4.timestamp])
+            oracle.request.whenCalledWith(user.address).returns()
+
+            await settle(market, user)
+            await settle(market, userB)
+            await settle(market, userC)
+
+            expectLocalEq(await market.locals(user.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL),
+            })
+            expectPositionEq(await market.positions(user.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              long: POSITION.div(2),
+            })
+            expectOrderEq(await market.pendingOrders(user.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              longPos: POSITION.div(2),
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(user.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(userB.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.add(EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF).sub(SETTLEMENT_FEE.div(2)).sub(4), // loss of precision
+            })
+            expectPositionEq(await market.positions(userB.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              maker: POSITION,
+            })
+            expectOrderEq(await market.pendingOrders(userB.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              makerPos: POSITION,
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(userB.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(userC.address), {
+              ...DEFAULT_LOCAL,
+              currentId: 1,
+              latestId: 1,
+              collateral: COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
+                .sub(TAKER_FEE)
+                .add(EXPECTED_PNL)
+                .sub(SETTLEMENT_FEE.div(2)),
+            })
+            expectPositionEq(await market.positions(userC.address), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              short: POSITION.div(2),
+            })
+            expectOrderEq(await market.pendingOrders(userC.address, 1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 1,
+              shortPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL,
+            })
+            expectCheckpointEq(await market.checkpoints(userC.address, ORACLE_VERSION_4.timestamp), {
+              ...DEFAULT_CHECKPOINT,
+            })
+            expectLocalEq(await market.locals(liquidator.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
+            })
+            expectLocalEq(await market.locals(owner.address), {
+              ...DEFAULT_LOCAL,
+              claimable: TAKER_FEE.mul(2).div(10).div(2),
+            })
+            const totalFee = EXPECTED_INTEREST_FEE_10_123_EFF.add(TAKER_FEE.sub(TAKER_FEE.mul(2).div(10)))
+            expectGlobalEq(await market.global(), {
+              ...DEFAULT_GLOBAL,
+              currentId: 1,
+              latestId: 1,
+              protocolFee: totalFee.mul(8).div(10).add(3), // loss of precision
+              oracleFee: totalFee.div(10).add(SETTLEMENT_FEE), // loss of precision
+              riskFee: totalFee.div(10).sub(1), // loss of precision
+              latestPrice: PRICE,
+            })
+            expectPositionEq(await market.position(), {
+              ...DEFAULT_POSITION,
+              timestamp: ORACLE_VERSION_3.timestamp,
+              maker: POSITION,
+              long: POSITION.div(2),
+              short: POSITION.div(2),
+            })
+            expectOrderEq(await market.pendingOrder(1), {
+              ...DEFAULT_ORDER,
+              timestamp: ORACLE_VERSION_2.timestamp,
+              orders: 3,
+              makerPos: POSITION,
+              shortPos: POSITION.div(2),
+              longPos: POSITION.div(2),
+              takerReferral: POSITION.div(2).mul(2).div(10),
+              collateral: COLLATERAL.mul(3),
+            })
+            expectVersionEq(await market.versions(ORACLE_VERSION_3.timestamp), {
+              ...DEFAULT_VERSION,
+              makerValue: {
+                _value: EXPECTED_INTEREST_WITHOUT_FEE_10_123_EFF.div(10),
+              },
+              longValue: { _value: EXPECTED_INTEREST_10_123_EFF.div(2).div(5).mul(-1) },
+              shortValue: { _value: EXPECTED_INTEREST_10_123_EFF.div(2).div(5).mul(-1) },
+              price: PRICE,
+              liquidationFee: { _value: -riskParameter.liquidationFee },
+            })
+          })
         })
 
         context('closes position', async () => {
@@ -21468,8 +21717,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21731,8 +21980,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -21994,8 +22243,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -22259,8 +22508,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -22530,8 +22779,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -22801,8 +23050,8 @@ describe('Market', () => {
               market
                 .connect(userC)
                 [
-                  'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-                ](intent, DEFAULT_SIGNATURE),
+                  'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+                ](userC.address, intent, DEFAULT_SIGNATURE),
             )
               .to.emit(market, 'OrderCreated')
               .withArgs(
@@ -23028,8 +23277,8 @@ describe('Market', () => {
             market
               .connect(userC)
               [
-                'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-              ](intent, DEFAULT_SIGNATURE),
+                'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE),
           ).to.be.revertedWithCustomError(market, 'MarketOperatorNotAllowedError')
         })
 
@@ -23084,8 +23333,8 @@ describe('Market', () => {
             market
               .connect(userC)
               [
-                'update((int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
-              ](intent, DEFAULT_SIGNATURE),
+                'update(address,(int256,int256,uint256,address,address,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE),
           ).to.be.revertedWithCustomError(market, 'MarketInvalidIntentFeeError')
         })
       })


### PR DESCRIPTION
Adds an `account` parameter to the intent `update()` signifying to the maker in the match. This allows intent orders to be filled by an operator is one is approved for account.