### PR TITLE
[Code Size] Move position processed events into respective libraries

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -779,6 +779,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         VersionAccumulationContext memory accumulationContext = VersionAccumulationContext(
             context.global,
             context.latestPositionGlobal,
+            newOrderId,
             newOrder,
             newGuarantee,
             settlementContext.orderOracleVersion,
@@ -796,8 +797,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         settlementContext.orderOracleVersion = oracleVersion;
         _versions[newOrder.timestamp].store(settlementContext.latestVersion);
-
-        emit PositionProcessed(newOrderId, newOrder, accumulationResult);
     }
 
     /// @notice Processes the given local pending position into the latest position
@@ -833,6 +832,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         CheckpointAccumulationResult memory accumulationResult;
         (settlementContext.latestCheckpoint, accumulationResult) = CheckpointLib.accumulate(
             settlementContext.latestCheckpoint,
+            context.account,
+            newOrderId,
             newOrder,
             newGuarantee,
             context.latestPositionLocal,
@@ -848,8 +849,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         _credit(context, liquidators[context.account][newOrderId], accumulationResult.liquidationFee);
         _credit(context, orderReferrers[context.account][newOrderId], accumulationResult.subtractiveFee);
         _credit(context, guaranteeReferrers[context.account][newOrderId], accumulationResult.solverFee);
-
-        emit AccountPositionProcessed(context.account, newOrderId, newOrder, accumulationResult);
     }
 
     /// @notice Credits an account's claimable

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -62,6 +62,8 @@ interface IMarket is IInstance {
 
     event Updated(address indexed sender, address indexed account, uint256 version, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer);
     event OrderCreated(address indexed account, Order order, Guarantee guarantee, address liquidator, address orderReferrer, address guaranteeReferrer);
+    event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
+    event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
     event BeneficiaryUpdated(address newBeneficiary);
     event CoordinatorUpdated(address newCoordinator);
     /// @notice Fee earned by an account was transferred from market to a receiver
@@ -72,9 +74,6 @@ interface IMarket is IInstance {
     event ExposureClaimed(address indexed account, Fixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);
-
-    event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
-    event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
 
     // sig: 0x0fe90964
     error MarketInsufficientLiquidityError();

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -62,8 +62,6 @@ interface IMarket is IInstance {
 
     event Updated(address indexed sender, address indexed account, uint256 version, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer);
     event OrderCreated(address indexed account, Order order, Guarantee guarantee, address liquidator, address orderReferrer, address guaranteeReferrer);
-    event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
-    event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
     event BeneficiaryUpdated(address newBeneficiary);
     event CoordinatorUpdated(address newCoordinator);
     /// @notice Fee earned by an account was transferred from market to a receiver
@@ -74,6 +72,9 @@ interface IMarket is IInstance {
     event ExposureClaimed(address indexed account, Fixed6 amount);
     event ParameterUpdated(MarketParameter newParameter);
     event RiskParameterUpdated(RiskParameter newRiskParameter);
+
+    event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
+    event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
 
     // sig: 0x0fe90964
     error MarketInsufficientLiquidityError();

--- a/packages/perennial/contracts/libs/CheckpointLib.sol
+++ b/packages/perennial/contracts/libs/CheckpointLib.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "@equilibria/root/accumulator/types/Accumulator6.sol";
+import "../interfaces/IMarket.sol";
 import "../types/OracleVersion.sol";
 import "../types/RiskParameter.sol";
 import "../types/Global.sol";

--- a/packages/perennial/contracts/libs/CheckpointLib.sol
+++ b/packages/perennial/contracts/libs/CheckpointLib.sol
@@ -41,8 +41,6 @@ struct CheckpointAccumulationResult {
 /// @dev (external-safe): this library is safe to externalize
 /// @notice Manages the logic for the local order accumulation
 library CheckpointLib {
-    event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
-
     /// @notice Accumulate pnl and fees from the latest position to next position
     /// @param self The Local object to update
     /// @param order The next order
@@ -81,7 +79,7 @@ library CheckpointLib {
         next.tradeFee = Fixed6Lib.from(result.tradeFee).add(result.offset);
         next.settlementFee = result.settlementFee.add(result.liquidationFee);
 
-        emit AccountPositionProcessed(account, orderId, order, result);
+        emit IMarket.AccountPositionProcessed(account, orderId, order, result);
     }
 
     /// @notice Accumulate pnl, funding, and interest from the latest position to next position

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -82,6 +82,7 @@ struct VersionAccumulationResult {
 struct VersionAccumulationContext {
     Global global;
     Position fromPosition;
+    uint256 orderId;
     Order order;
     Guarantee guarantee;
     OracleVersion fromOracleVersion;
@@ -95,6 +96,8 @@ struct VersionAccumulationContext {
 /// @dev (external-safe): this library is safe to externalize
 /// @notice Manages the logic for the global order accumulation
 library VersionLib {
+    event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
+
     /// @notice Accumulates the global state for the period from `fromVersion` to `toOracleVersion`
     /// @param self The Version object to update
     /// @param context The accumulation context
@@ -104,7 +107,7 @@ library VersionLib {
     function accumulate(
         Version memory self,
         VersionAccumulationContext memory context
-    ) external pure returns (Version memory next, Global memory nextGlobal, VersionAccumulationResult memory result) {
+    ) external returns (Version memory next, Global memory nextGlobal, VersionAccumulationResult memory result) {
         // setup next accumulators
         _next(self, next);
 
@@ -146,6 +149,8 @@ library VersionLib {
 
         // accumulate P&L
         (result.pnlMaker, result.pnlLong, result.pnlShort) = _accumulatePNL(next, context);
+
+        emit PositionProcessed(context.orderId, context.order, result);
 
         return (next, context.global, result);
     }

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@equilibria/root/accumulator/types/Accumulator6.sol";
 import "@equilibria/root/accumulator/types/UAccumulator6.sol";
+import "../interfaces/IMarket.sol";
 import "../types/ProtocolParameter.sol";
 import "../types/MarketParameter.sol";
 import "../types/RiskParameter.sol";

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -96,8 +96,6 @@ struct VersionAccumulationContext {
 /// @dev (external-safe): this library is safe to externalize
 /// @notice Manages the logic for the global order accumulation
 library VersionLib {
-    event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
-
     /// @notice Accumulates the global state for the period from `fromVersion` to `toOracleVersion`
     /// @param self The Version object to update
     /// @param context The accumulation context
@@ -150,7 +148,7 @@ library VersionLib {
         // accumulate P&L
         (result.pnlMaker, result.pnlLong, result.pnlShort) = _accumulatePNL(next, context);
 
-        emit PositionProcessed(context.orderId, context.order, result);
+        emit IMarket.PositionProcessed(context.orderId, context.order, result);
 
         return (next, context.global, result);
     }

--- a/packages/perennial/contracts/test/CheckpointTester.sol
+++ b/packages/perennial/contracts/test/CheckpointTester.sol
@@ -16,6 +16,8 @@ contract CheckpointTester {
     }
 
     function accumulate(
+        address account,
+        uint256 orderId,
         Order memory order,
         Guarantee memory guarantee,
         Position memory fromPosition,
@@ -23,7 +25,7 @@ contract CheckpointTester {
         Version memory toVersion
     ) external returns (CheckpointAccumulationResult memory result) {
         Checkpoint memory newCheckpoint = checkpoint.read();
-        (newCheckpoint, result) = CheckpointLib.accumulate(newCheckpoint, order, guarantee, fromPosition, fromVersion, toVersion);
+        (newCheckpoint, result) = CheckpointLib.accumulate(newCheckpoint, account, orderId, order, guarantee, fromPosition, fromVersion, toVersion);
         checkpoint.store(newCheckpoint);
     }
 }

--- a/packages/perennial/test/unit/types/Checkpoint.test.ts
+++ b/packages/perennial/test/unit/types/Checkpoint.test.ts
@@ -25,8 +25,11 @@ import {
 const { ethers } = HRE
 use(smock.matchers)
 
+const ORDER_ID = BigNumber.from(17)
+
 describe('Checkpoint', () => {
   let owner: SignerWithAddress
+  let user: SignerWithAddress
   let checkpointLib: CheckpointLib
   let checkpointStorageLib: CheckpointStorageLib
   let checkpoint: CheckpointTester
@@ -39,7 +42,7 @@ describe('Checkpoint', () => {
   }
 
   beforeEach(async () => {
-    ;[owner] = await ethers.getSigners()
+    ;[owner, user] = await ethers.getSigners()
 
     checkpointLib = await new CheckpointLib__factory(owner).deploy()
     checkpointStorageLib = await new CheckpointStorageLib__factory(owner).deploy()
@@ -256,6 +259,8 @@ describe('Checkpoint', () => {
 
       it('accumulates transfer', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, collateral: parse6decimal('123') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -263,6 +268,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, collateral: parse6decimal('123') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -276,6 +283,8 @@ describe('Checkpoint', () => {
 
       it('accumulates price override pnl (long)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10'), longNeg: parse6decimal('5') },
           {
             ...DEFAULT_GUARANTEE,
@@ -288,6 +297,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, price: parse6decimal('123') },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10'), longNeg: parse6decimal('5') },
           {
             ...DEFAULT_GUARANTEE,
@@ -307,6 +318,8 @@ describe('Checkpoint', () => {
 
       it('accumulates price override pnl (short)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, shortPos: parse6decimal('10'), shortNeg: parse6decimal('5') },
           {
             ...DEFAULT_GUARANTEE,
@@ -319,6 +332,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, price: parse6decimal('123') },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, shortPos: parse6decimal('10'), shortNeg: parse6decimal('5') },
           {
             ...DEFAULT_GUARANTEE,
@@ -338,6 +353,8 @@ describe('Checkpoint', () => {
 
       it('accumulates pnl (maker)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION, maker: parse6decimal('10') },
@@ -345,6 +362,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('200') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION, maker: parse6decimal('10') },
@@ -359,6 +378,8 @@ describe('Checkpoint', () => {
 
       it('accumulates pnl (long)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION, long: parse6decimal('10') },
@@ -366,6 +387,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('200') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION, long: parse6decimal('10') },
@@ -380,6 +403,8 @@ describe('Checkpoint', () => {
 
       it('accumulates pnl (short)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION, short: parse6decimal('10') },
@@ -387,6 +412,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('200') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION, short: parse6decimal('10') },
@@ -401,6 +428,8 @@ describe('Checkpoint', () => {
 
       it('accumulates fees (maker)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -408,6 +437,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, makerFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -422,6 +453,8 @@ describe('Checkpoint', () => {
 
       it('accumulates fees (taker)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -429,6 +462,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, takerFee: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -443,6 +478,8 @@ describe('Checkpoint', () => {
 
       it('accumulates fees (maker offset)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -450,6 +487,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, makerOffset: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -464,6 +503,8 @@ describe('Checkpoint', () => {
 
       it('accumulates fees (taker pos offset)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -471,6 +512,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, takerPosOffset: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -485,6 +528,8 @@ describe('Checkpoint', () => {
 
       it('accumulates fees (taker neg offset)', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longNeg: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -492,6 +537,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, takerNegOffset: { _value: parse6decimal('-2') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, longNeg: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -506,6 +553,8 @@ describe('Checkpoint', () => {
 
       it('accumulates settlement fee', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, orders: 2 },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -513,6 +562,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, settlementFee: { _value: parse6decimal('-4') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, orders: 2 },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -527,6 +578,8 @@ describe('Checkpoint', () => {
 
       it('accumulates liquidation fee', async () => {
         const result = await checkpoint.callStatic.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, protection: 1 },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },
@@ -534,6 +587,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, liquidationFee: { _value: parse6decimal('-4') } },
         )
         await checkpoint.accumulate(
+          user.address,
+          ORDER_ID,
           { ...DEFAULT_ORDER, protection: 1 },
           { ...DEFAULT_GUARANTEE },
           { ...DEFAULT_POSITION },

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -57,7 +57,6 @@ const GLOBAL: GlobalStruct = {
   protocolFee: 2,
   oracleFee: 3,
   riskFee: 4,
-  donation: 5,
   pAccumulator: {
     _value: 6,
     _skew: 7,
@@ -72,6 +71,8 @@ const FROM_POSITION: PositionStruct = {
   long: 4,
   short: 5,
 }
+
+const ORDER_ID: BigNumber = BigNumber.from(17)
 
 const ORDER: OrderStruct = {
   timestamp: 20,
@@ -112,6 +113,7 @@ describe('Version', () => {
   const accumulateWithReturn = async (
     global: GlobalStruct,
     fromPosition: PositionStruct,
+    orderId: BigNumber,
     order: OrderStruct,
     guarantee: GuaranteeStruct,
     fromOracleVersion: OracleVersionStruct,
@@ -123,6 +125,7 @@ describe('Version', () => {
     const accumulationResult = await version.callStatic.accumulate({
       global,
       fromPosition,
+      orderId,
       order,
       guarantee,
       fromOracleVersion,
@@ -134,6 +137,7 @@ describe('Version', () => {
     await version.accumulate({
       global,
       fromPosition,
+      orderId,
       order,
       guarantee,
       fromOracleVersion,
@@ -629,6 +633,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           { ...FROM_POSITION, long: parse6decimal('10'), short: parse6decimal('10'), maker: parse6decimal('10') },
+          ORDER_ID,
           { ...DEFAULT_ORDER, orders: 1, longPos: parse6decimal('10') },
           { ...DEFAULT_GUARANTEE },
           ORACLE_VERSION_1,
@@ -684,6 +689,7 @@ describe('Version', () => {
           await accumulateWithReturn(
             GLOBAL,
             FROM_POSITION,
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -704,6 +710,7 @@ describe('Version', () => {
           await accumulateWithReturn(
             GLOBAL,
             FROM_POSITION,
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -724,6 +731,7 @@ describe('Version', () => {
           await accumulateWithReturn(
             GLOBAL,
             FROM_POSITION,
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -745,6 +753,7 @@ describe('Version', () => {
         await accumulateWithReturn(
           GLOBAL,
           FROM_POSITION,
+          ORDER_ID,
           ORDER,
           { ...DEFAULT_GUARANTEE },
           ORACLE_VERSION_1,
@@ -809,6 +818,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           { ...order, orders: 1, makerPos: parse6decimal('4') },
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 },
@@ -829,6 +839,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           order,
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 },
@@ -846,6 +857,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           { ...order, orders: 1, shortNeg: parse6decimal('2') },
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 },
@@ -864,6 +876,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           {
             ...order,
             orders: orderCount,
@@ -890,6 +903,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           {
             ...order,
             orders: orderCount,
@@ -961,6 +975,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           order,
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 },
@@ -981,6 +996,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           order,
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 },
@@ -1001,6 +1017,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           order,
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 },
@@ -1067,6 +1084,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           { ...ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 }, // 123
@@ -1086,6 +1104,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           position,
+          ORDER_ID,
           { ...ORDER },
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1 }, // 123
@@ -1112,6 +1131,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           { ...position, maker: 0 },
+          ORDER_ID,
           { ...order, makerPos: parse6decimal('0.7'), longPos: 0 },
           { ...DEFAULT_GUARANTEE },
           { ...ORACLE_VERSION_1, price: parse6decimal('142') },
@@ -1146,6 +1166,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           { ...FROM_POSITION, long: parse6decimal('20'), short: parse6decimal('30'), maker: 0 },
+          ORDER_ID,
           {
             ...ORDER,
             makerNeg: parse6decimal('0'),
@@ -1250,6 +1271,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           { ...FROM_POSITION, long: parse6decimal('20'), short: parse6decimal('30'), maker: parse6decimal('50') },
+          ORDER_ID,
           {
             ...ORDER,
             makerNeg: parse6decimal('10'),
@@ -1352,6 +1374,7 @@ describe('Version', () => {
         const { ret, value } = await accumulateWithReturn(
           GLOBAL,
           { ...FROM_POSITION, long: parse6decimal('20'), short: parse6decimal('30'), maker: parse6decimal('50') },
+          ORDER_ID,
           {
             ...ORDER,
             makerNeg: parse6decimal('10'),
@@ -1462,6 +1485,7 @@ describe('Version', () => {
               long: parse6decimal('12'),
               short: parse6decimal('2'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1506,6 +1530,7 @@ describe('Version', () => {
               long: 0,
               short: 0,
             },
+            ORDER_ID,
             {
               ...ORDER,
               makerPos: ORDER.makerPos,
@@ -1554,6 +1579,7 @@ describe('Version', () => {
               long: parse6decimal('12'),
               short: parse6decimal('8'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1599,6 +1625,7 @@ describe('Version', () => {
               long: parse6decimal('8'),
               short: parse6decimal('12'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1644,6 +1671,7 @@ describe('Version', () => {
               long: parse6decimal('8'),
               short: parse6decimal('12'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1692,6 +1720,7 @@ describe('Version', () => {
               long: parse6decimal('12'),
               short: parse6decimal('2'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1736,6 +1765,7 @@ describe('Version', () => {
               long: parse6decimal('12'),
               short: parse6decimal('2'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1787,6 +1817,7 @@ describe('Version', () => {
               long: parse6decimal('8'),
               short: parse6decimal('2'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1838,6 +1869,7 @@ describe('Version', () => {
               long: 0,
               short: 0,
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1885,6 +1917,7 @@ describe('Version', () => {
               long: parse6decimal('2'),
               short: parse6decimal('9'),
             },
+            ORDER_ID,
             ORDER,
             { ...DEFAULT_GUARANTEE },
             ORACLE_VERSION_1,
@@ -1930,6 +1963,7 @@ describe('Version', () => {
                 long: parse6decimal('9'),
                 short: parse6decimal('9'),
               },
+              ORDER_ID,
               ORDER,
               { ...DEFAULT_GUARANTEE },
               ORACLE_VERSION_1,
@@ -1988,6 +2022,7 @@ describe('Version', () => {
                 long: parse6decimal('2'),
                 short: parse6decimal('9'),
               },
+              ORDER_ID,
               ORDER,
               { ...DEFAULT_GUARANTEE },
               ORACLE_VERSION_1,
@@ -2046,6 +2081,7 @@ describe('Version', () => {
                 long: parse6decimal('20'),
                 short: parse6decimal('15'),
               },
+              ORDER_ID,
               ORDER,
               { ...DEFAULT_GUARANTEE },
               ORACLE_VERSION_1,
@@ -2106,6 +2142,7 @@ describe('Version', () => {
                 long: parse6decimal('9'),
                 short: parse6decimal('9'),
               },
+              ORDER_ID,
               ORDER,
               { ...DEFAULT_GUARANTEE },
               ORACLE_VERSION_1,
@@ -2164,6 +2201,7 @@ describe('Version', () => {
                 long: parse6decimal('2'),
                 short: parse6decimal('9'),
               },
+              ORDER_ID,
               ORDER,
               { ...DEFAULT_GUARANTEE },
               ORACLE_VERSION_1,
@@ -2222,6 +2260,7 @@ describe('Version', () => {
                 long: parse6decimal('20'),
                 short: parse6decimal('15'),
               },
+              ORDER_ID,
               ORDER,
               { ...DEFAULT_GUARANTEE },
               ORACLE_VERSION_1,
@@ -2282,6 +2321,7 @@ describe('Version', () => {
             long: parse6decimal('2'),
             short: parse6decimal('9'),
           },
+          ORDER_ID,
           ORDER,
           { ...DEFAULT_GUARANTEE },
           ORACLE_VERSION_1,
@@ -2319,6 +2359,7 @@ describe('Version', () => {
             long: parse6decimal('2'),
             short: parse6decimal('9'),
           },
+          ORDER_ID,
           ORDER,
           { ...DEFAULT_GUARANTEE },
           ORACLE_VERSION_1,


### PR DESCRIPTION
Moves the calls to emit `PositionProcessed` and `AccountPositionProcessed` into `VersionLib` and `CheckpointLib` respectively prior to returning the accumulation result.

We leave a copy of the events in `IMarket` for offchain interface compatibility.

This saves `479 bytes` of code size.