### PR TITLE
[Fix] Add maximum for intent price deviation

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -105,6 +105,7 @@ export interface MarketParameter {
   riskFee: BigNumberish
   maxPendingGlobal: number
   maxPendingLocal: number
+  maxPriceDeviation: BigNumberish
   closed: boolean
   settle: boolean
 }
@@ -356,6 +357,7 @@ export const DEFAULT_MARKET_PARAMETER: MarketParameter = {
   riskFee: 0,
   maxPendingGlobal: 0,
   maxPendingLocal: 0,
+  maxPriceDeviation: 0,
   closed: false,
   settle: false,
 }

--- a/packages/perennial-account/test/helpers/setupHelpers.ts
+++ b/packages/perennial-account/test/helpers/setupHelpers.ts
@@ -134,6 +134,7 @@ export async function createMarket(
     takerFee: 0,
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
+    maxPriceDeviation: parse6decimal('0.1'),
     closed: false,
     settle: false,
     ...marketParamOverrides,

--- a/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-extensions/test/integration/helpers/setupHelpers.ts
@@ -329,6 +329,7 @@ export async function createMarket(
     takerFee: 0,
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
+    maxPriceDeviation: parse6decimal('0.1'),
     closed: false,
     settle: false,
     ...marketParamOverrides,

--- a/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -402,7 +402,7 @@ testOracles.forEach(testOracle => {
         takerFee: 0,
         maxPendingGlobal: 8,
         maxPendingLocal: 8,
-        settlementFee: 0,
+        maxPriceDeviation: parse6decimal('0.1'),
         closed: false,
         settle: false,
       }

--- a/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -358,7 +358,7 @@ testOracles.forEach(testOracle => {
         takerFee: 0,
         maxPendingGlobal: 8,
         maxPendingLocal: 8,
-        settlementFee: 0,
+        maxPriceDeviation: parse6decimal('0.1'),
         closed: false,
         settle: false,
       }

--- a/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/perennial-oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -370,7 +370,7 @@ testOracles.forEach(testOracle => {
         takerFee: 0,
         maxPendingGlobal: 8,
         maxPendingLocal: 8,
-        settlementFee: 0,
+        maxPriceDeviation: parse6decimal('0.1'),
         closed: false,
         settle: false,
       }

--- a/packages/perennial-order/test/helpers/marketHelpers.ts
+++ b/packages/perennial-order/test/helpers/marketHelpers.ts
@@ -84,6 +84,7 @@ export async function createMarket(
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
     settlementFee: 0,
+    maxPriceDeviation: parse6decimal('0.1'),
     closed: false,
     settle: false,
     ...marketParamOverrides,

--- a/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-vault/test/integration/helpers/setupHelpers.ts
@@ -84,6 +84,7 @@ export async function deployProductOnMainnetFork({
     settlementFee: 0,
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
+    maxPriceDeviation: parse6decimal('0.1'),
     closed: false,
     settle: false,
   }

--- a/packages/perennial/contracts/interfaces/IMarket.sol
+++ b/packages/perennial/contracts/interfaces/IMarket.sol
@@ -120,6 +120,8 @@ interface IMarket is IInstance {
     error MarketSettleOnlyError();
     // sig: 0x1e9d2296
     error MarketInvalidIntentFeeError();
+    // sig: 0xaf5dfc8f
+    error MarketIntentPriceDeviationError();
 
     // sig: 0x2142bc27
     error GlobalStorageInvalidError();

--- a/packages/perennial/contracts/libs/InvariantLib.sol
+++ b/packages/perennial/contracts/libs/InvariantLib.sol
@@ -73,6 +73,9 @@ library InvariantLib {
             )
         ) revert IMarket.MarketNotSingleSidedError();
 
+        if (newGuarantee.priceDeviation(context.latestOracleVersion.price).gt(context.marketParameter.maxPriceDeviation))
+            revert IMarket.MarketIntentPriceDeviationError();
+
         if (newOrder.protected()) return; // The following invariants do not apply to protected position updates (liquidations)
 
         if (

--- a/packages/perennial/contracts/test/GuaranteeTester.sol
+++ b/packages/perennial/contracts/test/GuaranteeTester.sol
@@ -20,6 +20,10 @@ abstract contract GuaranteeTester {
     function priceAdjustment(Guarantee memory guarantee, Fixed6 price) public pure returns (Fixed6) {
         return GuaranteeLib.priceAdjustment(guarantee, price);
     }
+
+    function priceDeviation(Guarantee memory guarantee, Fixed6 price) public pure returns (UFixed6) {
+        return GuaranteeLib.priceDeviation(guarantee, price);
+    }
 }
 
 contract GuaranteeGlobalTester is GuaranteeTester {

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -94,6 +94,19 @@ library GuaranteeLib {
         return self.taker().mul(price).sub(self.notional);
     }
 
+    /// @notice Returns the price deviation of the guarantee from the oracle price
+    /// @dev The price deviation is (intent price - oracle price) / min(intent price, oracle price)
+    ///      Only supports new guarantees for updates, does not work for aggregated guarantees (local / global)
+    /// @param self The guarantee object to check
+    /// @param price The oracle price to compare
+    /// @return The price deviation of the guarantee from the oracle price
+    function priceDeviation(Guarantee memory self, Fixed6 price) internal pure returns (UFixed6) {
+        if (takerTotal(self).isZero()) return UFixed6Lib.ZERO;
+
+        Fixed6 guarenteePrice = self.notional.div(taker(self));
+        return guarenteePrice.sub(price).div(guarenteePrice.min(price)).abs();
+    }
+
     /// @notice Updates the current global guarantee with a new local guarantee
     /// @param self The guarantee object to update
     /// @param guarantee The new guarantee

--- a/packages/perennial/contracts/types/Guarantee.sol
+++ b/packages/perennial/contracts/types/Guarantee.sol
@@ -95,7 +95,7 @@ library GuaranteeLib {
     }
 
     /// @notice Returns the price deviation of the guarantee from the oracle price
-    /// @dev The price deviation is (intent price - oracle price) / min(intent price, oracle price)
+    /// @dev The price deviation is the difference between the prices over the closest price to zero
     ///      Only supports new guarantees for updates, does not work for aggregated guarantees (local / global)
     /// @param self The guarantee object to check
     /// @param price The oracle price to compare
@@ -103,8 +103,8 @@ library GuaranteeLib {
     function priceDeviation(Guarantee memory self, Fixed6 price) internal pure returns (UFixed6) {
         if (takerTotal(self).isZero()) return UFixed6Lib.ZERO;
 
-        Fixed6 guarenteePrice = self.notional.div(taker(self));
-        return guarenteePrice.sub(price).div(guarenteePrice.min(price)).abs();
+        Fixed6 guaranteePrice = self.notional.div(taker(self));
+        return guaranteePrice.sub(price).abs().unsafeDiv(guaranteePrice.abs().min(price.abs()));
     }
 
     /// @notice Updates the current global guarantee with a new local guarantee

--- a/packages/perennial/contracts/types/MarketParameter.sol
+++ b/packages/perennial/contracts/types/MarketParameter.sol
@@ -28,6 +28,9 @@ struct MarketParameter {
     /// @dev The maximum amount of orders that can be pending at one time per account
     uint256 maxPendingLocal;
 
+    /// @dev The maximum deviation percentage from the oracle price that is allowed for an intent price override
+    UFixed6 maxPriceDeviation;
+
     /// @dev Whether the market is in close-only mode
     bool closed;
 
@@ -49,7 +52,8 @@ using MarketParameterStorageLib for MarketParameterStorage global;
 ///        uint24 riskFee;             // <= 1677%
 ///        uint16 maxPendingGlobal;    // <= 65k
 ///        uint16 maxPendingLocal;     // <= 65k
-///        uint48 __unallocated__;     // <= 281m
+///        uint24 maxPriceDeviation;   // <= 16.77x
+///        uint24 __unallocated__;
 ///        uint8 flags;
 ///    }
 ///
@@ -60,7 +64,7 @@ library MarketParameterStorageLib {
     function read(MarketParameterStorage storage self) internal view returns (MarketParameter memory) {
         uint256 slot0 = self.slot0;
 
-        uint256 flags = uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 48 - 8)) >> (256 - 8);
+        uint256 flags = uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 24 - 24 - 8)) >> (256 - 8);
         (bool closed, bool settle) =
             (flags & 0x04 == 0x04, flags & 0x08 == 0x08);
 
@@ -70,8 +74,9 @@ library MarketParameterStorageLib {
             UFixed6.wrap(uint256(slot0 << (256 - 24 - 24 - 24)) >> (256 - 24)),
             UFixed6.wrap(uint256(slot0 << (256 - 24 - 24 - 24 - 24)) >> (256 - 24)),
             UFixed6.wrap(uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24)) >> (256 - 24)),
-            uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16)) >> (256 - 16),
-            uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16)) >> (256 - 16),
+                         uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16)) >> (256 - 16),
+                         uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16)) >> (256 - 16),
+            UFixed6.wrap(uint256(slot0 << (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 24)) >> (256 - 24)),
             closed,
             settle
         );
