### PR TITLE
[Fix] Add KeeperOracle migration shim

### DIFF
--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -144,12 +144,13 @@ contract KeeperOracle is IKeeperOracle, Instance {
 
         emit OracleProviderVersionFulfilled(version);
 
-        IMarket market = oracle.market();
-        if (market == IMarket(address(0))) return; // v2.3 migration -- don't callback if market is not yet set
-
-        market.settle(address(0));
-        oracle.claimFee(priceResponse.toOracleReceipt(_localCallbacks[version.timestamp].length()).settlementFee);
-        market.token().push(receiver, UFixed18Lib.from(priceResponse.syncFee));
+        try oracle.market() returns (IMarket market) { // v2.3 migration -- don't callback if Oracle is still on its v2.2 implementation
+            market.settle(address(0));
+            oracle.claimFee(priceResponse.toOracleReceipt(_localCallbacks[version.timestamp].length()).settlementFee);
+            market.token().push(receiver, UFixed18Lib.from(priceResponse.syncFee));
+        } catch {
+            return;
+        }
     }
 
     /// @notice Performs an asynchronous local settlement callback

--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -66,21 +66,21 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @notice Returns the local oracle callback set for a version and market
     /// @param version The version to lookup
     /// @return The local oracle callback set for the version and market
-    function localCallbacks(uint256 version) external view returns (address[] memory) {
+    function localCallbacks(uint256 version) external view virtual returns (address[] memory) {
         return _localCallbacks[version].values();
     }
 
     /// @notice Returns the next requested oracle version
     /// @dev Returns 0 if no next version is requested
     /// @return The next requested oracle version
-    function next() public view returns (uint256) {
+    function next() public view virtual returns (uint256) {
         return requests[_global.latestIndex + 1];
     }
 
     /// @notice Returns the response for a given oracle version
     /// @param timestamp The timestamp of the oracle version
     /// @return The response for the given oracle version
-    function responses(uint256 timestamp) external view returns (PriceResponse memory) {
+    function responses(uint256 timestamp) external view virtual returns (PriceResponse memory) {
         return _responses[timestamp].read();
     }
 
@@ -88,7 +88,7 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @dev  - If no request has been made this version, a price request will be created
     ///       - If a request has been made this version, no action will be taken
     /// @param account The account to callback to
-    function request(IMarket, address account) external onlyOracle {
+    function request(IMarket, address account) external virtual onlyOracle {
         uint256 currentTimestamp = current();
 
         _localCallbacks[currentTimestamp].add(account);
@@ -103,19 +103,19 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @notice Returns the latest synced oracle version and the current oracle version
     /// @return The latest synced oracle version
     /// @return The current oracle version collecting new orders
-    function status() external view returns (OracleVersion memory, uint256) {
+    function status() external view virtual returns (OracleVersion memory, uint256) {
         return (latest(), current());
     }
 
     /// @notice Returns the latest synced oracle version
     /// @return latestVersion Latest oracle version
-    function latest() public view returns (OracleVersion memory latestVersion) {
+    function latest() public view virtual returns (OracleVersion memory latestVersion) {
         (latestVersion, ) = at(_global.latestVersion);
     }
 
     /// @notice Returns the current oracle version accepting new orders
     /// @return Current oracle version
-    function current() public view returns (uint256) {
+    function current() public view virtual returns (uint256) {
         return IKeeperFactory(address(factory())).current();
     }
 
@@ -123,7 +123,7 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @param timestamp The timestamp of which to lookup
     /// @return Oracle version at version `version`
     /// @return Oracle receipt at version `version`
-    function at(uint256 timestamp) public view returns (OracleVersion memory, OracleReceipt memory) {
+    function at(uint256 timestamp) public view virtual returns (OracleVersion memory, OracleReceipt memory) {
         return (
             _responses[timestamp].read().toOracleVersion(timestamp),
             _responses[timestamp].read().toOracleReceipt(_localCallbacks[timestamp].length())
@@ -135,7 +135,7 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @param version The oracle version to commit
     /// @param receiver The receiver of the settlement fee
     /// @param value The value charged to commit the price in ether
-    function commit(OracleVersion memory version, address receiver, uint256 value) external onlyFactory {
+    function commit(OracleVersion memory version, address receiver, uint256 value) external virtual onlyFactory {
         if (version.timestamp == 0) revert KeeperOracleVersionOutsideRangeError();
         PriceResponse memory priceResponse = (version.timestamp == next()) ?
             _commitRequested(version, value) :
@@ -154,7 +154,7 @@ contract KeeperOracle is IKeeperOracle, Instance {
     /// @dev Distribution of keeper incentive is consolidated in the oracle's factory
     /// @param version The version to settle
     /// @param maxCount The maximum number of settlement callbacks to perform before exiting
-    function settle(uint256 version, uint256 maxCount) external onlyFactory {
+    function settle(uint256 version, uint256 maxCount) external virtual onlyFactory {
         EnumerableSet.AddressSet storage callbacks = _localCallbacks[version];
 
         if (_global.latestVersion < version) revert KeeperOracleVersionOutsideRangeError();

--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle.sol
@@ -145,6 +145,8 @@ contract KeeperOracle is IKeeperOracle, Instance {
         emit OracleProviderVersionFulfilled(version);
 
         IMarket market = oracle.market();
+        if (market == IMarket(address(0))) return; // v2.3 migration -- don't callback if market is not yet set
+
         market.settle(address(0));
         oracle.claimFee(priceResponse.toOracleReceipt(_localCallbacks[version.timestamp].length()).settlementFee);
         market.token().push(receiver, UFixed18Lib.from(priceResponse.syncFee));

--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle_Migration.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle_Migration.sol
@@ -17,10 +17,11 @@ contract KeeperOracle_Migration is KeeperOracle {
     /// @dev Empty responses, as long as they are of the correct format, will be overridden by the Global.latestPrice
     /// @return oracleVersion The empty oracle version
     /// @return oracleReceipt The empty oracle receipt
-    function at(uint256) public pure override returns (
+    function at(uint256 timestamp) public pure override returns (
         OracleVersion memory oracleVersion,
         OracleReceipt memory oracleReceipt
     ) {
+        oracleVersion.timestamp = timestamp;
         return (oracleVersion, oracleReceipt);
     }
 

--- a/packages/perennial-oracle/contracts/keeper/KeeperOracle_Migration.sol
+++ b/packages/perennial-oracle/contracts/keeper/KeeperOracle_Migration.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {IMarket, OracleVersion, OracleReceipt } from "../interfaces/IKeeperFactory.sol";
+import { PriceResponse } from "./types/PriceResponse.sol";
+import { KeeperOracle } from "./KeeperOracle.sol";
+
+/// @title KeeperOracle_Migration
+/// @notice Stub implementation to upgrade the prior KeeperOracle to during the v2.3 migration for compatibility.
+contract KeeperOracle_Migration is KeeperOracle {
+    // sig: 0xd41c17e7
+    error NotImplementedError();
+
+    constructor(uint256 timeout_) KeeperOracle(timeout_) { }
+
+    /// @notice Returns an empty response of the correct v2.3 format for forwards compatibility of the previous sub-oracle
+    /// @dev Empty responses, as long as they are of the correct format, will be overridden by the Global.latestPrice
+    /// @return oracleVersion The empty oracle version
+    /// @return oracleReceipt The empty oracle receipt
+    function at(uint256) public pure override returns (
+        OracleVersion memory oracleVersion,
+        OracleReceipt memory oracleReceipt
+    ) {
+        return (oracleVersion, oracleReceipt);
+    }
+
+    /* Do not allow any unintented calls to the previous sub-oracle after migration */
+
+    function localCallbacks(uint256) external pure override returns (address[] memory) { revert NotImplementedError(); }
+    function next() public pure override returns (uint256) { revert NotImplementedError(); }
+    function responses(uint256) external pure override returns (PriceResponse memory) { revert NotImplementedError(); }
+    function request(IMarket, address) external pure override { revert NotImplementedError(); }
+    function status() external pure override returns (OracleVersion memory, uint256) { revert NotImplementedError(); }
+    function latest() public pure override returns (OracleVersion memory) { revert NotImplementedError(); }
+    function current() public pure override returns (uint256) { revert NotImplementedError(); }
+    function commit(OracleVersion memory, address, uint256) external pure override { revert NotImplementedError(); }
+    function settle(uint256, uint256) external pure override { revert NotImplementedError(); }
+}


### PR DESCRIPTION
Adds a Noop v2.3 migration shim for the `KeeperOracle`.

### How to Use
1. Enter settle-only mode
2. Settle up all accounts in the system
3. Deploy new v2.3 KeeperOracle
4. Commit fresh price more recent than the previous latest (important that this happens prior to the next step)
5. Update the Oracle to the new KeeperOracle
6. Upgrade the prior KeeperOracle to the shim implementation

Market should now be able to update.

### Why this works
- After (2) all accounts will be settled up to the same version `v` (either a requested or unrequested version) along with global.
- (4) will only work because of this [try/catch](https://github.com/equilibria-xyz/perennial-v2_private/pull/15/files#diff-a24c8ce062ad04684b31e345eee9b359bf296aac024925fa40df4ceb88576272R147) that has been added. Previously, all posted prices require the global settlement callback to the registered market, but in this case there would not yet be one, and therefore the callback would revert.
- [In (5)](https://github.com/equilibria-xyz/perennial-v2_private/blob/main/packages/perennial-oracle/contracts/Oracle.sol#L30) if the new KeeperOracle's latest version > `v`, we will immediately switch both `global.current` and `global.latest` to the new KeeperOracle in the [`_updateCurrent()`](https://github.com/equilibria-xyz/perennial-v2_private/blob/main/packages/perennial-oracle/contracts/Oracle.sol#L82) and [`_updateLatest()`](https://github.com/equilibria-xyz/perennial-v2_private/blob/main/packages/perennial-oracle/contracts/Oracle.sol#L100) internal function respectively.
  - `at()` is not reference in this call, so it is safe to keep the v2.2 logic on the prior KeeperOracle implementation, as we need to access its data.
- Once (6) is complete:
  - `_handleLatest()` will no longer call the previous KeeperOracle because [`global.current == global.latest`](https://github.com/equilibria-xyz/perennial-v2_private/blob/main/packages/perennial-oracle/contracts/Oracle.sol#L111), which means `latest()` and `status()` are safe.
  - `at()` is only called by the market for:
    - [New order's timestamps](https://github.com/equilibria-xyz/perennial-v2_private/blob/v2.3/packages/perennial/contracts/Market.sol#L771), which will point at the new KeeperOracle
    - [The latest timestamp](https://github.com/equilibria-xyz/perennial-v2_private/blob/v2.3/packages/perennial/contracts/Market.sol#L712), which will point to the shim on the first update / settlement, and is safe because:
      - A zero value will be overwritten by `Global.latestPrice`
      - `Global.latestPrice` is the correct price for latest because we are still on `v`
      - Only the price and timestamp are used from the `context.orderOracleVersion`

Fixes: https://github.com/sherlock-audit/2024-08-perennial-v2-update-3-judging/issues/91.