### PR TITLE
[Code Size] Return only necessary fields from CheckpointLib / VersionLib

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -768,11 +768,11 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             context.marketParameter,
             context.riskParameter
         );
-        VersionAccumulationResult memory accumulationResult;
-        (settlementContext.latestVersion, context.global, accumulationResult) =
+        VersionAccumulationResponse memory accumulationResponse;
+        (settlementContext.latestVersion, context.global, accumulationResponse) =
             VersionLib.accumulate(settlementContext.latestVersion, accumulationContext);
 
-        context.global.update(newOrderId, accumulationResult, context.marketParameter, oracleReceipt);
+        context.global.update(newOrderId, accumulationResponse, context.marketParameter, oracleReceipt);
         context.latestPositionGlobal.update(newOrder);
 
         settlementContext.orderOracleVersion = oracleVersion;

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -809,8 +809,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             newGuarantee.invalidate();
         }
 
-        CheckpointAccumulationResult memory accumulationResult;
-        (settlementContext.latestCheckpoint, accumulationResult) = CheckpointLib.accumulate(
+        CheckpointAccumulationResponse memory accumulationResponse;
+        (settlementContext.latestCheckpoint, accumulationResponse) = CheckpointLib.accumulate(
             settlementContext.latestCheckpoint,
             context.account,
             newOrderId,
@@ -821,14 +821,14 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             versionTo
         );
 
-        context.local.update(newOrderId, accumulationResult);
+        context.local.update(newOrderId, accumulationResponse);
         context.latestPositionLocal.update(newOrder);
 
         _checkpoints[context.account][newOrder.timestamp].store(settlementContext.latestCheckpoint);
 
-        _credit(context, liquidators[context.account][newOrderId], accumulationResult.liquidationFee);
-        _credit(context, orderReferrers[context.account][newOrderId], accumulationResult.subtractiveFee);
-        _credit(context, guaranteeReferrers[context.account][newOrderId], accumulationResult.solverFee);
+        _credit(context, liquidators[context.account][newOrderId], accumulationResponse.liquidationFee);
+        _credit(context, orderReferrers[context.account][newOrderId], accumulationResponse.subtractiveFee);
+        _credit(context, guaranteeReferrers[context.account][newOrderId], accumulationResponse.solverFee);
     }
 
     /// @notice Credits an account's claimable

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -167,8 +167,6 @@ library VersionLib {
         // accumulate P&L
         (result.pnlMaker, result.pnlLong, result.pnlShort) = _accumulatePNL(next, context);
 
-        emit IMarket.PositionProcessed(context.orderId, context.order, result);
-
         return _return(context, result, next);
     }
 

--- a/packages/perennial/contracts/libs/VersionLib.sol
+++ b/packages/perennial/contracts/libs/VersionLib.sol
@@ -13,30 +13,46 @@ import "../types/Version.sol";
 import "../types/OracleVersion.sol";
 import "../types/OracleReceipt.sol";
 
+/// @dev The response of the version accumulation
+///      Contains only select fee information needed for the downstream market contract
+///      Returned by the accumulate function
+struct VersionAccumulationResponse {
+    /// @dev The total market fee charged including (tradeFee, tradeOffsetMarket, fundingFee, interestFee)
+    UFixed6 marketFee;
+
+    /// @dev The settlement fee charged
+    UFixed6 settlementFee;
+
+    /// @dev The market's adiabatic exposure
+    Fixed6 marketExposure;
+}
+
 /// @dev The result of the version accumulation
