### PR TITLE
Optimism contracts for Collateral Account controller and Trigger Order manager

### DIFF
--- a/packages/perennial-account/contracts/Controller_Optimism.sol
+++ b/packages/perennial-account/contracts/Controller_Optimism.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import { Kept_Optimism, Kept } from "@equilibria/root/attribute/Kept/Kept_Optimism.sol";
+import { UFixed18 } from "@equilibria/root/number/types/UFixed18.sol";
+import { IVerifierBase } from "@equilibria/root/verifier/interfaces/IVerifierBase.sol";
+import { IMarketFactory } from "@perennial/core/contracts/interfaces/IMarketFactory.sol";
+import { Controller_Incentivized } from "./Controller_Incentivized.sol";
+
+/// @title Controller_Optimism
+/// @notice Controller which compensates keepers for handling or relaying messages on Optimism L2.
+contract Controller_Optimism is Controller_Incentivized, Kept_Optimism {
+    /// @dev Creates instance of Controller which compensates keepers
+    /// @param implementation Pristine collateral account contract
+    /// @param marketFactory Market Factory contract
+    /// @param nonceManager Verifier contract to which nonce and group cancellations are relayed
+    constructor(
+        address implementation,
+        IMarketFactory marketFactory,
+        IVerifierBase nonceManager
+    ) Controller_Incentivized(implementation, marketFactory, nonceManager) {}
+
+    /// @dev Use the Kept_Optimism implementation for calculating the dynamic fee
+    function _calldataFee(
+        bytes memory applicableCalldata,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata
+    ) internal view override(Kept_Optimism, Kept) returns (UFixed18) {
+        return Kept_Optimism._calldataFee(applicableCalldata, multiplierCalldata, bufferCalldata);
+    }
+
+    /// @dev Transfers funds from collateral account to controller, and limits compensation
+    /// to the user-defined maxFee in the Action message
+    /// @param amount Calculated keeper fee
+    /// @param data Encoded address of collateral account and UFixed6 user-specified maximum fee
+    /// @return raisedKeeperFee Amount pulled from controller to keeper
+    function _raiseKeeperFee(
+        UFixed18 amount,
+        bytes memory data
+    ) internal override(Controller_Incentivized, Kept) returns (UFixed18 raisedKeeperFee) {
+        return Controller_Incentivized._raiseKeeperFee(amount, data);
+    }
+}

--- a/packages/perennial-order/contracts/Manager_Optimism.sol
+++ b/packages/perennial-order/contracts/Manager_Optimism.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import { IEmptySetReserve } from "@equilibria/emptyset-batcher/interfaces/IEmptySetReserve.sol";
+import { Kept, Kept_Optimism, Token18, UFixed18 } from "@equilibria/root/attribute/Kept/Kept_Optimism.sol";
+import { Token6 } from "@equilibria/root/token/types/Token6.sol";
+import { IMarketFactory } from "@perennial/core/contracts/interfaces/IMarketFactory.sol";
+
+import { IOrderVerifier, Manager } from "./Manager.sol";
+
+contract Manager_Optimism is Manager, Kept_Optimism {
+    /// @dev passthrough constructor
+    constructor(
+        Token6 usdc,
+        Token18 dsu,
+        IEmptySetReserve reserve,
+        IMarketFactory marketFactory,
+        IOrderVerifier verifier
+    ) Manager(usdc, dsu, reserve, marketFactory, verifier) {}
+
+    /// @dev Use the Kept_Optimism implementation for calculating the dynamic fee
+    function _calldataFee(
+        bytes memory applicableCalldata,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata
+    ) internal view override(Kept_Optimism, Kept) returns (UFixed18) {
+        return Kept_Optimism._calldataFee(applicableCalldata, multiplierCalldata, bufferCalldata);
+    }
+
+    /// @dev Use the base implementation for raising the keeper fee
+    function _raiseKeeperFee(
+        UFixed18 amount,
+        bytes memory data
+    ) internal override(Manager, Kept) returns (UFixed18) {
+        return Manager._raiseKeeperFee(amount, data);
+    }
+}


### PR DESCRIPTION
Copypasta-ed the contracts from v2.4, where they have been tested against a Base fork, and updated imports for naming.   No other changes.  If backmerging into v2.4, the commit within should be ignored.