### PR TITLE
Account for pending position in notional value calculation

### DIFF
--- a/packages/perennial-order/contracts/Manager.sol
+++ b/packages/perennial-order/contracts/Manager.sol
@@ -126,8 +126,8 @@ abstract contract Manager is IManager, Kept {
         if (!canExecute) revert ManagerCannotExecuteError();
 
         _compensateKeeper(market, account, order.maxFee);
-        order.execute(market, account);
         bool interfaceFeeCharged = _chargeInterfaceFee(market, account, order);
+        order.execute(market, account);
 
         // invalidate the order nonce
         order.isSpent = true;

--- a/packages/perennial-order/contracts/types/TriggerOrder.sol
+++ b/packages/perennial-order/contracts/types/TriggerOrder.sol
@@ -111,6 +111,9 @@ library TriggerOrderLib {
     /// @notice Returns user's position for the side of the order they placed
     function _position(IMarket market, address account, uint8 side) private view returns (UFixed6) {
         Position memory current = market.positions(account);
+        Order memory pending = market.pendings(account);
+        current.update(pending);
+
         if (side == 4) return current.maker;
         else if (side == 5) return current.long;
         else if (side == 6) return current.short;

--- a/packages/perennial-order/test/unit/TriggerOrder.test.ts
+++ b/packages/perennial-order/test/unit/TriggerOrder.test.ts
@@ -133,12 +133,12 @@ describe('TriggerOrder', () => {
         timestamp: now(),
         orders: constants.One,
         collateral: constants.Zero,
-        makerPos: Side.MAKER && pending.gt(0) ? pending : constants.Zero,
-        makerNeg: Side.MAKER && pending.lt(0) ? pending.mul(-1) : constants.Zero,
-        longPos: Side.LONG && pending.gt(0) ? pending : constants.Zero,
-        longNeg: Side.LONG && pending.lt(0) ? pending.mul(-1) : constants.Zero,
-        shortPos: Side.SHORT && pending.gt(0) ? pending : constants.Zero,
-        shortNeg: Side.SHORT && pending.lt(0) ? pending.mul(-1) : constants.Zero,
+        makerPos: side === Side.MAKER && pending.gt(0) ? pending : constants.Zero,
+        makerNeg: side === Side.MAKER && pending.lt(0) ? pending.mul(-1) : constants.Zero,
+        longPos: side === Side.LONG && pending.gt(0) ? pending : constants.Zero,
+        longNeg: side === Side.LONG && pending.lt(0) ? pending.mul(-1) : constants.Zero,
+        shortPos: side === Side.SHORT && pending.gt(0) ? pending : constants.Zero,
+        shortNeg: side === Side.SHORT && pending.lt(0) ? pending.mul(-1) : constants.Zero,
         protection: constants.Zero,
         makerReferral: constants.Zero,
         takerReferral: constants.Zero,
@@ -185,6 +185,40 @@ describe('TriggerOrder', () => {
         },
       }
       const expectedNotional = parse6decimal('24400') // price * position
+      expect(await orderTester.notionalValue(order, market.address, user.address)).to.equal(expectedNotional)
+    })
+
+    it('calculates notional to close position with pending open', async () => {
+      mockPrice(parse6decimal('2000'))
+      mockPosition(Side.MAKER, parse6decimal('12.2'), parse6decimal('0.3'))
+      const order = {
+        ...ORDER_MAKER,
+        delta: MAGIC_VALUE_CLOSE_POSITION,
+        interfaceFee: {
+          amount: parse6decimal('0.0111'),
+          receiver: recipient.address,
+          fixedFee: false,
+          unwrap: true,
+        },
+      }
+      const expectedNotional = parse6decimal('25000') // price * position
+      expect(await orderTester.notionalValue(order, market.address, user.address)).to.equal(expectedNotional)
+    })
+
+    it('calculates national to close position with pending close', async () => {
+      mockPrice(parse6decimal('2000'))
+      mockPosition(Side.MAKER, parse6decimal('12.2'), parse6decimal('-0.2'))
+      const order = {
+        ...ORDER_MAKER,
+        delta: MAGIC_VALUE_CLOSE_POSITION,
+        interfaceFee: {
+          amount: parse6decimal('0.0111'),
+          receiver: recipient.address,
+          fixedFee: false,
+          unwrap: true,
+        },
+      }
+      const expectedNotional = parse6decimal('24000') // price * position
       expect(await orderTester.notionalValue(order, market.address, user.address)).to.equal(expectedNotional)
     })
 

--- a/packages/perennial/contracts/Market.sol
+++ b/packages/perennial/contracts/Market.sol
@@ -208,8 +208,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @notice Updates the account's position and collateral
     /// @param account The account to operate on
     /// @param newMaker The new maker position for the account
-    /// @param newMaker The new long position for the account
-    /// @param newMaker The new short position for the account
+    /// @param newLong The new long position for the account
+    /// @param newShort The new short position for the account
     /// @param collateral The collateral amount to add or remove from the account
     /// @param protect Whether to put the account into a protected status for liquidations
     /// @param referrer The referrer of the order


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2024-08-perennial-v2-update-3-judging/issues/62