+///      Contains all the accumulated values for the version
+///      Emitted via the PositionProcessed event
 struct VersionAccumulationResult {
-    /// @dev TODO
+    /// @dev The trade fee charged
     UFixed6 tradeFee;
 
-    /// @dev TODO
+    /// @dev The subtractive fee charged
     UFixed6 subtractiveFee;
 
-    /// @dev TODO
+    /// @dev The total price impact of the trade (including linear, proportional, and adiabatic)
     Fixed6 tradeOffset;
 
-    /// @dev TODO
+    /// @dev The portion of the trade offset that the makers receive
     Fixed6 tradeOffsetMaker;
 
-    /// @dev TODO
+    /// @dev The portion of the trade offset that the market receives (if there are no makers)
     UFixed6 tradeOffsetMarket;
 
-    /// @dev TODO
+    /// @dev The adiabatic exposure accrued
     Fixed6 adiabaticExposure;
 
-    /// @dev TODO
+    /// @dev The adiabatic exposure accrued by makers
     Fixed6 adiabaticExposureMaker;
 
-    /// @dev TODO
+    /// @dev The adiabatic exposure accrued by the market
     Fixed6 adiabaticExposureMarket;
 
     /// @dev Funding accrued by makers
@@ -102,11 +118,13 @@ library VersionLib {
     /// @param context The accumulation context
     /// @return next The accumulated version
     /// @return nextGlobal The next global state
-    /// @return result The accumulation result
+    /// @return response The accumulation response
     function accumulate(
         Version memory self,
         VersionAccumulationContext memory context
-    ) external returns (Version memory next, Global memory nextGlobal, VersionAccumulationResult memory result) {
+    ) external returns (Version memory next, Global memory nextGlobal, VersionAccumulationResponse memory response) {
+        VersionAccumulationResult memory result;
+
         // setup next accumulators
         _next(self, next);
 
@@ -136,7 +154,7 @@ library VersionLib {
         _accumulateAdiabaticFee(next, context, result);
 
         // if closed, don't accrue anything else
-        if (context.marketParameter.closed) return (next, context.global, result);
+        if (context.marketParameter.closed) return _return(context, result, next);
 
         // accumulate funding
         (result.fundingMaker, result.fundingLong, result.fundingShort, result.fundingFee) =
@@ -151,7 +169,31 @@ library VersionLib {
 
         emit IMarket.PositionProcessed(context.orderId, context.order, result);
 
-        return (next, context.global, result);
+        return _return(context, result, next);
+    }
+
+    function _return(
+        VersionAccumulationContext memory context,
+        VersionAccumulationResult memory result,
+        Version memory next
+    ) private returns (Version memory, Global memory, VersionAccumulationResponse memory) {
+        emit IMarket.PositionProcessed(context.orderId, context.order, result);
+
+        return (next, context.global, _response(result));
+    }
+
+    /// @notice Converts the accumulation result into a response
+    /// @param result The accumulation result
+    /// @return response The accumulation response
+    function _response(
+        VersionAccumulationResult memory result
+    ) private pure returns (VersionAccumulationResponse memory response) {
+        response.marketFee = result.tradeFee
+            .add(result.tradeOffsetMarket)
+            .add(result.fundingFee)
+            .add(result.interestFee);
+        response.settlementFee = result.settlementFee;
+        response.marketExposure = result.adiabaticExposureMarket;
     }
 
     /// @notice Copies over the version-over-version accumulators to prepare the next version

--- a/packages/perennial/contracts/test/CheckpointTester.sol
+++ b/packages/perennial/contracts/test/CheckpointTester.sol
@@ -23,9 +23,9 @@ contract CheckpointTester {
         Position memory fromPosition,
         Version memory fromVersion,
         Version memory toVersion
-    ) external returns (CheckpointAccumulationResult memory result) {
+    ) external returns (CheckpointAccumulationResponse memory response) {
         Checkpoint memory newCheckpoint = checkpoint.read();
-        (newCheckpoint, result) = CheckpointLib.accumulate(newCheckpoint, account, orderId, order, guarantee, fromPosition, fromVersion, toVersion);
+        (newCheckpoint, response) = CheckpointLib.accumulate(newCheckpoint, account, orderId, order, guarantee, fromPosition, fromVersion, toVersion);
         checkpoint.store(newCheckpoint);
     }
 }

--- a/packages/perennial/contracts/test/GlobalTester.sol
+++ b/packages/perennial/contracts/test/GlobalTester.sol
@@ -16,7 +16,7 @@ contract GlobalTester {
 
     function update(
         uint256 newLatestId,
-        VersionAccumulationResult memory accumulation,
+        VersionAccumulationResponse memory accumulation,
         MarketParameter memory marketParameter,
         OracleReceipt memory oracleReceipt
     ) external {

--- a/packages/perennial/contracts/test/LocalTester.sol
+++ b/packages/perennial/contracts/test/LocalTester.sol
@@ -22,7 +22,7 @@ contract LocalTester {
 
     function update(
         uint256 newId,
-        CheckpointAccumulationResult memory accumulation
+        CheckpointAccumulationResponse memory accumulation
     ) external {
         Local memory newLocal = local.read();
         newLocal.update(newId, accumulation);

--- a/packages/perennial/contracts/test/VersionTester.sol
+++ b/packages/perennial/contracts/test/VersionTester.sol
@@ -17,10 +17,10 @@ contract VersionTester {
 
     function accumulate(
         VersionAccumulationContext memory context
-    ) external returns (Global memory nextGlobal, VersionAccumulationResult memory values) {
+    ) external returns (Global memory nextGlobal, VersionAccumulationResponse memory response) {
         Version memory newVersion = version.read();
 
-        (newVersion, nextGlobal, values) = VersionLib.accumulate(newVersion, context);
+        (newVersion, nextGlobal, response) = VersionLib.accumulate(newVersion, context);
 
         version.store(newVersion);
     }

--- a/packages/perennial/contracts/types/Global.sol
+++ b/packages/perennial/contracts/types/Global.sol
@@ -70,14 +70,11 @@ library GlobalLib {
     function update(
         Global memory self,
         uint256 newLatestId,
-        VersionAccumulationResult memory accumulation,
+        VersionAccumulationResponse memory accumulation,
         MarketParameter memory marketParameter,
         OracleReceipt memory oracleReceipt
     ) internal pure {
-        UFixed6 marketFee = accumulation.tradeFee
-            .add(accumulation.tradeOffsetMarket)
-            .add(accumulation.fundingFee)
-            .add(accumulation.interestFee);
+        UFixed6 marketFee = accumulation.marketFee;
 
         UFixed6 oracleFee = marketFee.mul(oracleReceipt.oracleFee);
         marketFee = marketFee.sub(oracleFee);
@@ -89,7 +86,7 @@ library GlobalLib {
         self.protocolFee = self.protocolFee.add(marketFee);
         self.oracleFee = self.oracleFee.add(accumulation.settlementFee).add(oracleFee);
         self.riskFee = self.riskFee.add(riskFee);
-        self.exposure = self.exposure.add(accumulation.adiabaticExposureMarket);
+        self.exposure = self.exposure.add(accumulation.marketExposure);
     }
 
     /// @notice Overrides the price of the oracle with the latest global version if it is empty

--- a/packages/perennial/contracts/types/Local.sol
+++ b/packages/perennial/contracts/types/Local.sol
@@ -44,14 +44,12 @@ library LocalLib {
     /// @notice Updates the collateral with the new collateral change
     /// @param self The Local object to update
     /// @param accumulation The accumulation result
-    function update(Local memory self, uint256 newId, CheckpointAccumulationResult memory accumulation) internal pure {
-        Fixed6 tradeFee = Fixed6Lib.from(accumulation.tradeFee).add(accumulation.offset);
-        self.collateral = self.collateral
-            .add(accumulation.collateral)
-            .add(accumulation.priceOverride)
-            .sub(tradeFee)
-            .sub(Fixed6Lib.from(accumulation.settlementFee))
-            .sub(Fixed6Lib.from(accumulation.liquidationFee));
+    function update(
+        Local memory self,
+        uint256 newId,
+        CheckpointAccumulationResponse memory accumulation
+    ) internal pure {
+        self.collateral = self.collateral.add(accumulation.collateral).sub(Fixed6Lib.from(accumulation.liquidationFee));
         self.latestId = newId;
     }
 

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -68,7 +68,7 @@ const MARKET_PARAMS = {
   takerFee: parse6decimal('0.025'),
 }
 
-describe.only('Fees', () => {
+describe('Fees', () => {
   let instanceVars: InstanceVars
   let market: Market
 

--- a/packages/perennial/test/integration/core/fees.test.ts
+++ b/packages/perennial/test/integration/core/fees.test.ts
@@ -68,7 +68,7 @@ const MARKET_PARAMS = {
   takerFee: parse6decimal('0.025'),
 }
 
-describe('Fees', () => {
+describe.only('Fees', () => {
   let instanceVars: InstanceVars
   let market: Market
 

--- a/packages/perennial/test/unit/types/Checkpoint.test.ts
+++ b/packages/perennial/test/unit/types/Checkpoint.test.ts
@@ -10,9 +10,16 @@ import {
   CheckpointStorageLib__factory,
   CheckpointTester,
   CheckpointTester__factory,
+  IMarket__factory,
 } from '../../../types/generated'
 import { BigNumber } from 'ethers'
-import { CheckpointStruct, PositionStruct, VersionStruct } from '../../../types/generated/contracts/Market'
+import {
+  CheckpointStruct,
+  PositionStruct,
+  VersionStruct,
+  OrderStruct,
+  GuaranteeStruct,
+} from '../../../types/generated/contracts/Market'
 import {
   DEFAULT_ORDER,
   DEFAULT_CHECKPOINT,
@@ -26,6 +33,36 @@ const { ethers } = HRE
 use(smock.matchers)
 
 const ORDER_ID = BigNumber.from(17)
+
+const accumulateWithReturn = async (
+  checkpoint: CheckpointTester,
+  account: string,
+  orderId: BigNumber,
+  order: OrderStruct,
+  guarantee: GuaranteeStruct,
+  fromPosition: PositionStruct,
+  fromVersion: VersionStruct,
+  toVersion: VersionStruct,
+) => {
+  const marketInterface = new ethers.utils.Interface(IMarket__factory.abi)
+  const accumulationResult = await checkpoint.callStatic.accumulate(
+    account,
+    orderId,
+    order,
+    guarantee,
+    fromPosition,
+    fromVersion,
+    toVersion,
+  )
+  const tx = await checkpoint.accumulate(account, orderId, order, guarantee, fromPosition, fromVersion, toVersion)
+  const result = await tx.wait()
+  const value = await checkpoint.read()
+  return {
+    ret: marketInterface.parseLog(result.events![0]).args.accumulationResult,
+    value,
+    rsp: accumulationResult[1],
+  }
+}
 
 describe('Checkpoint', () => {
   let owner: SignerWithAddress
@@ -258,16 +295,8 @@ describe('Checkpoint', () => {
       })
 
       it('accumulates transfer', async () => {
-        const result = await checkpoint.callStatic.accumulate(
-          user.address,
-          ORDER_ID,
-          { ...DEFAULT_ORDER, collateral: parse6decimal('123') },
-          { ...DEFAULT_GUARANTEE },
-          { ...DEFAULT_POSITION },
-          { ...DEFAULT_VERSION },
-          { ...DEFAULT_VERSION },
-        )
-        await checkpoint.accumulate(
+        const { value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, collateral: parse6decimal('123') },
@@ -277,12 +306,12 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
         )
 
-        const value = await checkpoint.read()
         expect(value.transfer).to.equal(parse6decimal('123'))
       })
 
       it('accumulates price override pnl (long)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10'), longNeg: parse6decimal('5') },
@@ -296,28 +325,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, price: parse6decimal('123') },
         )
-        await checkpoint.accumulate(
-          user.address,
-          ORDER_ID,
-          { ...DEFAULT_ORDER, longPos: parse6decimal('10'), longNeg: parse6decimal('5') },
-          {
-            ...DEFAULT_GUARANTEE,
-            takerPos: parse6decimal('5'),
-            takerNeg: parse6decimal('2'),
-            notional: parse6decimal('300'),
-          },
-          { ...DEFAULT_POSITION },
-          { ...DEFAULT_VERSION },
-          { ...DEFAULT_VERSION, price: parse6decimal('123') },
-        )
-        expect(result.priceOverride).to.equal(parse6decimal('69')) // open 3 long @ 100 w/ 123 price
+        expect(ret.priceOverride).to.equal(parse6decimal('69')) // open 3 long @ 100 w/ 123 price
 
-        const value = await checkpoint.read()
         expect(value.collateral).to.equal(parse6decimal('69'))
       })
 
       it('accumulates price override pnl (short)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, shortPos: parse6decimal('10'), shortNeg: parse6decimal('5') },
@@ -331,28 +346,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, price: parse6decimal('123') },
         )
-        await checkpoint.accumulate(
-          user.address,
-          ORDER_ID,
-          { ...DEFAULT_ORDER, shortPos: parse6decimal('10'), shortNeg: parse6decimal('5') },
-          {
-            ...DEFAULT_GUARANTEE,
-            takerNeg: parse6decimal('5'),
-            takerPos: parse6decimal('2'),
-            notional: parse6decimal('-300'),
-          },
-          { ...DEFAULT_POSITION },
-          { ...DEFAULT_VERSION },
-          { ...DEFAULT_VERSION, price: parse6decimal('123') },
-        )
-        expect(result.priceOverride).to.equal(parse6decimal('-69')) // open 3 short @ 100 w/ 123 price
+        expect(ret.priceOverride).to.equal(parse6decimal('-69')) // open 3 short @ 100 w/ 123 price
 
-        const value = await checkpoint.read()
         expect(value.collateral).to.equal(parse6decimal('-69'))
       })
 
       it('accumulates pnl (maker)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER },
@@ -370,14 +371,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, makerValue: { _value: parse6decimal('200') } },
         )
-        expect(result.collateral).to.equal(parse6decimal('1000'))
+        expect(ret.collateral).to.equal(parse6decimal('1000'))
 
-        const value = await checkpoint.read()
         expect(value.collateral).to.equal(parse6decimal('1000'))
       })
 
       it('accumulates pnl (long)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER },
@@ -395,14 +396,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, longValue: { _value: parse6decimal('200') } },
         )
-        expect(result.collateral).to.equal(parse6decimal('1000'))
+        expect(ret.collateral).to.equal(parse6decimal('1000'))
 
-        const value = await checkpoint.read()
         expect(value.collateral).to.equal(parse6decimal('1000'))
       })
 
       it('accumulates pnl (short)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER },
@@ -420,14 +421,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('100') } },
           { ...DEFAULT_VERSION, shortValue: { _value: parse6decimal('200') } },
         )
-        expect(result.collateral).to.equal(parse6decimal('1000'))
+        expect(ret.collateral).to.equal(parse6decimal('1000'))
 
-        const value = await checkpoint.read()
         expect(value.collateral).to.equal(parse6decimal('1000'))
       })
 
       it('accumulates fees (maker)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
@@ -445,14 +446,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(ret.tradeFee).to.equal(parse6decimal('20'))
 
-        const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
       })
 
       it('accumulates fees (taker)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
@@ -470,14 +471,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerFee: { _value: parse6decimal('-2') } },
         )
-        expect(result.tradeFee).to.equal(parse6decimal('20'))
+        expect(ret.tradeFee).to.equal(parse6decimal('20'))
 
-        const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
       })
 
       it('accumulates fees (maker offset)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, makerPos: parse6decimal('10') },
@@ -495,14 +496,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, makerOffset: { _value: parse6decimal('-2') } },
         )
