### PR TITLE
Consolidate operator settings to only marketFactory

### DIFF
--- a/packages/periphery/contracts/MultiInvoker/MultiInvoker.sol
+++ b/packages/periphery/contracts/MultiInvoker/MultiInvoker.sol
@@ -15,6 +15,7 @@ import { UFixed18, UFixed18Lib } from "@equilibria/root/number/types/UFixed18.so
 import { Fixed6, Fixed6Lib } from "@equilibria/root/number/types/Fixed6.sol";
 import { Fixed18, Fixed18Lib } from "@equilibria/root/number/types/Fixed18.sol";
 import { IMarket } from "@perennial/v2-core/contracts/interfaces/IMarket.sol";
+import { IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
 import { IPythFactory } from "@perennial/v2-oracle/contracts/interfaces/IPythFactory.sol";
 import { IVault } from "@perennial/v2-vault/contracts/interfaces/IVault.sol";
 import { Intent } from "@perennial/v2-core/contracts/types/Intent.sol";
@@ -31,7 +32,7 @@ contract MultiInvoker is IMultiInvoker, Initializable {
     Token18 public immutable DSU; // solhint-disable-line var-name-mixedcase
 
     /// @dev Protocol factory to validate market approvals
-    IFactory public immutable marketFactory;
+    IMarketFactory public immutable marketFactory;
 
     /// @dev Vault factory to validate vault approvals
     IFactory public immutable vaultFactory;
@@ -48,8 +49,8 @@ contract MultiInvoker is IMultiInvoker, Initializable {
     /// @notice  DEPRECATED SLOT -- previously UID to orders mapping
     bytes32 private __unused1__;
 
-    /// @dev Mapping of allowed operators for each account
-    mapping(address => mapping(address => bool)) public operators;
+    /// @notice  DEPRECATED SLOT -- previously operators mapping
+    bytes32 private __unused2__;
 
     /// @dev Mapping of claimable DSU for each account
     mapping(address => UFixed6) public claimable;
@@ -64,7 +65,7 @@ contract MultiInvoker is IMultiInvoker, Initializable {
     constructor(
         Token6 usdc_,
         Token18 dsu_,
-        IFactory marketFactory_,
+        IMarketFactory marketFactory_,
         IFactory vaultFactory_,
         IBatcher batcher_,
         IEmptySetReserve reserve_
@@ -87,14 +88,6 @@ contract MultiInvoker is IMultiInvoker, Initializable {
 
         DSU.approve(address(reserve));
         USDC.approve(address(reserve));
-    }
-
-    /// @notice Updates the status of an operator for the caller
-    /// @param operator The operator to update
-    /// @param newEnabled The new status of the operator
-    function updateOperator(address operator, bool newEnabled) external {
-        operators[msg.sender][operator] = newEnabled;
-        emit OperatorUpdated(msg.sender, operator, newEnabled);
     }
 
     /// @notice entry to perform invocations for msg.sender
@@ -392,7 +385,7 @@ contract MultiInvoker is IMultiInvoker, Initializable {
 
     /// @notice Only the account or an operator can call
     modifier onlyOperator(address account, address operator) {
-        if (account != operator && !operators[account][msg.sender]) revert MultiInvokerUnauthorizedError();
+        if (account != operator && !marketFactory.operators(account, operator)) revert MultiInvokerUnauthorizedError();
         _;
     }
 }

--- a/packages/periphery/contracts/MultiInvoker/interfaces/IMultiInvoker.sol
+++ b/packages/periphery/contracts/MultiInvoker/interfaces/IMultiInvoker.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import { IFactory } from "@equilibria/root/attribute/interfaces/IFactory.sol";
 import { IMarket } from "@perennial/v2-core/contracts/interfaces/IMarket.sol";
+import { IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
 import { IBatcher } from "@equilibria/emptyset-batcher/interfaces/IBatcher.sol";
 import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
 import { InterfaceFee } from "../types/InterfaceFee.sol";
@@ -27,7 +28,6 @@ interface IMultiInvoker {
         bytes args;
     }
 
-    event OperatorUpdated(address indexed account, address indexed operator, bool newEnabled);
     event InterfaceFeeCharged(address indexed account, IMarket indexed market, InterfaceFee fee);
 
     // sig: 0x42ecdedb
@@ -35,12 +35,10 @@ interface IMultiInvoker {
     // sig: 0x47b7c1b0
     error MultiInvokerInvalidInstanceError();
 
-    function updateOperator(address operator, bool newEnabled) external;
-    function operators(address account, address operator) external view returns (bool);
     function invoke(address account, Invocation[] calldata invocations) external payable;
     function invoke(Invocation[] calldata invocations) external payable;
     function claim(address account, bool unwrap) external;
-    function marketFactory() external view returns (IFactory);
+    function marketFactory() external view returns (IMarketFactory);
     function vaultFactory() external view returns (IFactory);
     function batcher() external view returns (IBatcher);
     function reserve() external view returns (IEmptySetReserve);

--- a/packages/periphery/test/integration/MultiInvoker/Invoke.test.ts
+++ b/packages/periphery/test/integration/MultiInvoker/Invoke.test.ts
@@ -156,26 +156,6 @@ export function RunInvokerTests(
       ).to.be.revertedWithCustomError(multiInvoker, 'MultiInvokerInvalidInstanceError')
     })
 
-    describe('#updateOperator', () => {
-      it('sets operator as enabled', async () => {
-        const { user, userD } = instanceVars
-        await expect(multiInvoker.connect(user).updateOperator(userD.address, true))
-          .to.emit(multiInvoker, 'OperatorUpdated')
-          .withArgs(user.address, userD.address, true)
-        expect(await multiInvoker.operators(user.address, userD.address)).to.be.true
-      })
-
-      it('sets an operator as disabled', async () => {
-        const { user, userD } = instanceVars
-        await multiInvoker.connect(user).updateOperator(userD.address, true)
-        expect(await multiInvoker.operators(user.address, userD.address)).to.be.true
-        await expect(multiInvoker.connect(user).updateOperator(userD.address, false))
-          .to.emit(multiInvoker, 'OperatorUpdated')
-          .withArgs(user.address, userD.address, false)
-        expect(await multiInvoker.operators(user.address, userD.address)).to.be.false
-      })
-    })
-
     const testCases = [
       {
         context: 'From user',
@@ -188,8 +168,8 @@ export function RunInvokerTests(
       {
         context: 'From delegate',
         setup: async () => {
-          const { user, userD } = instanceVars
-          await multiInvoker.connect(user).updateOperator(userD.address, true)
+          const { marketFactory, user, userD } = instanceVars
+          await marketFactory.connect(user).updateOperator(userD.address, true)
         },
         invoke: async (args: IMultiInvoker.InvocationStruct[]) => {
           const { user, userD } = instanceVars

--- a/packages/periphery/test/integration/MultiInvoker/setupHelpers.ts
+++ b/packages/periphery/test/integration/MultiInvoker/setupHelpers.ts
@@ -387,9 +387,5 @@ export async function configureInvoker(
 
   await instanceVars.marketFactory.connect(user).updateOperator(multiInvoker.address, true)
   await instanceVars.marketFactory.connect(userB).updateOperator(multiInvoker.address, true)
-  if (vaultFactory) {
-    await vaultFactory.connect(user).updateOperator(multiInvoker.address, true)
-    await vaultFactory.connect(userB).updateOperator(multiInvoker.address, true)
-  }
   await multiInvoker.initialize(instanceVars.chainlinkKeptFeed.address)
 }

--- a/packages/vault/contracts/Vault.sol
+++ b/packages/vault/contracts/Vault.sol
@@ -300,7 +300,7 @@ contract Vault is IVault, Instance {
         if (redeemShares.eq(UFixed6Lib.MAX)) redeemShares = context.local.shares;
 
         // invariant
-        if (msg.sender != account && !IVaultFactory(address(factory())).operators(account, msg.sender))
+        if (msg.sender != account && !IVaultFactory(address(factory())).marketFactory().operators(account, msg.sender))
             revert VaultNotOperatorError();
         if (!depositAssets.add(redeemShares).add(claimAssets).eq(depositAssets.max(redeemShares).max(claimAssets)))
             revert VaultNotSingleSidedError();

--- a/packages/vault/contracts/VaultFactory.sol
+++ b/packages/vault/contracts/VaultFactory.sol
@@ -18,8 +18,8 @@ contract VaultFactory is IVaultFactory, Factory {
     /// @dev The market factory
     IMarketFactory public immutable marketFactory;
 
-    /// @dev Mapping of allowed operators for each account
-    mapping(address => mapping(address => bool)) public operators;
+    /// @dev DEPRECATED SLOT -- previously the operators mapping
+    bytes32 private __unused0__;
 
     /// @notice Constructs the contract
     /// @param marketFactory_ The market factory
@@ -59,13 +59,5 @@ contract VaultFactory is IVaultFactory, Factory {
         newVault.update(address(this), initialAmount, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
 
         emit VaultCreated(newVault, asset, initialMarket);
-    }
-
-    /// @notice Updates the status of an operator for the caller
-    /// @param operator The operator to update
-    /// @param newEnabled The new status of the operator
-    function updateOperator(address operator, bool newEnabled) external {
-        operators[msg.sender][operator] = newEnabled;
-        emit OperatorUpdated(msg.sender, operator, newEnabled);
     }
 }

--- a/packages/vault/contracts/interfaces/IVaultFactory.sol
+++ b/packages/vault/contracts/interfaces/IVaultFactory.sol
@@ -9,13 +9,10 @@ import { Token18 } from "@equilibria/root/token/types/Token18.sol";
 import { IVault } from "./IVault.sol";
 
 interface IVaultFactory is IFactory {
-    event OperatorUpdated(address indexed account, address indexed operator, bool newEnabled);
     event VaultCreated(IVault indexed vault, Token18 indexed asset, IMarket initialMarket);
 
     function initialAmount() external view returns (UFixed6);
     function marketFactory() external view returns (IMarketFactory);
     function initialize() external;
-    function operators(address account, address operator) external view returns (bool);
-    function updateOperator(address operator, bool newEnabled) external;
     function create(Token18 asset, IMarket initialMarket, string calldata name) external returns (IVault);
 }

--- a/packages/vault/test/integration/vault/Vault.test.ts
+++ b/packages/vault/test/integration/vault/Vault.test.ts
@@ -1274,9 +1274,9 @@ describe('Vault', () => {
         vault,
         'VaultNotOperatorError',
       )
-      await vaultFactory.connect(user).updateOperator(liquidator.address, true)
+      await marketFactory.connect(user).updateOperator(liquidator.address, true)
       vault.connect(liquidator).update(user.address, largeDeposit, 0, 0)
-      await vaultFactory.connect(user).updateOperator(liquidator.address, false)
+      await marketFactory.connect(user).updateOperator(liquidator.address, false)
 
       await updateOracle()
       await vault.rebalance(user.address)
@@ -1289,9 +1289,9 @@ describe('Vault', () => {
       await expect(
         vault.connect(liquidator).update(user.address, parse6decimal('10000'), 0, 0),
       ).to.revertedWithCustomError(vault, 'VaultNotOperatorError')
-      await vaultFactory.connect(user).updateOperator(liquidator.address, true)
+      await marketFactory.connect(user).updateOperator(liquidator.address, true)
       await vault.connect(liquidator).update(user.address, 0, parse6decimal('10000'), 0)
-      await vaultFactory.connect(user).updateOperator(liquidator.address, false)
+      await marketFactory.connect(user).updateOperator(liquidator.address, false)
       await updateOracle()
       await vault.rebalance(user.address)
 
@@ -1299,9 +1299,9 @@ describe('Vault', () => {
       await expect(
         vault.connect(liquidator).update(user.address, 0, 0, ethers.constants.MaxUint256),
       ).to.revertedWithCustomError(vault, 'VaultNotOperatorError')
-      await vaultFactory.connect(user).updateOperator(liquidator.address, true)
+      await marketFactory.connect(user).updateOperator(liquidator.address, true)
       await vault.connect(liquidator).update(user.address, 0, 0, ethers.constants.MaxUint256)
-      await vaultFactory.connect(user).updateOperator(liquidator.address, false)
+      await marketFactory.connect(user).updateOperator(liquidator.address, false)
 
       expect(await totalCollateralInVault()).to.equal(0)
       expect(await vault.totalAssets()).to.equal(0)


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-1979/[cleanup]-consolidate-operator-settings-to-only-marketfactory

Migration Note:
- Ensure that multiInvoker and vault users are notified to approve marketFactory for authorization.
- Update frontend to approve marketFactory for all multiInvoker and vault transactions.