### PR TITLE
Add `minMinMaintenance` protocol parameter 

### DIFF
--- a/packages/core/contracts/MarketFactory.sol
+++ b/packages/core/contracts/MarketFactory.sol
@@ -23,8 +23,8 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @dev The verifier contract
     IVerifier public immutable verifier;
 
-    /// @dev The global protocol parameters
-    ProtocolParameterStorage private _parameter;
+    /// @dev DEPRECATED SLOT -- previously the protocl parameter storage
+    bytes32 private __unused0__;
 
     /// @dev Mapping of allowed operators per account
     mapping(address => mapping(address => bool)) public operators;
@@ -41,6 +41,9 @@ contract MarketFactory is IMarketFactory, Factory {
 
     /// @dev Mapping of allowed protocol-wide operators
     mapping(address => bool) public extensions;
+
+    /// @dev The global protocol parameters
+    ProtocolParameterStorage private _parameter;
 
     /// @notice Constructs the contract
     /// @param oracleFactory_ The oracle factory

--- a/packages/core/contracts/MarketFactory.sol
+++ b/packages/core/contracts/MarketFactory.sol
@@ -23,7 +23,7 @@ contract MarketFactory is IMarketFactory, Factory {
     /// @dev The verifier contract
     IVerifier public immutable verifier;
 
-    /// @dev DEPRECATED SLOT -- previously the protocl parameter storage
+    /// @dev DEPRECATED SLOT -- previously the protocol parameter storage
     bytes32 private __unused0__;
 
     /// @dev Mapping of allowed operators per account

--- a/packages/core/contracts/types/ProtocolParameter.sol
+++ b/packages/core/contracts/types/ProtocolParameter.sol
@@ -92,6 +92,7 @@ library ProtocolParameterStorageLib {
         if (newValue.minMaintenance.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
         if (newValue.minEfficiency.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
         if (newValue.maxStaleAfter > uint256(type(uint16).max)) revert ProtocolParameterStorageInvalidError();
+        if (newValue.minMinMaintenance.gt(UFixed6.wrap(type(uint48).max))) revert ProtocolParameterStorageInvalidError();
 
         uint256 encoded0 = 
             uint256(UFixed6.unwrap(newValue.maxFee)                << (256 - 24)) >> (256 - 24) |

--- a/packages/core/contracts/types/ProtocolParameter.sol
+++ b/packages/core/contracts/types/ProtocolParameter.sol
@@ -52,6 +52,7 @@ struct ProtocolParameter {
 //     uint48 minMinMaintenance;       // <= 281m
 // }
 
+// SECURITY: update ProtocolParameterStorage to 2 slots.
 struct ProtocolParameterStorage { uint256 slot0; uint256 slot1; }
 using ProtocolParameterStorageLib for ProtocolParameterStorage global;
 

--- a/packages/core/contracts/types/ProtocolParameter.sol
+++ b/packages/core/contracts/types/ProtocolParameter.sol
@@ -52,8 +52,7 @@ struct ProtocolParameter {
 //     uint48 minMinMaintenance;       // <= 281m
 // }
 
-// SECURITY: update ProtocolParameterStorage to 2 slots.
-struct ProtocolParameterStorage { uint256 slot0; uint256 slot1; }
+struct ProtocolParameterStorage { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
 using ProtocolParameterStorageLib for ProtocolParameterStorage global;
 
 /// @dev (external-safe): this library is safe to externalize
@@ -73,7 +72,7 @@ library ProtocolParameterStorageLib {
             UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24)) >> (256 - 24)),
             UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24)) >> (256 - 24)),
             uint16(                  slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24 - 16) >> (256 - 16)),
-            
+
             UFixed6.wrap(uint256(    slot1 << (256 - 48)) >> (256 - 48))
         );
     }
