### PR TITLE
update pending position when checking maintenance requirements

### DIFF
--- a/packages/core/contracts/libs/InvariantLib.sol
+++ b/packages/core/contracts/libs/InvariantLib.sol
@@ -36,8 +36,9 @@ library InvariantLib {
             revert IMarket.MarketOverCloseError();
 
         if (newOrder.protected() && (
-            !context.pendingLocal.neg().eq(context.latestPositionLocal.magnitude()) ||  // total pending close is not equal to latest position
-            context.latestPositionLocal.maintained(                                     // latest position is properly maintained
+            !context.pendingLocal.neg().eq(context.latestPositionLocal.magnitude()) ||    // total pending close is not equal to latest position
+            !PositionLib.maintained(                                                      // latest position is properly maintained
+                context.latestPositionLocal.magnitude().add(context.pendingLocal.pos()),
                 context.latestOracleVersion,
                 context.riskParameter,
                 context.local.collateral


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-2067/[fix]-incorporate-pending-positive-position-when-checking-maintenance