### PR TITLE
Rename Verifier's market factory interface

### DIFF
--- a/packages/perennial-verifier/contracts/Verifier.sol
+++ b/packages/perennial-verifier/contracts/Verifier.sol
@@ -8,7 +8,7 @@ import { VerifierBase } from "@equilibria/root/verifier/VerifierBase.sol";
 import { Initializable } from "@equilibria/root/attribute/Initializable.sol";
 
 import { IVerifier } from "./interfaces/IVerifier.sol";
-import { IMarketFactory } from "./interfaces/IMarketFactory.sol";
+import { IMarketFactorySigners } from "./interfaces/IMarketFactorySigners.sol";
 import { Intent, IntentLib } from "./types/Intent.sol";
 import { OperatorUpdate, OperatorUpdateLib } from "./types/OperatorUpdate.sol";
 import { SignerUpdate, SignerUpdateLib } from "./types/SignerUpdate.sol";
@@ -25,14 +25,14 @@ import { AccessUpdateBatch, AccessUpdateBatchLib } from "./types/AccessUpdateBat
 ///
 contract Verifier is VerifierBase, IVerifier, Initializable {
     /// @dev market factory to check authorization
-    IMarketFactory public marketFactory;
+    IMarketFactorySigners public marketFactory;
 
     /// @dev Initializes the domain separator and parameter caches
     constructor() EIP712("Perennial", "1.0.0") { }
 
     /// @notice Initializes the contract state
     /// @param marketFactory_ The market factory
-    function initialize(IMarketFactory marketFactory_) external initializer(1) {
+    function initialize(IMarketFactorySigners marketFactory_) external initializer(1) {
         marketFactory = marketFactory_;
     }
 

--- a/packages/perennial-verifier/contracts/interfaces/IMarketFactorySigners.sol
+++ b/packages/perennial-verifier/contracts/interfaces/IMarketFactorySigners.sol
@@ -2,6 +2,6 @@
 pragma solidity ^0.8.13;
 import "@equilibria/root/number/types/UFixed6.sol";
 
-interface IMarketFactory {
+interface IMarketFactorySigners {
     function signers(address signer, address operator) external view returns (bool);
 }

--- a/packages/perennial-verifier/test/unit/Verifier/Verifier.test.ts
+++ b/packages/perennial-verifier/test/unit/Verifier/Verifier.test.ts
@@ -1,18 +1,12 @@
 import { smock, FakeContract } from '@defi-wonderland/smock'
-import { BigNumber, constants } from 'ethers'
+import { constants } from 'ethers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { time } from '@nomicfoundation/hardhat-network-helpers'
 
 import { expect, use } from 'chai'
 import HRE from 'hardhat'
 
-import {
-  Verifier,
-  Verifier__factory,
-  IERC1271,
-  IMarketFactory,
-  IMarketFactory__factory,
-} from '../../../types/generated'
+import { Verifier, Verifier__factory, IERC1271, IMarketFactorySigners } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import {
   signIntent,
@@ -33,13 +27,13 @@ describe('Verifier', () => {
   let signer: SignerWithAddress
   let operator: SignerWithAddress
   let verifier: Verifier
-  let marketFactory: FakeContract<IMarketFactory>
+  let marketFactory: FakeContract<IMarketFactorySigners>
   let scSigner: FakeContract<IERC1271>
 
   beforeEach(async () => {
     ;[owner, market, caller, caller2, signer, operator] = await ethers.getSigners()
 
-    marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
+    marketFactory = await smock.fake<IMarketFactorySigners>('IMarketFactorySigners')
     verifier = await new Verifier__factory(owner).deploy()
     verifier.initialize(marketFactory.address)
     scSigner = await smock.fake<IERC1271>('IERC1271')


### PR DESCRIPTION
Re-attempt from #472 - Having the multiple market factories was causing some issues in the perennial-deploy package's tasks and tests.