### PR TITLE
Collateral Accounts - Made RebalanceLib library internal

### DIFF
--- a/packages/perennial-account/contracts/libs/RebalanceLib.sol
+++ b/packages/perennial-account/contracts/libs/RebalanceLib.sol
@@ -19,7 +19,7 @@ library RebalanceLib {
         RebalanceConfig memory marketConfig,
         Fixed6 groupCollateral,
         Fixed6 marketCollateral
-    ) external pure returns (bool canRebalance, Fixed6 imbalance) {
+    ) internal pure returns (bool canRebalance, Fixed6 imbalance) {
         // determine how much collateral the market should have
         Fixed6 targetCollateral = groupCollateral.mul(Fixed6Lib.from(marketConfig.target));
 

--- a/packages/perennial-account/test/helpers/arbitrumHelpers.ts
+++ b/packages/perennial-account/test/helpers/arbitrumHelpers.ts
@@ -23,7 +23,6 @@ import {
   IMarket,
   IMarketFactory,
   IOracleProvider,
-  RebalanceLib__factory,
   GasOracle__factory,
 } from '../../types/generated'
 import { IKept } from '../../types/generated/contracts/Controller_Arbitrum'
@@ -159,12 +158,12 @@ export async function deployControllerArbitrum(
 ): Promise<Controller_Arbitrum> {
   const accountImpl = await new Account__factory(owner).deploy(USDC_ADDRESS, DSU_ADDRESS, DSU_RESERVE)
   accountImpl.initialize(constants.AddressZero)
-  const controller = await new Controller_Arbitrum__factory(
-    {
-      'contracts/libs/RebalanceLib.sol:RebalanceLib': (await new RebalanceLib__factory(owner).deploy()).address,
-    },
-    owner,
-  ).deploy(accountImpl.address, keepConfig, nonceManager.address, overrides ?? {})
+  const controller = await new Controller_Arbitrum__factory(owner).deploy(
+    accountImpl.address,
+    keepConfig,
+    nonceManager.address,
+    overrides ?? {},
+  )
   return controller
 }
 

--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -8,13 +8,7 @@ import { parse6decimal } from '../../../common/testutil/types'
 import { currentBlockTimestamp, increaseTo } from '../../../common/testutil/time'
 import { getTimestamp } from '../../../common/testutil/transaction'
 
-import {
-  Account__factory,
-  Controller,
-  Controller__factory,
-  IERC20Metadata,
-  RebalanceLib__factory,
-} from '../../types/generated'
+import { Account__factory, Controller, Controller__factory, IERC20Metadata } from '../../types/generated'
 import {
   CheckpointLib__factory,
   CheckpointStorageLib__factory,
@@ -162,12 +156,7 @@ export async function deployController(
 ): Promise<Controller> {
   const accountImpl = await new Account__factory(owner).deploy(usdcAddress, dsuAddress, reserveAddress)
   accountImpl.initialize(constants.AddressZero)
-  const controller = await new Controller__factory(
-    {
-      'contracts/libs/RebalanceLib.sol:RebalanceLib': (await new RebalanceLib__factory(owner).deploy()).address,
-    },
-    owner,
-  ).deploy(accountImpl.address)
+  const controller = await new Controller__factory(owner).deploy(accountImpl.address)
   return controller
 }
 

--- a/packages/perennial-account/test/integration/Controller_Arbitrum.ts
+++ b/packages/perennial-account/test/integration/Controller_Arbitrum.ts
@@ -201,7 +201,7 @@ describe('Controller_Arbitrum', () => {
     // touch the provider, such that smock doesn't error out running a single test
     await advanceBlock()
     // Hardhat fork does not support Arbitrum built-ins; Kept produces "invalid opcode" error without this
-    await smock.fake<ArbGasInfo>('@equilibria/root/attribute/Kept/Kept_Arbitrum.sol:ArbGasInfo', {
+    await smock.fake<ArbGasInfo>('ArbGasInfo', {
       address: '0x000000000000000000000000000000000000006C',
     })
   })

--- a/packages/perennial-account/test/integration/Controller_Arbitrum.ts
+++ b/packages/perennial-account/test/integration/Controller_Arbitrum.ts
@@ -201,7 +201,7 @@ describe('Controller_Arbitrum', () => {
     // touch the provider, such that smock doesn't error out running a single test
     await advanceBlock()
     // Hardhat fork does not support Arbitrum built-ins; Kept produces "invalid opcode" error without this
-    await smock.fake<ArbGasInfo>('ArbGasInfo', {
+    await smock.fake<ArbGasInfo>('@equilibria/root/attribute/Kept/Kept_Arbitrum.sol:ArbGasInfo', {
       address: '0x000000000000000000000000000000000000006C',
     })
   })


### PR DESCRIPTION
Contract size with default optimizer runs went from 20.749 to 20.995; no concerns.