### PR TITLE
adjust wrapIfNecessary logic

### DIFF
--- a/packages/periphery/contracts/CollateralAccounts/Account.sol
+++ b/packages/periphery/contracts/CollateralAccounts/Account.sol
@@ -94,7 +94,7 @@ contract Account is IAccount, Instance {
         if (DSU.balanceOf().lt(amount)) {
             UFixed6 usdcBalance = USDC.balanceOf();
             if (!usdcBalance.eq(UFixed6Lib.ZERO))
-                wrap(wrapAll ? UFixed18Lib.from(usdcBalance) : amount);
+                wrap(wrapAll ? UFixed18Lib.from(usdcBalance) : amount.sub(DSU.balanceOf()));
         }
     }
 

--- a/packages/periphery/test/integration/CollateralAccounts/Account.test.ts
+++ b/packages/periphery/test/integration/CollateralAccounts/Account.test.ts
@@ -146,6 +146,18 @@ export function RunAccountTests(
         expect(await usdc.balanceOf(account.address)).to.equal(0)
       })
 
+      it('unwraps only what is necessary', async () => {
+        await dsu.connect(userA).transfer(account.address, utils.parseEther('0.3'))
+        await usdc.connect(userA).transfer(account.address, parse6decimal('0.9'))
+
+        // should only unwrap the 0.1 DSU needed to satisfy the withdrawal
+        await expect(account.withdraw(parse6decimal('1'), true))
+          .to.emit(usdc, 'Transfer')
+          .withArgs(account.address, userA.address, parse6decimal('1'))
+        expect(await dsu.balanceOf(account.address)).to.equal(utils.parseEther('0.2'))
+        expect(await usdc.balanceOf(account.address)).to.equal(0)
+      })
+
       it('burns dust amounts upon withdrawal', async () => {
         // deposit a dust amount into the account
         const dust = utils.parseEther('0.000000555')


### PR DESCRIPTION
This seems more favorable than modifying than modifying `Controller_Incentivized`, as the function is now doing what is implied.  If user wants to _wrap a specific amount_, they may call `wrap`.  If they want to _ensure some amount is wrapped_, they may call `wrapIfNecessary`.