### PR TITLE
Fix margin check to incorporate price override

### DIFF
--- a/packages/perennial/contracts/libs/CheckpointLib.sol
+++ b/packages/perennial/contracts/libs/CheckpointLib.sol
@@ -219,6 +219,6 @@ library CheckpointLib {
         Version memory toVersion
     ) private pure returns (Fixed6) {
         if (!toVersion.valid) return Fixed6Lib.ZERO;
-        return guarantee.taker().mul(toVersion.price).sub(guarantee.notional);
+        return guarantee.priceAdjustment(toVersion.price);
     }
 }

--- a/packages/perennial/contracts/libs/InvariantLib.sol
+++ b/packages/perennial/contracts/libs/InvariantLib.sol
@@ -92,7 +92,7 @@ library InvariantLib {
                 context.latestOracleVersion,
                 context.riskParameter,
                 updateContext.collateralization,
-                context.local.collateral
+                context.local.collateral.add(newGuarantee.priceAdjustment(context.latestOracleVersion.price)) // apply price override adjustment from intent if present
             )
         ) revert IMarket.MarketInsufficientMarginError();
 

--- a/packages/perennial/contracts/test/GuaranteeTester.sol
+++ b/packages/perennial/contracts/test/GuaranteeTester.sol
@@ -15,7 +15,11 @@ abstract contract GuaranteeTester {
 
     function takerTotal(Guarantee memory guarantee) public pure returns (UFixed6) {
         return GuaranteeLib.takerTotal(guarantee);
-    } 
+    }
+
+    function priceAdjustment(Guarantee memory guarantee, Fixed6 price) public pure returns (Fixed6) {
+        return GuaranteeLib.priceAdjustment(guarantee, price);
+    }
 }
 
 contract GuaranteeGlobalTester is GuaranteeTester {

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -86,6 +86,14 @@ library GuaranteeLib {
         return self.takerPos.add(self.takerNeg);
     }
 
+    /// @notice Returns the collateral adjusted due to the price override
+    /// @param self The guarantee object to check
+    /// @param price The oracle price to compare to the price override
+    /// @return The collateral adjusted due to the price override
+    function priceAdjustment(Guarantee memory self, Fixed6 price) internal pure returns (Fixed6) {
+        return self.taker().mul(price).sub(self.notional);
+    }
+
     /// @notice Updates the current global guarantee with a new local guarantee
     /// @param self The guarantee object to update
     /// @param guarantee The new guarantee

--- a/packages/perennial/test/unit/types/Guarantee.test.ts
+++ b/packages/perennial/test/unit/types/Guarantee.test.ts
@@ -529,6 +529,84 @@ describe('Guarantee', () => {
         ).to.equal(7)
       })
     })
+
+    describe('#priceAdjustment', () => {
+      it('long / higher price', async () => {
+        await expect(
+          await guaranteeLocal.priceAdjustment(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('1230'),
+              takerPos: parse6decimal('10'),
+            },
+            parse6decimal('125'),
+          ),
+        ).to.equal(parse6decimal('20'))
+      })
+
+      it('short / lower price', async () => {
+        await expect(
+          await guaranteeLocal.priceAdjustment(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('-1230'),
+              takerNeg: parse6decimal('10'),
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('20'))
+      })
+
+      it('long / lower price', async () => {
+        await expect(
+          await guaranteeLocal.priceAdjustment(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('1230'),
+              takerPos: parse6decimal('10'),
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('-20'))
+      })
+
+      it('short / higher price', async () => {
+        await expect(
+          await guaranteeLocal.priceAdjustment(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('-1230'),
+              takerNeg: parse6decimal('10'),
+            },
+            parse6decimal('125'),
+          ),
+        ).to.equal(parse6decimal('-20'))
+      })
+
+      it('zero price', async () => {
+        await expect(
+          await guaranteeLocal.priceAdjustment(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('0'),
+              takerNeg: parse6decimal('10'),
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('-1210'))
+      })
+
+      it('zero size', async () => {
+        await expect(
+          await guaranteeLocal.priceAdjustment(
+            {
+              ...DEFAULT_GUARANTEE,
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('0'))
+      })
+    })
   })
 
   function shouldBehaveLike(


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2024-08-perennial-v2-update-3-judging/issues/42

Includes the expected collateral adjustment based on the difference between the latest oracle price and the price override if present when calculating the margin requirement in the invariant.