### PR TITLE
prevent close order from executing if account has no position

### DIFF
--- a/packages/perennial-order/contracts/Manager.sol
+++ b/packages/perennial-order/contracts/Manager.sol
@@ -131,7 +131,7 @@ abstract contract Manager is IManager, Kept {
         order = _orders[market][account][orderId].read();
         // prevent calling canExecute on a spent or empty order
         if (order.isSpent || order.isEmpty()) revert ManagerInvalidOrderNonceError();
-        canExecute = order.canExecute(market.oracle().latest());
+        canExecute = order.canExecute(market, account);
     }
 
     /// @inheritdoc IManager

--- a/packages/perennial-order/contracts/test/TriggerOrderTester.sol
+++ b/packages/perennial-order/contracts/test/TriggerOrderTester.sol
@@ -21,8 +21,8 @@ contract TriggerOrderTester {
         order.store(newOrder);
     }
 
-    function canExecute(TriggerOrder calldata order_, OracleVersion calldata version) external pure returns (bool) {
-        return order_.canExecute(version);
+    function canExecute(TriggerOrder calldata order_, IMarket market, address user) external view returns (bool) {
+        return order_.canExecute(market, user);
     }
 
     function notionalValue(TriggerOrder calldata order_, IMarket market, address user) external view returns (UFixed6) {

--- a/packages/perennial-order/contracts/types/TriggerOrder.sol
+++ b/packages/perennial-order/contracts/types/TriggerOrder.sol
@@ -38,13 +38,24 @@ library TriggerOrderLib {
 
     /// @notice Determines whether the trigger order is fillable at the latest price
     /// @param self Trigger order
-    /// @param latestVersion Latest oracle version
+    /// @param market Market for which the order is intended to be executed
+    /// @param account Market participant
     /// @return Whether the trigger order is fillable
-    function canExecute(TriggerOrder memory self, OracleVersion memory latestVersion) internal pure returns (bool) {
+    function canExecute(TriggerOrder memory self, IMarket market, address account) internal view returns (bool) {
+        OracleVersion memory latestVersion = market.oracle().latest();
+
         if (!latestVersion.valid) return false;
-        if (self.comparison == 1) return latestVersion.price.gte(self.price);
-        if (self.comparison == -1) return latestVersion.price.lte(self.price);
-        return false;
+        if (self.comparison == 1 && latestVersion.price.lt(self.price)) return false;
+        if (self.comparison == -1 && latestVersion.price.gt(self.price)) return false;
+        if (self.comparison != 1 && self.comparison != -1) revert TriggerOrderInvalidError();
+
+        if (self.delta.eq(MAGIC_VALUE_CLOSE_POSITION)) {
+            Position memory position = market.positions(account);
+            // prevent execution if the position was not opened or is already closed
+            if (position.empty()) return false;
+        }
+
+        return true;
     }
 
     /// @notice Applies the order to the user's position and updates the market

--- a/packages/perennial-order/test/integration/Manager_Arbitrum.test.ts
+++ b/packages/perennial-order/test/integration/Manager_Arbitrum.test.ts
@@ -712,6 +712,13 @@ describe('Manager_Arbitrum', () => {
       await ensureNoPosition(userA)
       await market.settle(userB.address, TX_OVERRIDES)
       await ensureNoPosition(userB)
+
+      // cannot close with no position
+      orderId = await placeOrder(userB, Side.LONG, Compare.LTE, parse6decimal('4001'), MAGIC_VALUE_CLOSE_POSITION)
+      expect(orderId).to.equal(BigNumber.from(505))
+      await expect(
+        manager.connect(keeper).executeOrder(market.address, userB.address, orderId, TX_OVERRIDES),
+      ).to.be.revertedWithCustomError(manager, 'ManagerCannotExecuteError')
     })
   })
 


### PR DESCRIPTION
Seems there is a use case where users submit a trigger order to close their position alongside an intent for opening a position.  When this happens, the trigger order becomes immediately executable.  When the trigger order executes as a no-op update, the UX is that their trigger order disappeared.

To work around this behavior, update logic such that trigger orders to close are not executable if user has no position.

## TODO
- [x] Self-review
- [ ] Merge this to v2.4 branch after approval