@@ -95,7 +94,7 @@ library ProtocolParameterStorageLib {
         if (newValue.maxStaleAfter > uint256(type(uint16).max)) revert ProtocolParameterStorageInvalidError();
         if (newValue.minMinMaintenance.gt(UFixed6.wrap(type(uint48).max))) revert ProtocolParameterStorageInvalidError();
 
-        uint256 encoded0 = 
+        uint256 encoded0 =
             uint256(UFixed6.unwrap(newValue.maxFee)                << (256 - 24)) >> (256 - 24) |
             uint256(UFixed6.unwrap(newValue.maxLiquidationFee)     << (256 - 32)) >> (256 - 24 - 32) |
             uint256(UFixed6.unwrap(newValue.maxCut)                << (256 - 24)) >> (256 - 24 - 32 - 24) |
@@ -106,7 +105,7 @@ library ProtocolParameterStorageLib {
             uint256(UFixed6.unwrap(newValue.minScale)              << (256 - 24)) >> (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24) |
             uint256(newValue.maxStaleAfter                         << (256 - 16)) >> (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24 - 16);
 
-        uint256 encoded1 = 
+        uint256 encoded1 =
             uint256(UFixed6.unwrap(newValue.minMinMaintenance)     << (256 - 48)) >> (256 - 48);
 
         assembly {

--- a/packages/core/contracts/types/ProtocolParameter.sol
+++ b/packages/core/contracts/types/ProtocolParameter.sol
@@ -31,20 +31,28 @@ struct ProtocolParameter {
 
     /// @dev The maximum for parameter restricting maximum time between oracle version and update
     uint256 maxStaleAfter;
+
+    /// @dev The minimum for market minimum maintenance parameters
+    UFixed6 minMinMaintenance;
 }
-struct StoredProtocolParameter {
-    /* slot 0 (28) */
-    uint24 maxFee;                  // <= 1677%
-    uint32 maxLiquidationFee;       // <= 4294
-    uint24 maxCut;                  // <= 1677%
-    uint32 maxRate;                 // <= 214748% (capped at 31 bits to accommodate int32 rates)
-    uint24 minMaintenance;          // <= 1677%
-    uint24 minEfficiency;           // <= 1677%
-    uint24 referralFee;             // <= 1677%
-    uint24 minScale;                // <= 1677%
-    uint16 maxStaleAfter;           // <= 18 hours
-}
-struct ProtocolParameterStorage { StoredProtocolParameter value; } // SECURITY: must remain at (1) slots
+
+// struct StoredProtocolParameter {
+//     /* slot 0 (28) */
+//     uint24 maxFee;                  // <= 1677%
+//     uint32 maxLiquidationFee;       // <= 4294
+//     uint24 maxCut;                  // <= 1677%
+//     uint32 maxRate;                 // <= 214748% (capped at 31 bits to accommodate int32 rates)
+//     uint24 minMaintenance;          // <= 1677%
+//     uint24 minEfficiency;           // <= 1677%
+//     uint24 referralFee;             // <= 1677%
+//     uint24 minScale;                // <= 1677%
+//     uint16 maxStaleAfter;           // <= 18 hours
+
+//     /* slot 1 (6) */
+//     uint48 minMinMaintenance;       // <= 281m
+// }
+
+struct ProtocolParameterStorage { uint256 slot0; uint256 slot1; }
 using ProtocolParameterStorageLib for ProtocolParameterStorage global;
 
 /// @dev (external-safe): this library is safe to externalize
@@ -53,17 +61,19 @@ library ProtocolParameterStorageLib {
     error ProtocolParameterStorageInvalidError();
 
     function read(ProtocolParameterStorage storage self) internal view returns (ProtocolParameter memory) {
-        StoredProtocolParameter memory value = self.value;
+        (uint256 slot0, uint256 slot1) = (self.slot0, self.slot1);
         return ProtocolParameter(
-            UFixed6.wrap(uint256(value.maxFee)),
-            UFixed6.wrap(uint256(value.maxLiquidationFee)),
-            UFixed6.wrap(uint256(value.maxCut)),
-            UFixed6.wrap(uint256(value.maxRate)),
-            UFixed6.wrap(uint256(value.minMaintenance)),
-            UFixed6.wrap(uint256(value.minEfficiency)),
-            UFixed6.wrap(uint256(value.referralFee)),
-            UFixed6.wrap(uint256(value.minScale)),
-            uint16(value.maxStaleAfter)
+            UFixed6.wrap(uint256(    slot0 << (256 - 24)) >> (256 - 24)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32)) >> (256 - 32)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24)) >> (256 - 24)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32)) >> (256 - 32)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32 - 24)) >> (256 - 24)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24)) >> (256 - 24)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24)) >> (256 - 24)),
+            UFixed6.wrap(uint256(    slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24)) >> (256 - 24)),
+            uint16(                  slot0 << (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24 - 16) >> (256 - 16)),
+            
+            UFixed6.wrap(uint256(    slot1 << (256 - 48)) >> (256 - 48))
         );
     }
 