@@ -94,6 +99,7 @@ library MarketParameterStorageLib {
 
         if (newValue.maxPendingGlobal > uint256(type(uint16).max)) revert MarketParameterStorageInvalidError();
         if (newValue.maxPendingLocal > uint256(type(uint16).max)) revert MarketParameterStorageInvalidError();
+        if (newValue.maxPriceDeviation.gt(UFixed6.wrap(type(uint24).max))) revert MarketParameterStorageInvalidError();
 
         _store(self, newValue);
     }
@@ -103,14 +109,15 @@ library MarketParameterStorageLib {
             (newValue.settle ? 0x08 : 0x00);
 
         uint256 encoded0 =
-            uint256(UFixed6.unwrap(newValue.fundingFee) << (256 - 24)) >> (256 - 24) |
-            uint256(UFixed6.unwrap(newValue.interestFee) << (256 - 24)) >> (256 - 24 - 24) |
-            uint256(UFixed6.unwrap(newValue.makerFee) << (256 - 24)) >> (256 - 24 - 24 - 24) |
-            uint256(UFixed6.unwrap(newValue.takerFee) << (256 - 24)) >> (256 - 24 - 24 - 24 - 24) |
-            uint256(UFixed6.unwrap(newValue.riskFee) << (256 - 24)) >> (256 - 24 - 24 - 24 - 24 - 24) |
-            uint256(newValue.maxPendingGlobal << (256 - 16)) >> (256 - 24 - 24 - 24 - 24 - 24 - 16) |
-            uint256(newValue.maxPendingLocal << (256 - 16)) >> (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16) |
-            uint256(flags << (256 - 8)) >> (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 48 - 8);
+            uint256(UFixed6.unwrap(newValue.fundingFee)         << (256 - 24)) >> (256 - 24) |
+            uint256(UFixed6.unwrap(newValue.interestFee)        << (256 - 24)) >> (256 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.makerFee)           << (256 - 24)) >> (256 - 24 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.takerFee)           << (256 - 24)) >> (256 - 24 - 24 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.riskFee)            << (256 - 24)) >> (256 - 24 - 24 - 24 - 24 - 24) |
+            uint256(newValue.maxPendingGlobal                   << (256 - 16)) >> (256 - 24 - 24 - 24 - 24 - 24 - 16) |
+            uint256(newValue.maxPendingLocal                    << (256 - 16)) >> (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16) |
+            uint256(UFixed6.unwrap(newValue.maxPriceDeviation)  << (256 - 24)) >> (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 24) |
+            uint256(flags                                       << (256 - 8))  >> (256 - 24 - 24 - 24 - 24 - 24 - 16 - 16 - 24 - 24 - 8);
 
         assembly {
             sstore(self.slot, encoded0)

--- a/packages/perennial/contracts/types/MarketParameter.sol
+++ b/packages/perennial/contracts/types/MarketParameter.sol
@@ -52,7 +52,7 @@ using MarketParameterStorageLib for MarketParameterStorage global;
 ///        uint24 riskFee;             // <= 1677%
 ///        uint16 maxPendingGlobal;    // <= 65k
 ///        uint16 maxPendingLocal;     // <= 65k
-///        uint24 maxPriceDeviation;   // <= 16.77x
+///        uint24 maxPriceDeviation;   // <= 1677%
 ///        uint24 __unallocated__;
 ///        uint8 flags;
 ///    }

--- a/packages/perennial/test/integration/core/happyPath.test.ts
+++ b/packages/perennial/test/integration/core/happyPath.test.ts
@@ -115,6 +115,7 @@ describe('Happy Path', () => {
       takerFee: 0,
       maxPendingGlobal: 8,
       maxPendingLocal: 8,
+      maxPriceDeviation: parse6decimal('0.1'),
       closed: false,
       settle: false,
     }
@@ -1290,6 +1291,7 @@ describe('Happy Path', () => {
       maxPendingLocal: 8,
       makerFee: positionFeesOn ? parse6decimal('0.2') : 0,
       takerFee: positionFeesOn ? parse6decimal('0.1') : 0,
+      maxPriceDeviation: parse6decimal('0.1'),
       closed: false,
       settle: false,
     }
@@ -1453,6 +1455,7 @@ describe('Happy Path', () => {
       maxPendingLocal: 8,
       makerFee: parse6decimal('0.2'),
       takerFee: parse6decimal('0.1'),
+      maxPriceDeviation: parse6decimal('0.1'),
       closed: false,
       settle: false,
     }
@@ -2529,6 +2532,7 @@ describe('Happy Path', () => {
       maxPendingLocal: 8,
       makerFee: positionFeesOn ? parse6decimal('0.2') : 0,
       takerFee: positionFeesOn ? parse6decimal('0.1') : 0,
+      maxPriceDeviation: parse6decimal('0.1'),
       closed: false,
       settle: false,
     }

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -267,6 +267,7 @@ export async function createMarket(
     takerFee: 0,
     maxPendingGlobal: 8,
     maxPendingLocal: 8,
+    maxPriceDeviation: parse6decimal('0.1'),
     closed: false,
     settle: false,
     ...marketParamOverrides,

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -14716,6 +14716,10 @@ describe('Market', () => {
         })
 
         it('reverts if under margin (intent maker)', async () => {
+          const marketParameter = { ...(await market.parameter()) }
+          marketParameter.maxPriceDeviation = parse6decimal('10.00')
+          await market.updateParameter(marketParameter)
+
           const intent = {
             amount: POSITION.div(2),
             price: parse6decimal('1250'),
@@ -14774,6 +14778,10 @@ describe('Market', () => {
         })
 
         it('reverts if under margin (intent taker)', async () => {
+          const marketParameter = { ...(await market.parameter()) }
+          marketParameter.maxPriceDeviation = parse6decimal('10.00')
+          await market.updateParameter(marketParameter)
+
           const intent = {
             amount: POSITION.div(2),
             price: parse6decimal('25'),
@@ -14829,6 +14837,104 @@ describe('Market', () => {
                 'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
               ](userC.address, intent, DEFAULT_SIGNATURE),
           ).to.be.revertedWithCustomError(market, 'MarketInsufficientMarginError')
+        })
+
+        it('reverts if above price deviation (higher)', async () => {
+          const intent = {
+            amount: POSITION.div(2),
+            price: parse6decimal('136'),
+            fee: parse6decimal('0.5'),
+            originator: liquidator.address,
+            solver: owner.address,
+            collateralization: parse6decimal('0.01'),
+            common: {
+              account: user.address,
+              signer: user.address,
+              domain: market.address,
+              nonce: 0,
+              group: 0,
+              expiry: 0,
+            },
+          }
+
+          dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+
+          await market
+            .connect(userB)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+          await market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+          await market
+            .connect(userC)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+          verifier.verifyIntent.returns()
+
+          // taker
+          factory.authorization
+            .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
+            .returns([false, true, parse6decimal('0.20')])
+
+          await expect(
+            market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE),
+          ).to.be.revertedWithCustomError(market, 'MarketIntentPriceDeviationError')
+        })
+
+        it('reverts if above price deviation (lower)', async () => {
+          const intent = {
+            amount: POSITION.div(2),
+            price: parse6decimal('110'),
+            fee: parse6decimal('0.5'),
+            originator: liquidator.address,
+            solver: owner.address,
+            collateralization: parse6decimal('0.01'),
+            common: {
+              account: user.address,
+              signer: user.address,
+              domain: market.address,
+              nonce: 0,
+              group: 0,
+              expiry: 0,
+            },
+          }
+
+          dsu.transferFrom.whenCalledWith(user.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+          dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+
+          await market
+            .connect(userB)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+
+          await market
+            .connect(user)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, COLLATERAL, false)
+          await market
+            .connect(userC)
+            ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+          verifier.verifyIntent.returns()
+
+          // taker
+          factory.authorization
+            .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
+            .returns([false, true, parse6decimal('0.20')])
+
+          await expect(
+            market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE),
+          ).to.be.revertedWithCustomError(market, 'MarketIntentPriceDeviationError')
         })
 
         it('reverts if paused (market)', async () => {

--- a/packages/perennial/test/unit/market/Market.test.ts
+++ b/packages/perennial/test/unit/market/Market.test.ts
@@ -511,6 +511,7 @@ describe('Market', () => {
       takerFee: 0,
       maxPendingGlobal: 5,
       maxPendingLocal: 3,
+      maxPriceDeviation: parse6decimal('0.1'),
       closed: false,
       settle: false,
     }
@@ -690,6 +691,7 @@ describe('Market', () => {
         riskFee: parse6decimal('0.05'),
         maxPendingGlobal: 5,
         maxPendingLocal: 3,
+        maxPriceDeviation: parse6decimal('0.1'),
         closed: true,
         settle: true,
       }
@@ -706,6 +708,7 @@ describe('Market', () => {
         expect(marketParameter.takerFee).to.equal(defaultMarketParameter.takerFee)
         expect(marketParameter.maxPendingGlobal).to.equal(defaultMarketParameter.maxPendingGlobal)
         expect(marketParameter.maxPendingLocal).to.equal(defaultMarketParameter.maxPendingLocal)
+        expect(marketParameter.maxPriceDeviation).to.equal(defaultMarketParameter.maxPriceDeviation)
         expect(marketParameter.closed).to.equal(defaultMarketParameter.closed)
         expect(marketParameter.settle).to.equal(defaultMarketParameter.settle)
       })

--- a/packages/perennial/test/unit/types/Global.test.ts
+++ b/packages/perennial/test/unit/types/Global.test.ts
@@ -46,6 +46,7 @@ function generateMarketParameter(riskFee: BigNumberish): MarketParameterStruct {
     takerFee: 0,
     maxPendingGlobal: 0,
     maxPendingLocal: 0,
+    maxPriceDeviation: 0,
     riskFee,
     closed: false,
     settle: false,

--- a/packages/perennial/test/unit/types/Guarantee.test.ts
+++ b/packages/perennial/test/unit/types/Guarantee.test.ts
@@ -663,7 +663,7 @@ describe('Guarantee', () => {
 
       it('zero price', async () => {
         await expect(
-          guaranteeLocal.priceDeviation(
+          await guaranteeLocal.priceDeviation(
             {
               ...DEFAULT_GUARANTEE,
               notional: parse6decimal('0'),
@@ -671,7 +671,33 @@ describe('Guarantee', () => {
             },
             parse6decimal('121'),
           ),
-        ).to.revertedWithPanic('0x12')
+        ).to.equal(ethers.constants.MaxUint256)
+      })
+
+      it('negative oracle price', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('1230'),
+              takerPos: parse6decimal('10'),
+            },
+            parse6decimal('-125'),
+          ),
+        ).to.equal(parse6decimal('2.016260'))
+      })
+
+      it('negative guarantee price', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('-1230'),
+              takerPos: parse6decimal('10'),
+            },
+            parse6decimal('125'),
+          ),
+        ).to.equal(parse6decimal('2.016260'))
       })
 
       it('zero size', async () => {

--- a/packages/perennial/test/unit/types/Guarantee.test.ts
+++ b/packages/perennial/test/unit/types/Guarantee.test.ts
@@ -607,6 +607,84 @@ describe('Guarantee', () => {
         ).to.equal(parse6decimal('0'))
       })
     })
+
+    describe('#priceDeviation', () => {
+      it('long / higher price', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('1230'),
+              takerPos: parse6decimal('10'),
+            },
+            parse6decimal('125'),
+          ),
+        ).to.equal(parse6decimal('0.016260'))
+      })
+
+      it('short / lower price', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('-1230'),
+              takerNeg: parse6decimal('10'),
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('0.016528'))
+      })
+
+      it('long / lower price', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('1230'),
+              takerPos: parse6decimal('10'),
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('0.016528'))
+      })
+
+      it('short / higher price', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('-1230'),
+              takerNeg: parse6decimal('10'),
+            },
+            parse6decimal('125'),
+          ),
+        ).to.equal(parse6decimal('0.016260'))
+      })
+
+      it('zero price', async () => {
+        await expect(
+          guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+              notional: parse6decimal('0'),
+              takerNeg: parse6decimal('10'),
+            },
+            parse6decimal('121'),
+          ),
+        ).to.revertedWithPanic('0x12')
+      })
+
+      it('zero size', async () => {
+        await expect(
+          await guaranteeLocal.priceDeviation(
+            {
+              ...DEFAULT_GUARANTEE,
+            },
+            parse6decimal('121'),
+          ),
+        ).to.equal(parse6decimal('0'))
+      })
+    })
   })
 
   function shouldBehaveLike(

--- a/packages/perennial/test/unit/types/MarketParameter.test.ts
+++ b/packages/perennial/test/unit/types/MarketParameter.test.ts
@@ -25,12 +25,12 @@ export const VALID_MARKET_PARAMETER: MarketParameterStruct = {
   riskFee: 5,
   maxPendingGlobal: 10,
   maxPendingLocal: 11,
+  maxPriceDeviation: 12,
   closed: false,
   settle: false,
 }
 
 const PROTOCOL_PARAMETER: ProtocolParameterStruct = {
-  protocolFee: 0,
   maxFee: parse6decimal('1'),
   maxFeeAbsolute: BigNumber.from(2).pow(48).sub(1),
   maxCut: parse6decimal('1'),
@@ -72,6 +72,7 @@ describe('MarketParameter', () => {
       expect(value.riskFee).to.equal(5)
       expect(value.maxPendingGlobal).to.equal(10)
       expect(value.maxPendingLocal).to.equal(11)
+      expect(value.maxPriceDeviation).to.equal(12)
       expect(value.closed).to.equal(false)
       expect(value.settle).to.equal(false)
     })
@@ -263,6 +264,32 @@ describe('MarketParameter', () => {
             {
               ...VALID_MARKET_PARAMETER,
               maxPendingLocal: BigNumber.from(2).pow(16),
+            },
+            PROTOCOL_PARAMETER,
+          ),
+        ).to.be.revertedWithCustomError(marketParameterStorage, 'MarketParameterStorageInvalidError')
+      })
+    })
+
+    context('.maxPriceDeviation', async () => {
+      it('saves if in range', async () => {
+        await marketParameter.validateAndStore(
+          {
+            ...VALID_MARKET_PARAMETER,
+            maxPriceDeviation: BigNumber.from(2).pow(24).sub(1),
+          },
+          PROTOCOL_PARAMETER,
+        )
+        const value = await marketParameter.read()
+        expect(value.maxPriceDeviation).to.equal(BigNumber.from(2).pow(24).sub(1))
+      })
+
+      it('reverts if out of range', async () => {
+        await expect(
+          marketParameter.validateAndStore(
+            {
+              ...VALID_MARKET_PARAMETER,
+              maxPriceDeviation: BigNumber.from(2).pow(24),
             },
             PROTOCOL_PARAMETER,
           ),


### PR DESCRIPTION
Adds a new market parameter: `maxPriceDeviation` which caps the geometric distance that the quoted intent price can be from the underlying oracle price.

Suggested change from: https://github.com/sherlock-audit/2024-08-perennial-v2-update-3-judging/issues/42.