### PR TITLE
Cleanup duplicate MarketFactory import

### DIFF
--- a/packages/perennial-verifier/contracts/Verifier.sol
+++ b/packages/perennial-verifier/contracts/Verifier.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.13;
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import { Common, CommonLib } from "@equilibria/root/verifier/types/Common.sol";
+import { IMarketFactory } from "@equilibria/perennial-v2/contracts/interfaces/IMarketFactory.sol";
 import { VerifierBase } from "@equilibria/root/verifier/VerifierBase.sol";
 import { Initializable } from "@equilibria/root/attribute/Initializable.sol";
 
 import { IVerifier } from "./interfaces/IVerifier.sol";
-import { IMarketFactory } from "./interfaces/IMarketFactory.sol";
 import { Intent, IntentLib } from "./types/Intent.sol";
 import { OperatorUpdate, OperatorUpdateLib } from "./types/OperatorUpdate.sol";
 import { SignerUpdate, SignerUpdateLib } from "./types/SignerUpdate.sol";

--- a/packages/perennial-verifier/contracts/interfaces/IMarketFactory.sol
+++ b/packages/perennial-verifier/contracts/interfaces/IMarketFactory.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
-import "@equilibria/root/number/types/UFixed6.sol";
-
-interface IMarketFactory {
-    function signers(address signer, address operator) external view returns (bool);
-}

--- a/packages/perennial-verifier/package.json
+++ b/packages/perennial-verifier/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "@ethersproject/abstract-provider": "^5"
+    "@ethersproject/abstract-provider": "^5",
+    "@equilibria/perennial-v2": "1.3.0"
   }
 }


### PR DESCRIPTION
Having the multiple market factories was causing some issues in the perennial-deploy package's tasks and tests. This introduces a circular dependency but I think both NPM and Solidity should be able to resolve it