### PR TITLE
Create script for generating code documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .vscode
 
 **/.env
+**/docs

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | ----------------------- | :-------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------: |
 | `@perennial/core`       | Core perennial smart contracts.   |                                 [![npm version](https://badge.fury.io/js/@perennial%2Fcore.svg)](https://badge.fury.io/js/@perennial%2Fcore) |
 | `@perennial/deploy`     | Deployment scripts and artifacts. |         [![npm version](https://badge.fury.io/js/@perennial%2Fperennial/deploy.svg)](https://badge.fury.io/js/@perennial%2Fperennial/deploy) |
-| `@perennial/extensions` | Extension smart contracts.        | [![npm version](https://badge.fury.io/js/@perennial%2Fperennial/extensions.svg)](https://badge.fury.io/js/@perennial%2Fperennial/extensions) |
+| `@perennial/periphery`  | MultiInvoker and extension contracts. | [![npm version](https://badge.fury.io/js/@perennial%2Fperennial/periphery.svg)](https://badge.fury.io/js/@perennial%2Fperennial/periphery) |
 | `@perennial/oracle`     | Oracle provider smart contracts.  |         [![npm version](https://badge.fury.io/js/@perennial%2Fperennial/oracle.svg)](https://badge.fury.io/js/@perennial%2Fperennial/oracle) |
 | `@perennial/vault`      | Vault smart contracts.            |           [![npm version](https://badge.fury.io/js/@perennial%2Fperennial/vault.svg)](https://badge.fury.io/js/@perennial%2Fperennial/vault) |
 
@@ -36,16 +36,23 @@ Compile the smart contracts for each package with Hardhat:
 $ yarn workspaces run compile
 ```
 
-This also generates the Typechain types
+This also generates the Typechain types.
+
+### Docs
+
+Perennial has 4 logic packages: `core`, `deploy`, `periphery`, `oracle`, and `vault`
+
+To compile code documentation for a specific package:
+```sh
+$ yarn workspace @perennial/<package-name> run doc
+```
 
 ### Test
-
-Perennial has 4 logic packages: `core`, `deploy`, `extensions`, `oracle`, and `vault`
 
 Run the Mocha unit tests a specific package:
 
 ```sh
-$ yarn workspace @equilibria/<package-name> run test
+$ yarn workspace @perennial/<package-name> run test
 ```
 
 For example, to run the tests for the core package:
@@ -57,7 +64,7 @@ $ yarn workspace @perennial/core run test
 To run tests against a Mainnet fork, set your `MAINNET_NODE_URL` in the root `.env` and run
 
 ```sh
-$ yarn workspace run @equilibria/<package-name> test:integration
+$ yarn workspace run @perennial/<package-name> test:integration
 ```
 
 For example, to run the integration tests for the core package:
@@ -78,4 +85,4 @@ The vast majority of the Perennial V2 codebase is licensed under the Apache 2.0 
 | License      | License                                                                               |
 | ------------ | :------------------------------------------------------------------------------------ |
 | `Apache-2.0` | All, unless stated otherwise.                                                         |
-| `BUSL-1.1`   | Smart contracts: `Market.sol` and `MarketFactory.sol` in the `@perennial-v2` package. |
+| `BUSL-1.1`   | Smart contracts: `Market.sol` and `MarketFactory.sol` in the `@perennial/core` package. |

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "solhint": "^3.4.1",
     "solhint-plugin-prettier": "0.0.5",
     "solidity-coverage": "0.8.3",
+    "solidity-docgen": "^0.6.0-beta.36",
     "ts-generator": "^0.1.1",
     "ts-node": "^9.0.0",
     "typechain": "^8.1.0",

--- a/packages/common/hardhat.default.config.ts
+++ b/packages/common/hardhat.default.config.ts
@@ -10,6 +10,7 @@ import 'hardhat-deploy'
 import 'hardhat-dependency-compiler'
 import 'hardhat-tracer'
 import 'solidity-coverage'
+import 'solidity-docgen'
 
 import { getChainId, isArbitrum, isBase, isOptimism, SupportedChain } from './testutil/network'
 
@@ -222,6 +223,9 @@ export default function defaultConfig({
       slow: 1000,
       timeout: 4800000,
       retries: Number(MOCHA_RETRY_COUNT),
+    },
+    docgen: {
+      pages: 'files',
     },
     contractSizer: {
       alphaSort: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "build": "yarn compile",
     "compile": "OPTIMIZER_ENABLED=true hardhat compile",
     "deploy": "OPTIMIZER_ENABLED=true hardhat deploy",
+    "doc": "hardhat docgen",
     "verify": "hardhat etherscan-verify --sleep --solc-input",
     "gasReport": "REPORT_GAS=true OPTIMIZER_ENABLED=true yarn test:integration",
     "test": "hardhat test test/unit/**/*",

--- a/packages/oracle/package.json
+++ b/packages/oracle/package.json
@@ -16,6 +16,7 @@
     "build": "yarn compile",
     "compile": "hardhat compile",
     "deploy": "OPTIMIZER_ENABLED=true hardhat deploy",
+    "doc": "hardhat docgen",
     "verify": "hardhat etherscan-verify --sleep --solc-input",
     "gasReport": "REPORT_GAS=true yarn test:integration",
     "gasReport:optimizer": "REPORT_GAS=true OPTIMIZER_ENABLED=true yarn test:integration",

--- a/packages/periphery/package.json
+++ b/packages/periphery/package.json
@@ -13,6 +13,7 @@
     "build": "yarn compile",
     "compile": "hardhat compile",
     "deploy": "OPTIMIZER_ENABLED=true hardhat deploy",
+    "doc": "hardhat docgen",
     "verify": "hardhat etherscan-verify --sleep --solc-input",
     "gasReport": "REPORT_GAS=true OPTIMIZER_ENABLED=true yarn test:integration",
     "test": "HARDHAT_SHOW_STACK_TRACES=true hardhat test test/unit/**/*",

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -15,6 +15,7 @@
     "build": "yarn compile",
     "compile": "hardhat compile",
     "deploy": "OPTIMIZER_ENABLED=true hardhat deploy",
+    "doc": "hardhat docgen",
     "verify": "hardhat etherscan-verify --sleep --solc-input",
     "gasReport": "OPTIMIZER_ENABLED=true REPORT_GAS=true yarn test:integration",
     "test": "hardhat test test/unit/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8873,6 +8873,11 @@ solhint@^3.4.1:
   optionalDependencies:
     prettier "^2.8.3"
 
+solidity-ast@^0.4.38:
+  version "0.4.59"
+  resolved "https://registry.yarnpkg.com/solidity-ast/-/solidity-ast-0.4.59.tgz#290a2815aef70a61092591ab3e991da080ae5931"
+  integrity sha512-I+CX0wrYUN9jDfYtcgWSe+OAowaXy8/1YQy7NS4ni5IBDmIYBq7ZzaP/7QqouLjzZapmQtvGLqCaYgoUWqBo5g==
+
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz"
@@ -8903,6 +8908,14 @@ solidity-coverage@0.8.3:
     semver "^7.3.4"
     shelljs "^0.8.3"
     web3-utils "^1.3.6"
+
+solidity-docgen@^0.6.0-beta.36:
+  version "0.6.0-beta.36"
+  resolved "https://registry.yarnpkg.com/solidity-docgen/-/solidity-docgen-0.6.0-beta.36.tgz#9c76eda58580fb52e2db318c22fe3154e0c09dd1"
+  integrity sha512-f/I5G2iJgU1h0XrrjRD0hHMr7C10u276vYvm//rw1TzFcYQ4xTOyAoi9oNAHRU0JU4mY9eTuxdVc2zahdMuhaQ==
+  dependencies:
+    handlebars "^4.7.7"
+    solidity-ast "^0.4.38"
 
 sort-keys@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
After investigating several solutions, decided upon [solidity-docgen](https://github.com/OpenZeppelin/solidity-docgen), on OpenZeppelin project.  Other solutions were evaluated, but had bugs/limitations undesirable to us.

Not building docs into any CI tasks, but can add that if desired.

Also updated README to correct package names and instruct how to generate docs.  Expecting links to fall into place once 2.4 packages are published.