### PR TITLE
Add CLAIM_FEE action to MultiInvoker

### DIFF
--- a/packages/perennial-extensions/contracts/MultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/MultiInvoker.sol
@@ -184,6 +184,10 @@ contract MultiInvoker is IMultiInvoker, Kept {
                 (address target) = abi.decode(invocation.args, (address));
 
                 _approve(target);
+            } else if (invocation.action == PerennialAction.CLAIM_FEE) {
+                (IMarket market) = abi.decode(invocation.args, (IMarket));
+
+                _claimFee(account, market);
             }
         }
         // ETH must not remain in this contract at rest
@@ -290,6 +294,14 @@ contract MultiInvoker is IMultiInvoker, Kept {
         else DSU.push(interfaceFee.receiver, UFixed18Lib.from(interfaceFee.amount));
 
         emit InterfaceFeeCharged(account, market, interfaceFee);
+    }
+
+    /// @notice Claims market fees, unwraps DSU, and pushes USDC to fee earner
+    /// @param market Market from which fees should be claimed
+    /// @param account Address of the user who earned fees
+    function _claimFee(address account, IMarket market) internal isMarketInstance(market) {
+        UFixed6 claimAmount = market.claimFee(account);
+        _withdraw(account, claimAmount, true);
     }
 
     /// @notice Pull DSU or wrap and deposit USDC from `account` to this address for market usage