@@ -83,16 +93,23 @@ library ProtocolParameterStorageLib {
         if (newValue.minEfficiency.gt(UFixed6.wrap(type(uint24).max))) revert ProtocolParameterStorageInvalidError();
         if (newValue.maxStaleAfter > uint256(type(uint16).max)) revert ProtocolParameterStorageInvalidError();
 
-        self.value = StoredProtocolParameter(
-            uint24(UFixed6.unwrap(newValue.maxFee)),
-            uint32(UFixed6.unwrap(newValue.maxLiquidationFee)),
-            uint24(UFixed6.unwrap(newValue.maxCut)),
-            uint32(UFixed6.unwrap(newValue.maxRate)),
-            uint24(UFixed6.unwrap(newValue.minMaintenance)),
-            uint24(UFixed6.unwrap(newValue.minEfficiency)),
-            uint24(UFixed6.unwrap(newValue.referralFee)),
-            uint24(UFixed6.unwrap(newValue.minScale)),
-            uint16(newValue.maxStaleAfter)
-        );
+        uint256 encoded0 = 
+            uint256(UFixed6.unwrap(newValue.maxFee)                << (256 - 24)) >> (256 - 24) |
+            uint256(UFixed6.unwrap(newValue.maxLiquidationFee)     << (256 - 32)) >> (256 - 24 - 32) |
+            uint256(UFixed6.unwrap(newValue.maxCut)                << (256 - 24)) >> (256 - 24 - 32 - 24) |
+            uint256(UFixed6.unwrap(newValue.maxRate)               << (256 - 32)) >> (256 - 24 - 32 - 24 - 32) |
+            uint256(UFixed6.unwrap(newValue.minMaintenance)        << (256 - 24)) >> (256 - 24 - 32 - 24 - 32 - 24) |
+            uint256(UFixed6.unwrap(newValue.minEfficiency)         << (256 - 24)) >> (256 - 24 - 32 - 24 - 32 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.referralFee)           << (256 - 24)) >> (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24) |
+            uint256(UFixed6.unwrap(newValue.minScale)              << (256 - 24)) >> (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24) |
+            uint256(newValue.maxStaleAfter                         << (256 - 16)) >> (256 - 24 - 32 - 24 - 32 - 24 - 24 - 24 - 24 - 16);
+
+        uint256 encoded1 = 
+            uint256(UFixed6.unwrap(newValue.minMinMaintenance)     << (256 - 48)) >> (256 - 48);
+
+        assembly {
+            sstore(self.slot, encoded0)
+            sstore(add(self.slot, 1), encoded1)
+        }
     }
 }