-        expect(result.offset).to.equal(parse6decimal('20'))
+        expect(ret.offset).to.equal(parse6decimal('20'))
 
-        const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
       })
 
       it('accumulates fees (taker pos offset)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, longPos: parse6decimal('10') },
@@ -520,14 +521,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerPosOffset: { _value: parse6decimal('-2') } },
         )
-        expect(result.offset).to.equal(parse6decimal('20'))
+        expect(ret.offset).to.equal(parse6decimal('20'))
 
-        const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
       })
 
       it('accumulates fees (taker neg offset)', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, longNeg: parse6decimal('10') },
@@ -545,14 +546,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, takerNegOffset: { _value: parse6decimal('-2') } },
         )
-        expect(result.offset).to.equal(parse6decimal('20'))
+        expect(ret.offset).to.equal(parse6decimal('20'))
 
-        const value = await checkpoint.read()
         expect(value.tradeFee).to.equal(parse6decimal('20'))
       })
 
       it('accumulates settlement fee', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, orders: 2 },
@@ -570,14 +571,14 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, settlementFee: { _value: parse6decimal('-4') } },
         )
-        expect(result.settlementFee).to.equal(parse6decimal('8'))
+        expect(ret.settlementFee).to.equal(parse6decimal('8'))
 
-        const value = await checkpoint.read()
         expect(value.settlementFee).to.equal(parse6decimal('8'))
       })
 
       it('accumulates liquidation fee', async () => {
-        const result = await checkpoint.callStatic.accumulate(
+        const { ret, value } = await accumulateWithReturn(
+          checkpoint,
           user.address,
           ORDER_ID,
           { ...DEFAULT_ORDER, protection: 1 },
@@ -595,9 +596,8 @@ describe('Checkpoint', () => {
           { ...DEFAULT_VERSION },
           { ...DEFAULT_VERSION, liquidationFee: { _value: parse6decimal('-4') } },
         )
-        expect(result.liquidationFee).to.equal(parse6decimal('4'))
+        expect(ret.liquidationFee).to.equal(parse6decimal('4'))
 
-        const value = await checkpoint.read()
         expect(value.settlementFee).to.equal(parse6decimal('4'))
       })
     })

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -11,13 +11,10 @@ import {
 } from '../../../types/generated'
 import { BigNumber, BigNumberish } from 'ethers'
 import { OracleReceipt, parse6decimal, DEFAULT_GLOBAL } from '../../../../common/testutil/types'
-import {
-  GlobalStruct,
-  MarketParameterStruct,
-  VersionAccumulationResultStruct,
-} from '../../../types/generated/contracts/Market'
+import { GlobalStruct, MarketParameterStruct } from '../../../types/generated/contracts/Market'
 import { ProtocolParameterStruct } from '../../../types/generated/contracts/MarketFactory'
 import { OracleReceiptStruct } from '../../../types/generated/contracts/interfaces/IOracleProvider'
+import { VersionAccumulationResponseStruct } from '../../../types/generated/contracts/test/GlobalTester'
 
 const { ethers } = HRE
 use(smock.matchers)
@@ -26,33 +23,11 @@ function generateAccumulationResult(
   marketFee: BigNumberish,
   settlementFee: BigNumberish,
   marketExposure: BigNumberish,
-): VersionAccumulationResultStruct {
-  const interestFee = BigNumber.from(marketFee).div(10)
-  const fundingFee = BigNumber.from(marketFee).div(5)
-  const tradeFee = BigNumber.from(marketFee).sub(interestFee).sub(fundingFee)
-
+): VersionAccumulationResponseStruct {
   return {
-    tradeFee: tradeFee,
-    tradeOffset: 0,
-    tradeOffsetMaker: 0,
-    tradeOffsetMarket: 0,
-    subtractiveFee: 0,
-    adiabaticExposure: 0,
-    adiabaticExposureMaker: 0,
-    adiabaticExposureMarket: marketExposure,
-    fundingMaker: 0,
-    fundingLong: 0,
-    fundingShort: 0,
-    fundingFee,
-    interestMaker: 0,
-    interestLong: 0,
-    interestShort: 0,
-    interestFee,
-    pnlMaker: 0,
-    pnlLong: 0,
-    pnlShort: 0,
+    marketFee,
     settlementFee,
-    liquidationFee: 0,
+    marketExposure,
   }
 }
 

--- a/packages/perennial/test/unit/types/Local.test.ts
+++ b/packages/perennial/test/unit/types/Local.test.ts
@@ -165,12 +165,8 @@ describe('Local', () => {
   describe('#update', () => {
     it('correctly updates fees', async () => {
       await local.store({ ...DEFAULT_LOCAL, collateral: 1000 })
-      await local['update(uint256,(int256,int256,uint256,int256,uint256,uint256,uint256,uint256))'](11, {
-        collateral: 567,
-        priceOverride: -222,
-        tradeFee: 123,
-        offset: -246,
-        settlementFee: 456,
+      await local['update(uint256,(int256,uint256,uint256,uint256))'](11, {
+        collateral: 12,
         liquidationFee: 256,
         subtractiveFee: 0,
         solverFee: 0,

--- a/packages/perennial/test/unit/types/Version.test.ts
+++ b/packages/perennial/test/unit/types/Version.test.ts
@@ -4,6 +4,7 @@ import { expect, use } from 'chai'
 import HRE from 'hardhat'
 
 import {
+  IMarket__factory,
   VersionLib,
   VersionLib__factory,
   VersionStorageLib,
@@ -122,6 +123,7 @@ describe('Version', () => {
     marketParameter: MarketParameterStruct,
     riskParameter: RiskParameterStruct,
   ) => {
+    const marketInterface = new ethers.utils.Interface(IMarket__factory.abi)
     const accumulationResult = await version.callStatic.accumulate({
       global,
       fromPosition,
@@ -134,7 +136,7 @@ describe('Version', () => {
       marketParameter,
       riskParameter,
     })
-    await version.accumulate({
+    const tx = await version.accumulate({
       global,
       fromPosition,
       orderId,
@@ -146,9 +148,14 @@ describe('Version', () => {
       marketParameter,
       riskParameter,
     })
-
+    const result = await tx.wait()
     const value = await version.read()
-    return { ret: accumulationResult[1], value, nextGlobal: accumulationResult[0] }
+    return {
+      ret: marketInterface.parseLog(result.events![0]).args.accumulationResult,
+      value,
+      nextGlobal: accumulationResult[0],
+      rsp: accumulationResult[1],
+    }
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
Now that we are [emitting the position processed events](https://github.com/equilibria-xyz/perennial-v2/pull/407) inside of their respective libraries, we no longer need to return the bulk of the accumulation response data back to Market.

This PR two new paired down response structs for the Checkpoint and Version libs respectively, significantly cutting down on code size.

- Also fixes a bug where VersionLib was early-returning, not emitting its event.

Save `679 bytes` code size.