### PR TITLE
Add Position storage migration

### DIFF
--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -106,6 +106,12 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         oracle = definition_.oracle;
     }
 
+    /// @notice Performs logic related to the v2.3 migration for this market
+    /// @dev Must be called atomically at the time of implementation change
+    function migrate() external onlyOwner {
+        _position.migrate();
+    }
+
     /// @notice Settles the account's position and collateral
     /// @param account The account to operate on
     function settle(address account) external nonReentrant whenNotPaused {

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -135,6 +135,7 @@ interface IMarket is IInstance {
     error VersionStorageInvalidError();
 
     function initialize(MarketDefinition calldata definition_) external;
+    function migrate() external;
     function token() external view returns (Token18);
     function oracle() external view returns (IOracleProvider);
     function beneficiary() external view returns (address);

--- a/packages/perennial/contracts/types/Position.sol
+++ b/packages/perennial/contracts/types/Position.sol
@@ -307,12 +307,13 @@ library PositionLib {
 ///     struct StoredPositionGlobal {
 ///         /* slot 0 */
 ///         uint32 timestamp;
-///         uint96 __unallocated__;
+///         uint32 __unallocated__;
+///         uint64 maker;
 ///         uint64 long;
 ///         uint64 short;
 ///
 ///         /* slot 1 */
-///         uint64 maker;
+///         uint64 maker (deprecated);
 ///         uint192 __unallocated__;
 ///     }
 ///
@@ -327,7 +328,7 @@ library PositionStorageGlobalLib {
         );
     }
 
-    function store(PositionStorageGlobal storage self, Position memory newValue) external {
+    function store(PositionStorageGlobal storage self, Position memory newValue) public {
         PositionStorageLib.validate(newValue);
 
         if (newValue.maker.gt(UFixed6.wrap(type(uint64).max))) revert PositionStorageLib.PositionStorageInvalidError();
@@ -346,15 +347,29 @@ library PositionStorageGlobalLib {
             sstore(add(self.slot, 1), encoded1)
         }
     }
+
+    function migrate(PositionStorageGlobal storage self) external {
+        Position memory position = read(self);
+        uint256 slot1 = self.slot1;
+        UFixed6 deprecatedMaker = UFixed6.wrap(uint256(slot1 << (256 - 64)) >> (256 - 64));
+
+        // only migrate if the deprecated maker is set and new maker is unset to avoid double-migration
+        if (deprecatedMaker.isZero() || !position.maker.isZero())
+            revert PositionStorageLib.PositionStorageInvalidMigrationError();
+
+        position.maker = deprecatedMaker;
+        store(self, position);
+    }
 }
 
 /// @dev Manually encodes and decodes the local Position struct into storage.
 ///      (external-safe): this library is safe to externalize
 ///
-///     struct StoredPositionLocal {
+///     struct StoredPositionLocal (v0) {
 ///         /* slot 0 */
 ///         uint32 timestamp;
-///         uint224 __unallocated__;
+///         uint216 __unallocated__;
+///         uint8 layout;
 ///
 ///         /* slot 1 */
 ///         uint2 direction;
@@ -362,12 +377,29 @@ library PositionStorageGlobalLib {
 ///         uint192 __unallocated__;
 ///     }
 ///
+///     note: fresh Positions will still default to v0 until they are saved to, but this is safe because
+///           slot1 is still reserved and will return correct default values.
+///
+///     struct StoredPositionLocal (v1) {
+///         /* slot 0 */
+///         uint32 timestamp;
+///         uint2 direction;
+///         uint62 magnitude;
+///         uint152 __unallocated__;
+///         uint8 layout; // v2.3 migration -- can remove once all accounts have been migrated
+///     }
+///
 library PositionStorageLocalLib {
     function read(PositionStorageLocal storage self) internal view returns (Position memory) {
         (uint256 slot0, uint256 slot1) = (self.slot0, self.slot1);
+        uint256 layout = uint256(slot0 << (256 - 32 - 216 - 8)) >> (256 - 8);
 
-        uint256 direction = uint256(slot1 << (256 - 2)) >> (256 - 2);
-        UFixed6 magnitude = UFixed6.wrap(uint256(slot1 << (256 - 2 - 62)) >> (256 - 62));
+        uint256 direction = layout == 0 ?
+            uint256(slot1 << (256 - 2)) >> (256 - 2) :
+            uint256(slot0 << (256 - 32 - 2)) >> (256 - 2);
+        UFixed6 magnitude = layout == 0 ?
+            UFixed6.wrap(uint256(slot1 << (256 - 2 - 62)) >> (256 - 62)) :
+            UFixed6.wrap(uint256(slot0 << (256 - 32 - 2 - 62)) >> (256 - 62));
 
         return Position(
             uint256(slot0 << (256 - 32)) >> (256 - 32),
@@ -380,19 +412,19 @@ library PositionStorageLocalLib {
     function store(PositionStorageLocal storage self, Position memory newValue) external {
         PositionStorageLib.validate(newValue);
 
+        uint256 layout = 1;
         UFixed6 magnitude = newValue.magnitude();
 
         if (magnitude.gt(UFixed6.wrap(2 ** 62 - 1))) revert PositionStorageLib.PositionStorageInvalidError();
 
         uint256 encoded0 =
-            uint256(newValue.timestamp << (256 - 32)) >> (256 - 32);
-        uint256 encoded1 =
-            uint256(newValue.direction() << (256 - 2)) >> (256 - 2) |
-            uint256(UFixed6.unwrap(magnitude) << (256 - 62)) >> (256 - 2 - 62);
+            uint256(newValue.timestamp << (256 - 32)) >> (256 - 32) |
+            uint256(newValue.direction() << (256 - 2)) >> (256 - 32 - 2) |
+            uint256(UFixed6.unwrap(magnitude) << (256 - 62)) >> (256 - 32 - 2 - 62) |
+            uint256(layout << (256 - 8)) >> (256 - 32 - 2 - 62 - 152 - 8);
 
         assembly {
             sstore(self.slot, encoded0)
-            sstore(add(self.slot, 1), encoded1)
         }
     }
 }
@@ -400,6 +432,8 @@ library PositionStorageLocalLib {
 library PositionStorageLib {
     // sig: 0x52a8a97f
     error PositionStorageInvalidError();
+    // sig: 0x1bacb3a2
+    error PositionStorageInvalidMigrationError();
 
     function validate(Position memory newValue) internal pure {
         if (newValue.timestamp > type(uint32).max) revert PositionStorageInvalidError();

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -608,6 +608,19 @@ describe('Market', () => {
       await market.connect(owner).updateRiskParameter(riskParameter)
     })
 
+    describe('#migrate', async () => {
+      it('reverts if not owner (user)', async () => {
+        await expect(market.connect(user).migrate()).to.be.revertedWithCustomError(market, 'InstanceNotOwnerError')
+      })
+
+      it('reverts if not owner (coordinator)', async () => {
+        await expect(market.connect(coordinator).migrate()).to.be.revertedWithCustomError(
+          market,
+          'InstanceNotOwnerError',
+        )
+      })
+    })
+
     describe('#updateBeneficiary', async () => {
       it('updates the beneficiary', async () => {
         await expect(market.connect(owner).updateBeneficiary(beneficiary.address))


### PR DESCRIPTION
Adds migration flow to consolidate the global and local Position storage layouts from 2 to 1 slots (due to refactoring in v2.2).

#### Migration Notes
- The global Position exposes a `migrate()` function that must be called atomically (for each market) upon implementation upgrade. This bypasses the need for a layout version flag.
- The local Position will upgrade async, so we must track this with a new `layout` field in storage.
  - A value of `0` denotes either an old-layout `Position` or an unset Position. In both cases, the storage library will read from the v2.2 storage location. This is intended behavior in the former case, and safe in the latter case (due to the second slot still being reserved, and unset).
  - A value of `1` denotes that the Position has been successfully updated in state.
  - Once all accounts have been migrated, it is safe to remove the `layout` flag (i.e. in v2.4).
- Since this is an upgrade storage change, we must test this in the verifications scripts rather than in the standard tests.