--- a/packages/core/contracts/types/RiskParameter.sol
+++ b/packages/core/contracts/types/RiskParameter.sol
@@ -167,6 +167,8 @@ library RiskParameterStorageLib {
         UFixed6 scaleLimit = makerLimitTruncated.div(self.efficiencyLimit).mul(protocolParameter.minScale);
         if (takerFeeScaleTruncated.lt(scaleLimit) || makerFeeScaleTruncated.lt(scaleLimit))
             revert RiskParameterStorageInvalidError();
+
+        if (self.minMaintenance.lt(protocolParameter.minMinMaintenance)) revert RiskParameterStorageInvalidError();
     }
 
     function validateAndStore(

--- a/packages/core/test/integration/helpers/setupHelpers.ts
+++ b/packages/core/test/integration/helpers/setupHelpers.ts
@@ -164,6 +164,7 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
     referralFee: 0,
     minScale: parse6decimal('0.001'),
     maxStaleAfter: 64800, // 18 hours
+    minMinMaintenance: 0,
   })
   await oracleFactory.connect(owner).register(chainlink.oracleFactory.address)
   await oracleFactory.connect(owner).updateParameter({

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -461,6 +461,7 @@ describe('Market', () => {
       referralFee: 0,
       minScale: parse6decimal('0.001'),
       maxStaleAfter: 14400,
+      minMinMaintenance: 0,
     })
     factory.oracleFactory.returns(oracleFactorySigner.address)
 

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -5874,6 +5874,7 @@ describe('Market', () => {
                 referralFee: 0,
                 minScale: parse6decimal('0.001'),
                 maxStaleAfter: 14400,
+                minMinMaintenance: 0,
               })
 
               const riskParameter = { ...(await market.riskParameter()) }
@@ -16688,6 +16689,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
@@ -16750,6 +16752,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
@@ -18317,6 +18320,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const marketParameter = { ...(await market.parameter()) }
@@ -20268,6 +20272,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const riskParameter = { ...(await market.riskParameter()) }
@@ -20393,6 +20398,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const riskParameter = { ...(await market.riskParameter()) }
@@ -20558,6 +20564,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const riskParameter = { ...(await market.riskParameter()) }
@@ -20730,6 +20737,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -20976,6 +20984,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -21223,6 +21232,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -21470,6 +21480,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -21716,6 +21727,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -22062,6 +22074,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -22312,6 +22325,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -22497,6 +22511,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -22784,6 +22799,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -23046,6 +23062,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -23308,6 +23325,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -23571,6 +23589,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -23834,6 +23853,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -24103,6 +24123,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -24372,6 +24393,7 @@ describe('Market', () => {
               referralFee: parse6decimal('0.20'),
               minScale: parse6decimal('0.001'),
               maxStaleAfter: 14400,
+              minMinMaintenance: 0,
             })
 
             const marketParameter = { ...(await market.parameter()) }
@@ -24569,6 +24591,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const marketParameter = { ...(await market.parameter()) }
@@ -24627,6 +24650,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const marketParameter = { ...(await market.parameter()) }
@@ -24685,6 +24709,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const marketParameter = { ...(await market.parameter()) }
@@ -24760,6 +24785,7 @@ describe('Market', () => {
             referralFee: parse6decimal('0.20'),
             minScale: parse6decimal('0.001'),
             maxStaleAfter: 14400,
+            minMinMaintenance: 0,
           })
 
           const riskParameter = { ...(await market.riskParameter()) }

--- a/packages/core/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/core/test/unit/marketfactory/MarketFactory.test.ts
@@ -336,6 +336,7 @@ describe('MarketFactory', () => {
       referralFee: parse6decimal('0.2'),
       minScale: parse6decimal('0.001'),
       maxStaleAfter: 3600,
+      minMinMaintenance: 0,
     }
 
     it('updates the parameters', async () => {
@@ -351,6 +352,7 @@ describe('MarketFactory', () => {
       expect(parameter.referralFee).to.equal(newParameter.referralFee)
       expect(parameter.minScale).to.equal(newParameter.minScale)
       expect(parameter.maxStaleAfter).to.equal(newParameter.maxStaleAfter)
+      expect(parameter.minMinMaintenance).to.equal(newParameter.minMinMaintenance)
     })
 
     it('reverts if not owner', async () => {

--- a/packages/core/test/unit/types/MarketParameter.test.ts
+++ b/packages/core/test/unit/types/MarketParameter.test.ts
@@ -40,6 +40,7 @@ const PROTOCOL_PARAMETER: ProtocolParameterStruct = {
   referralFee: 0,
   minScale: parse6decimal('0.1'),
   maxStaleAfter: 64800, // 18 hours
+  minMinMaintenance: 0,
 }
 
 describe('MarketParameter', () => {

--- a/packages/core/test/unit/types/ProtocolParameter.test.ts
+++ b/packages/core/test/unit/types/ProtocolParameter.test.ts
@@ -21,6 +21,7 @@ export const VALID_PROTOCOL_PARAMETER: ProtocolParameterStruct = {
   referralFee: 9,
   minScale: 10,
   maxStaleAfter: 11,
+  minMinMaintenance: 12,
 }
 
 describe('ProtocolParameter', () => {

--- a/packages/core/test/unit/types/ProtocolParameter.test.ts
+++ b/packages/core/test/unit/types/ProtocolParameter.test.ts
@@ -49,6 +49,7 @@ describe('ProtocolParameter', () => {
       expect(value.referralFee).to.equal(9)
       expect(value.minScale).to.equal(10)
       expect(value.maxStaleAfter).to.equal(11)
+      expect(value.minMinMaintenance).to.equal(12)
     })
 
     context('.maxFee', async () => {

--- a/packages/core/test/unit/types/ProtocolParameter.test.ts
+++ b/packages/core/test/unit/types/ProtocolParameter.test.ts
@@ -236,5 +236,26 @@ describe('ProtocolParameter', () => {
         ).to.be.revertedWithCustomError(protocolParameter, 'ProtocolParameterStorageInvalidError')
       })
     })
+
+    context('.minMinMaintenance', async () => {
+      const STORAGE_SIZE = 48
+      it('saves if in range', async () => {
+        await protocolParameter.validateAndStore({
+          ...VALID_PROTOCOL_PARAMETER,
+          minMinMaintenance: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+        })
+        const value = await protocolParameter.read()
+        expect(value.minMinMaintenance).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+      })
+
+      it('reverts if out of range', async () => {
+        await expect(
+          protocolParameter.validateAndStore({
+            ...VALID_PROTOCOL_PARAMETER,
+            minMinMaintenance: BigNumber.from(2).pow(STORAGE_SIZE),
+          }),
+        ).to.be.revertedWithCustomError(protocolParameter, 'ProtocolParameterStorageInvalidError')
+      })
+    })
   })
 })

--- a/packages/core/test/unit/types/RiskParameter.test.ts
+++ b/packages/core/test/unit/types/RiskParameter.test.ts
@@ -61,6 +61,7 @@ const PROTOCOL_PARAMETER: ProtocolParameterStruct = {
   referralFee: 0,
   minScale: parse6decimal('0.10'),
   maxStaleAfter: 3600,
+  minMinMaintenance: 0,
 }
 
 describe('RiskParameter', () => {

--- a/packages/core/test/unit/types/RiskParameter.test.ts
+++ b/packages/core/test/unit/types/RiskParameter.test.ts
@@ -826,6 +826,21 @@ describe('RiskParameter', () => {
           ),
         ).to.be.revertedWithCustomError(riskParameterStorage, 'RiskParameterStorageInvalidError')
       })
+
+      it('reverts if less than minMinMaintenance', async () => {
+        await expect(
+          riskParameter.validateAndStore(
+            {
+              ...VALID_RISK_PARAMETER,
+              minMaintenance: 0,
+            },
+            {
+              ...PROTOCOL_PARAMETER,
+              minMinMaintenance: 1,
+            },
+          ),
+        ).to.be.revertedWithCustomError(riskParameterStorage, 'RiskParameterStorageInvalidError')
+      })
     })
 
     describe('.staleAfter', () => {

--- a/packages/deploy/util/constants.ts
+++ b/packages/deploy/util/constants.ts
@@ -13,6 +13,7 @@ export const DEFAULT_PROTOCOL_PARAMETER = {
   minEfficiency: utils.parseUnits('0.25', 6), // 25%
   referralFee: 0,
   maxStaleAfter: 7200, // 2 hours
+  minMinMaintenance: 0,
 }
 
 export const DEFAULT_MARKET_PARAMETER = {

--- a/packages/oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -301,6 +301,7 @@ testOracles.forEach(testOracle => {
         referralFee: 0,
         minScale: parse6decimal('0.001'),
         maxStaleAfter: 7200,
+        minMinMaintenance: 0,
       })
 
       const riskParameter = {

--- a/packages/oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -256,6 +256,7 @@ testOracles.forEach(testOracle => {
         referralFee: 0,
         minScale: parse6decimal('0.001'),
         maxStaleAfter: 7200,
+        minMinMaintenance: 0,
       })
 
       const riskParameter = {

--- a/packages/oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -268,6 +268,7 @@ testOracles.forEach(testOracle => {
         referralFee: 0,
         minScale: parse6decimal('0.001'),
         maxStaleAfter: 7200,
+        minMinMaintenance: 0,
       })
 
       const riskParameter = {

--- a/packages/periphery/test/helpers/setupHelpers.ts
+++ b/packages/periphery/test/helpers/setupHelpers.ts
@@ -193,6 +193,7 @@ async function deployMarketFactory(
     referralFee: 0,
     minScale: parse6decimal('0.001'),
     maxStaleAfter: 7200,
+    minMinMaintenance: 0,
   })
 
   return marketFactory

--- a/packages/periphery/test/integration/MultiInvoker/setupHelpers.ts
+++ b/packages/periphery/test/integration/MultiInvoker/setupHelpers.ts
@@ -145,6 +145,7 @@ export async function deployProtocol(
     referralFee: 0,
     minScale: parse6decimal('0.001'),
     maxStaleAfter: 7200,
+    minMinMaintenance: 0,
   })
 
   return {


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-1840/[fix]-since-liq-fee-is-no-longer-checked-against-minmargin-there-is-a
- Deprecated previous protocol parameter slot in marketFactory.
- Add new protocol parameter storage with 2 slots.

Updated protocol parameter slots:
```
// struct StoredProtocolParameter {
//     /* slot 0 (28) */
//     uint24 maxFee;                  // <= 1677%
//     uint32 maxLiquidationFee;       // <= 4294
//     uint24 maxCut;                  // <= 1677%
//     uint32 maxRate;                 // <= 214748% (capped at 31 bits to accommodate int32 rates)
//     uint24 minMaintenance;          // <= 1677%
//     uint24 minEfficiency;           // <= 1677%
//     uint24 referralFee;             // <= 1677%
//     uint24 minScale;                // <= 1677%
//     uint16 maxStaleAfter;           // <= 18 hours

//     /* slot 1 (6) */
//     uint48 minMinMaintenance;       // <= 281m
// }
```

Migration Note:

- `ProtocolParameter` must be updated on migration