--- a/packages/perennial-extensions/contracts/MultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/MultiInvoker.sol
@@ -338,9 +338,9 @@ contract MultiInvoker is IMultiInvoker, Kept {
     /// @notice Push DSU or unwrap DSU to push USDC from this address to `account`
     /// @param account Account to push DSU or USDC to
     /// @param amount Amount to transfer
-    /// @param wrap flag to unwrap DSU to USDC
-    function _withdraw(address account, UFixed6 amount, bool wrap) internal {
-        if (wrap) {
+    /// @param unwrap flag to unwrap DSU to USDC
+    function _withdraw(address account, UFixed6 amount, bool unwrap) internal {
+        if (unwrap) {
             _unwrap(account, UFixed18Lib.from(amount));
         } else {
             DSU.push(account, UFixed18Lib.from(amount));

--- a/packages/perennial-extensions/contracts/MultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/MultiInvoker.sol
@@ -189,9 +189,9 @@ contract MultiInvoker is IMultiInvoker, Kept {
 
                 _approve(target);
             } else if (invocation.action == PerennialAction.CLAIM_FEE) {
-                (IMarket market) = abi.decode(invocation.args, (IMarket));
+                (IMarket market, bool unwrap) = abi.decode(invocation.args, (IMarket, bool));
 
-                _claimFee(account, market);
+                _claimFee(account, market, unwrap);
             }
         }
         // ETH must not remain in this contract at rest
@@ -316,9 +316,10 @@ contract MultiInvoker is IMultiInvoker, Kept {
     /// @notice Claims market fees, unwraps DSU, and pushes USDC to fee earner
     /// @param market Market from which fees should be claimed
     /// @param account Address of the user who earned fees
-    function _claimFee(address account, IMarket market) internal isMarketInstance(market) {
+    /// @param unwrap Set true to unwrap DSU to USDC when withdrawing
+    function _claimFee(address account, IMarket market, bool unwrap) internal isMarketInstance(market) {
         UFixed6 claimAmount = market.claimFee(account);
-        _withdraw(account, claimAmount, true);
+        _withdraw(account, claimAmount, unwrap);
     }
 
     /// @notice Pull DSU or wrap and deposit USDC from `account` to this address for market usage

--- a/packages/perennial-extensions/contracts/interfaces/IMultiInvoker.sol
+++ b/packages/perennial-extensions/contracts/interfaces/IMultiInvoker.sol
@@ -29,7 +29,8 @@ interface IMultiInvoker {
         EXEC_ORDER,      // 5
         COMMIT_PRICE,    // 6
         __LIQUIDATE__DEPRECATED,
-        APPROVE          // 8
+        APPROVE,         // 8
+        CLAIM_FEE        // 9 // TODO: move to 10 after PR#402 merged
     }
 
     struct Invocation {

--- a/packages/perennial-extensions/test/helpers/invoke.ts
+++ b/packages/perennial-extensions/test/helpers/invoke.ts
@@ -275,11 +275,11 @@ export const buildExecOrder = ({
   ]
 }
 
-export const buildClaimFee = ({ market }: { market: string }): Actions => {
+export const buildClaimFee = ({ market, unwrap }: { market: string; unwrap: boolean }): Actions => {
   return [
     {
       action: 10,
-      args: utils.defaultAbiCoder.encode(['address'], [market]),
+      args: utils.defaultAbiCoder.encode(['address', 'bool'], [market, unwrap]),
     },
   ]
 }

--- a/packages/perennial-extensions/test/helpers/invoke.ts
+++ b/packages/perennial-extensions/test/helpers/invoke.ts
@@ -225,6 +225,15 @@ export const buildExecOrder = ({
   ]
 }
 
+export const buildClaimFee = ({ market }: { market: string }): Actions => {
+  return [
+    {
+      action: 9, // TODO: move to 10 after PR#402 merged
+      args: utils.defaultAbiCoder.encode(['address'], [market]),
+    },
+  ]
+}
+
 module.exports = {
   MAX_INT,
   MAX_UINT,
@@ -239,4 +248,5 @@ module.exports = {
   buildLiquidateUser,
   buildUpdateVault,
   buildApproveTarget,
+  buildClaimFee,
 }

--- a/packages/perennial-extensions/test/integration/core/Invoke.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Invoke.test.ts
@@ -724,7 +724,7 @@ describe('Invoke', () => {
         })
 
         it('fills an intent update', async () => {
-          const { marketFactory, owner, user, userB, userC, usdc, dsu, verifier } = instanceVars
+          const { marketFactory, owner, user, userB, userC, usdc, dsu, verifier, chainlink } = instanceVars
 
           await marketFactory.updateParameter({
             ...(await marketFactory.parameter()),
@@ -792,10 +792,11 @@ describe('Invoke', () => {
               intent,
             }),
           )
+          const intentTimestamp = await chainlink.oracle.current()
 
           expectOrderEq(await market.pendingOrders(user.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: 1631112904,
+            timestamp: intentTimestamp,
             orders: 1,
             shortPos: parse6decimal('1'),
             collateral: ethers.utils.parseUnits('1000', 6),
@@ -803,7 +804,7 @@ describe('Invoke', () => {
           })
           expectOrderEq(await market.pendingOrders(userB.address, 1), {
             ...DEFAULT_ORDER,
-            timestamp: 1631112904,
+            timestamp: intentTimestamp,
             orders: 1,
             longPos: parse6decimal('1'),
             collateral: ethers.utils.parseUnits('1000', 6),

--- a/packages/perennial-extensions/test/integration/core/Invoke.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Invoke.test.ts
@@ -166,7 +166,7 @@ describe('Invoke', () => {
         return multiInvoker.connect(user)['invoke((uint8,bytes)[])'](args)
       },
     },
-    /*{
+    {
       context: 'From delegate',
       setup: async () => {
         const { user, userD } = instanceVars
@@ -176,7 +176,7 @@ describe('Invoke', () => {
         const { user, userD } = instanceVars
         return multiInvoker.connect(userD)['invoke(address,(uint8,bytes)[])'](user.address, args)
       },
-    },*/
+    },
   ]
 
   testCases.forEach(({ context: contextStr, setup, invoke }) => {
@@ -842,9 +842,9 @@ describe('Invoke', () => {
           await chainlink.next()
           await market.connect(user).settle(user.address)
           await market.connect(userB).settle(userB.address)
+          const expectedFee = (await market.locals(user.address)).claimable
 
           // user invokes to claim their fee
-          const expectedFee = parse6decimal('2.560421')
           await expect(invoke(buildClaimFee({ market: market.address })))
             .to.emit(market, 'FeeClaimed')
             .withArgs(user.address, multiInvoker.address, expectedFee)

--- a/packages/perennial-extensions/test/integration/core/Invoke.test.ts
+++ b/packages/perennial-extensions/test/integration/core/Invoke.test.ts
@@ -38,7 +38,7 @@ import { DEFAULT_ORDER, expectOrderEq, OracleReceipt, parse6decimal } from '../.
 import { expect, use } from 'chai'
 import { FakeContract, smock } from '@defi-wonderland/smock'
 import { ethers } from 'hardhat'
-import { BigNumber } from 'ethers'
+import { BigNumber, constants } from 'ethers'
 import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs'
 import { Compare, Dir, openTriggerOrder } from '../../helpers/types'
 

--- a/packages/perennial-extensions/test/unit/MultiInvoker/MultiInvoker.test.ts
+++ b/packages/perennial-extensions/test/unit/MultiInvoker/MultiInvoker.test.ts
@@ -25,6 +25,7 @@ import {
   buildPlaceOrder,
   buildCancelOrder,
   buildExecOrder,
+  buildClaimFee,
   VaultUpdate,
   Actions,
   MAX_UINT,
@@ -524,7 +525,7 @@ export function RunMultiInvokerTests(name: string, setup: () => Promise<void>): 
             expect(dsu.transfer).to.have.been.calledWith(owner.address, feeAmt.mul(1e12))
           })
 
-          it('charges an interface fee on withdrawal, wraps DSU from colalteral to USDC, and pushes USDC to the receiver', async () => {
+          it('charges an interface fee on withdrawal, wraps DSU from collateral to USDC, and pushes USDC to the receiver', async () => {
             usdc.transferFrom.returns(true)
             dsu.transferFrom.returns(true)
             dsu.transfer.returns(true)
@@ -634,6 +635,24 @@ export function RunMultiInvokerTests(name: string, setup: () => Promise<void>): 
               collateral.sub(feeAmt).mul(-1),
               false,
               user2.address,
+            )
+          })
+
+          it('claims fee from a market', async () => {
+            const fee = parse6decimal('0.123')
+            usdc.transfer.returns(true)
+            market.claimFee.returns(fee)
+
+            await expect(invoke(buildClaimFee({ market: market.address }))).to.not.be.reverted
+            expect(market.claimFee).to.have.been.calledWith(user.address)
+            expect(reserve.redeem).to.have.been.calledWith(fee.mul(1e12))
+            expect(usdc.transfer).to.have.been.calledWith(user.address, fee)
+          })
+
+          it('reverts if claiming fee from a non-market', async () => {
+            await expect(invoke(buildClaimFee({ market: batcher.address }))).to.be.revertedWithCustomError(
+              multiInvoker,
+              'MultiInvokerInvalidInstanceError',
             )
           })
 

--- a/packages/perennial-extensions/test/unit/MultiInvoker/MultiInvoker.test.ts
+++ b/packages/perennial-extensions/test/unit/MultiInvoker/MultiInvoker.test.ts
@@ -643,17 +643,27 @@ export function RunMultiInvokerTests(name: string, setup: () => Promise<void>): 
             usdc.transfer.returns(true)
             market.claimFee.returns(fee)
 
-            await expect(invoke(buildClaimFee({ market: market.address }))).to.not.be.reverted
+            await expect(invoke(buildClaimFee({ market: market.address, unwrap: true }))).to.not.be.reverted
             expect(market.claimFee).to.have.been.calledWith(user.address)
             expect(reserve.redeem).to.have.been.calledWith(fee.mul(1e12))
             expect(usdc.transfer).to.have.been.calledWith(user.address, fee)
           })
 
+          it('claims fee from a market without unwrapping', async () => {
+            const fee = parse6decimal('0.0654')
+            dsu.transfer.returns(true)
+            market.claimFee.returns(fee)
+
+            await expect(invoke(buildClaimFee({ market: market.address, unwrap: false }))).to.not.be.reverted
+            expect(market.claimFee).to.have.been.calledWith(user.address)
+            expect(reserve.redeem).to.not.have.been.called
+            expect(dsu.transfer).to.have.been.calledWith(user.address, fee.mul(1e12))
+          })
+
           it('reverts if claiming fee from a non-market', async () => {
-            await expect(invoke(buildClaimFee({ market: batcher.address }))).to.be.revertedWithCustomError(
-              multiInvoker,
-              'MultiInvokerInvalidInstanceError',
-            )
+            await expect(
+              invoke(buildClaimFee({ market: batcher.address, unwrap: true })),
+            ).to.be.revertedWithCustomError(multiInvoker, 'MultiInvokerInvalidInstanceError')
           })
 
           describe('ETH return', async () => {


### PR DESCRIPTION
# Changes
Adds a _MultiInvoker_ action which claims earned market fees for the user and automatically unwraps to USDC.

# TODO
- [x] Merge with v2.3 (notably with PR#402)
- [x] Fix integration test calling from delegate
- [x] Self-review and resolve linter warnings
- [x] Confirm CI runs clean