### PR TITLE
Add string 'factoryType' to IKeeperFactory and impls

### DIFF
--- a/packages/perennial-oracle/contracts/chainlink/ChainlinkFactory.sol
+++ b/packages/perennial-oracle/contracts/chainlink/ChainlinkFactory.sol
@@ -8,6 +8,7 @@ import "../keeper/KeeperFactory.sol";
 /// @notice Factory contract for creating and managing Chainlink oracles
 contract ChainlinkFactory is IChainlinkFactory, KeeperFactory {
     uint256 private constant PERCENTAGE_SCALAR = 1e18;
+    string public constant factoryType = "ChainlinkFactory";
 
     /// @dev Chainlink verifier contract
     IVerifierProxy public immutable chainlink;

--- a/packages/perennial-oracle/contracts/interfaces/IKeeperFactory.sol
+++ b/packages/perennial-oracle/contracts/interfaces/IKeeperFactory.sol
@@ -44,6 +44,7 @@ interface IKeeperFactory is IOracleProviderFactory, IFactory {
     error KeeperFactoryVersionOutsideRangeError();
 
     function initialize(IOracleFactory oracleFactory) external;
+    function factoryType() external view returns (string memory);
     function commitmentGasOracle() external view returns (IGasOracle);
     function settlementGasOracle() external view returns (IGasOracle);
     function updateId(IOracleProvider oracleProvider, bytes32 oracleId) external;

--- a/packages/perennial-oracle/contracts/metaquants/MetaQuantsFactory.sol
+++ b/packages/perennial-oracle/contracts/metaquants/MetaQuantsFactory.sol
@@ -10,13 +10,17 @@ contract MetaQuantsFactory is IMetaQuantsFactory, KeeperFactory {
 
     address public immutable signer;
 
+    string public factoryType;
+
     constructor(
         address signer_,
         IGasOracle commitmentGasOracle_,
         IGasOracle settlementGasOracle_,
+        string memory factoryType_,
         address implementation_
     ) KeeperFactory(commitmentGasOracle_, settlementGasOracle_, implementation_) {
         signer = signer_;
+        factoryType = factoryType_;
     }
 
     /// @notice Validates and parses the update data payload against the specified version

--- a/packages/perennial-oracle/contracts/metaquants/MetaQuantsFactory.sol
+++ b/packages/perennial-oracle/contracts/metaquants/MetaQuantsFactory.sol
@@ -10,7 +10,7 @@ contract MetaQuantsFactory is IMetaQuantsFactory, KeeperFactory {
 
     address public immutable signer;
 
-    string public factoryType;
+    bytes32 private immutable _factoryType;
 
     constructor(
         address signer_,
@@ -20,7 +20,15 @@ contract MetaQuantsFactory is IMetaQuantsFactory, KeeperFactory {
         address implementation_
     ) KeeperFactory(commitmentGasOracle_, settlementGasOracle_, implementation_) {
         signer = signer_;
-        factoryType = factoryType_;
+        _factoryType = bytes32(abi.encodePacked(factoryType_));
+    }
+
+    function factoryType() external view returns (string memory ret) {
+        bytes memory b = bytes(abi.encodePacked(_factoryType));
+        // Remove null bytes
+        for (uint256 i; i < b.length; i++) {
+            if (b[i] != 0) ret = string.concat(ret, string(abi.encodePacked(b[i])));
+        }
     }
 
     /// @notice Validates and parses the update data payload against the specified version

--- a/packages/perennial-oracle/contracts/pyth/PythFactory.sol
+++ b/packages/perennial-oracle/contracts/pyth/PythFactory.sol
@@ -10,6 +10,7 @@ import "../keeper/KeeperFactory.sol";
 /// @notice Factory contract for creating and managing Pyth oracles
 contract PythFactory is IPythFactory, KeeperFactory {
     int32 private constant PARSE_DECIMALS = 18;
+    string public constant factoryType = "PythFactory";
 
     /// @dev Pyth contract
     AbstractPyth public immutable pyth;

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -249,8 +249,8 @@ testOracles.forEach(testOracle => {
         SIGNER,
         commitmentGasOracle.address,
         settlementGasOracle.address,
-        keeperOracleImpl.address,
         'SignedPriceFactory',
+        keeperOracleImpl.address,
       )
       await metaquantsOracleFactory.initialize(oracleFactory.address)
       await oracleFactory.register(metaquantsOracleFactory.address)
@@ -479,8 +479,8 @@ testOracles.forEach(testOracle => {
             SIGNER,
             commitmentGasOracle.address,
             settlementGasOracle.address,
-            await metaquantsOracleFactory.implementation(),
             'SignedPriceFactory',
+            await metaquantsOracleFactory.implementation(),
           )
           await metaquantsOracleFactory2.initialize(oracleFactory.address)
           await expect(metaquantsOracleFactory2.initialize(oracleFactory.address))

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -250,6 +250,7 @@ testOracles.forEach(testOracle => {
         commitmentGasOracle.address,
         settlementGasOracle.address,
         keeperOracleImpl.address,
+        'SignedPriceFactory',
       )
       await metaquantsOracleFactory.initialize(oracleFactory.address)
       await oracleFactory.register(metaquantsOracleFactory.address)
@@ -468,6 +469,10 @@ testOracles.forEach(testOracle => {
     })
 
     describe('Factory', async () => {
+      it('factoryType is set', async () => {
+        expect(await metaquantsOracleFactory.factoryType()).to.equal('SignedPriceFactory')
+      })
+
       context('#initialize', async () => {
         it('reverts if already initialized', async () => {
           const metaquantsOracleFactory2 = await new MetaQuantsFactory__factory(owner).deploy(
@@ -475,6 +480,7 @@ testOracles.forEach(testOracle => {
             commitmentGasOracle.address,
             settlementGasOracle.address,
             await metaquantsOracleFactory.implementation(),
+            'SignedPriceFactory',
           )
           await metaquantsOracleFactory2.initialize(oracleFactory.address)
           await expect(metaquantsOracleFactory2.initialize(oracleFactory.address))

--- a/packages/perennial-oracle/test/unit/chainlink/ChainlinkFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/chainlink/ChainlinkFactory.test.ts
@@ -162,6 +162,10 @@ describe('ChainlinkFactory', () => {
     oracleSigner = await impersonateWithBalance(oracle.address, utils.parseEther('10'))
   })
 
+  it('factoryType is ChainlinkFactory', async () => {
+    expect(await chainlinkFactory.factoryType()).to.equal('ChainlinkFactory')
+  })
+
   it('parses Chainlink report correctly', async () => {
     market.claimFee.returns(utils.parseUnits('0.25', 6))
     await keeperOracle.connect(oracleSigner).request(market.address, user.address)

--- a/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/unit/pyth/PythOracleFactory.test.ts
@@ -141,6 +141,10 @@ describe('PythOracleFactory', () => {
     oracleSigner = await impersonateWithBalance(oracle.address, utils.parseEther('10'))
   })
 
+  it('factoryType is PythFactory', async () => {
+    expect(await pythOracleFactory.factoryType()).to.equal('PythFactory')
+  })
+
   it('parses Pyth exponents correctly', async () => {
     market.claimFee.returns(utils.parseUnits('0.25', 6))
 


### PR DESCRIPTION
Adds a `factoryType` to the `IKeeperFactory` and each implementation. This will make it easier for off-chain systems to know where to pull prices from by mapping the `factoryType` to the off-chain source.

For the `MetaQuantsFactory` the type is dynamically set in the constructor as this factory can be used for different signed price providers. As a followup task, I think we should rename the contract to something like `SignedPriceFactory`