### PR TITLE
Market taker update through signed message

### DIFF
--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -28,7 +28,6 @@ import { InvariantLib } from "./libs/InvariantLib.sol";
 import { MagicValueLib } from "./libs/MagicValueLib.sol";
 import { VersionAccumulationResponse, VersionLib } from "./libs/VersionLib.sol";
 import { CheckpointAccumulationResponse, CheckpointLib } from "./libs/CheckpointLib.sol";
-import "hardhat/console.sol";
 
 /// @title Market
 /// @notice Manages logic and state for a single market.

--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -21,7 +21,7 @@ import { Order, OrderLib, OrderStorageGlobal, OrderStorageLocal } from "./types/
 import { Guarantee, GuaranteeLib, GuaranteeStorageGlobal, GuaranteeStorageLocal } from "./types/Guarantee.sol";
 import { Checkpoint, CheckpointStorage } from "./types/Checkpoint.sol";
 import { Intent } from "./types/Intent.sol";
-import { MarketUpdateTaker } from "./types/MarketUpdateTaker.sol";
+import { Take } from "./types/Take.sol";
 import { OracleVersion } from "./types/OracleVersion.sol";
 import { OracleReceipt } from "./types/OracleReceipt.sol";
 import { InvariantLib } from "./libs/InvariantLib.sol";
@@ -176,8 +176,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @notice Updates the account's taker position without collateral change
     /// @param update_ Message requesting change in user's taker position
     /// @param signature Taker's signature
-    function update(MarketUpdateTaker calldata update_, bytes memory signature) external {
-        verifier.verifyMarketUpdateTaker(update_, signature);
+    function update(Take calldata update_, bytes memory signature) external {
+        verifier.verifyTake(update_, signature);
         (Context memory context, UpdateContext memory updateContext) =
             _loadForUpdate(update_.common.account, update_.common.account, update_.referrer, address(0), UFixed6Lib.ZERO, UFixed6Lib.ZERO);
 

--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -21,6 +21,7 @@ import { Order, OrderLib, OrderStorageGlobal, OrderStorageLocal } from "./types/
 import { Guarantee, GuaranteeLib, GuaranteeStorageGlobal, GuaranteeStorageLocal } from "./types/Guarantee.sol";
 import { Checkpoint, CheckpointStorage } from "./types/Checkpoint.sol";
 import { Intent } from "./types/Intent.sol";
+import { MarketUpdateTaker } from "./types/MarketUpdateTaker.sol";
 import { OracleVersion } from "./types/OracleVersion.sol";
 import { OracleReceipt } from "./types/OracleReceipt.sol";
 import { InvariantLib } from "./libs/InvariantLib.sol";
@@ -170,6 +171,20 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             false,
             true
         ); // signer
+    }
+
+    /// @notice Updates the account's taker position without collateral change
+    /// @param account Identifies the user
+    /// @param update Message requesting to change taker position
+    /// @param signature Taker's signature
+    function update(
+        address account,
+        MarketUpdateTaker calldata update,
+        bytes memory signature
+    ) external {
+        verifier.verifyMarketUpdateTaker(update, signature);
+        // FIXME: public method generates "not callable" compile-time error
+        // update(account, Fixed6Lib.ZERO, update.amount, Fixed6Lib.ZERO, update.referrer);
     }
 
     /// @notice Updates the account's position and collateral

--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -178,8 +178,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @param signature Taker's signature
     function update(MarketUpdateTaker calldata update_, bytes memory signature) external {
         verifier.verifyMarketUpdateTaker(update_, signature);
-        // TODO: Cannot call update(address,uint256,uint256,uint256,address) because it zeros out the signer (second
-        // param to _loadForUpdate). See if there's a smaller way to do this without impacting other update functions.
         (Context memory context, UpdateContext memory updateContext) =
             _loadForUpdate(update_.common.account, update_.common.account, update_.referrer, address(0), UFixed6Lib.ZERO, UFixed6Lib.ZERO);
 

--- a/packages/core/contracts/Verifier.sol
+++ b/packages/core/contracts/Verifier.sol
@@ -10,7 +10,7 @@ import { Initializable } from "@equilibria/root/attribute/Initializable.sol";
 import { IVerifier } from "./interfaces/IVerifier.sol";
 import { IMarketFactorySigners } from "./interfaces/IMarketFactorySigners.sol";
 import { Intent, IntentLib } from "./types/Intent.sol";
-import { MarketUpdateTaker, MarketUpdateTakerLib } from "./types/MarketUpdateTaker.sol";
+import { Take, TakeLib } from "./types/Take.sol";
 import { OperatorUpdate, OperatorUpdateLib } from "./types/OperatorUpdate.sol";
 import { SignerUpdate, SignerUpdateLib } from "./types/SignerUpdate.sol";
 import { AccessUpdateBatch, AccessUpdateBatchLib } from "./types/AccessUpdateBatch.sol";
@@ -58,13 +58,13 @@ contract Verifier is VerifierBase, IVerifier, Initializable {
     ///      Reverts if the signature does not match the signer
     /// @param marketUpdateTaker Message to verify
     /// @param signature Taker's signtaure
-    function verifyMarketUpdateTaker(MarketUpdateTaker calldata marketUpdateTaker, bytes calldata signature)
+    function verifyTake(Take calldata marketUpdateTaker, bytes calldata signature)
         external
         validateAndCancel(marketUpdateTaker.common, signature)
     {
         if (!SignatureChecker.isValidSignatureNow(
             marketUpdateTaker.common.signer,
-            _hashTypedDataV4(MarketUpdateTakerLib.hash(marketUpdateTaker)),
+            _hashTypedDataV4(TakeLib.hash(marketUpdateTaker)),
             signature
         )) revert VerifierInvalidSignerError();
     }

--- a/packages/core/contracts/Verifier.sol
+++ b/packages/core/contracts/Verifier.sol
@@ -10,6 +10,7 @@ import { Initializable } from "@equilibria/root/attribute/Initializable.sol";
 import { IVerifier } from "./interfaces/IVerifier.sol";
 import { IMarketFactorySigners } from "./interfaces/IMarketFactorySigners.sol";
 import { Intent, IntentLib } from "./types/Intent.sol";
+import { MarketUpdateTaker, MarketUpdateTakerLib } from "./types/MarketUpdateTaker.sol";
 import { OperatorUpdate, OperatorUpdateLib } from "./types/OperatorUpdate.sol";
 import { SignerUpdate, SignerUpdateLib } from "./types/SignerUpdate.sol";
 import { AccessUpdateBatch, AccessUpdateBatchLib } from "./types/AccessUpdateBatch.sol";
@@ -48,6 +49,22 @@ contract Verifier is VerifierBase, IVerifier, Initializable {
         if (!SignatureChecker.isValidSignatureNow(
             intent.common.signer,
             _hashTypedDataV4(IntentLib.hash(intent)),
+            signature
+        )) revert VerifierInvalidSignerError();
+    }
+
+    /// @notice Verifies the signature of a market update taker type
+    /// @dev Cancels the nonce after verifying the signature
+    ///      Reverts if the signature does not match the signer
+    /// @param marketUpdateTaker Message to verify
+    /// @param signature Taker's signtaure
+    function verifyMarketUpdateTaker(MarketUpdateTaker calldata marketUpdateTaker, bytes calldata signature)
+        external
+        validateAndCancel(marketUpdateTaker.common, signature)
+    {
+        if (!SignatureChecker.isValidSignatureNow(
+            marketUpdateTaker.common.signer,
+            _hashTypedDataV4(MarketUpdateTakerLib.hash(marketUpdateTaker)),
             signature
         )) revert VerifierInvalidSignerError();
     }

--- a/packages/core/contracts/interfaces/IMarket.sol
+++ b/packages/core/contracts/interfaces/IMarket.sol
@@ -17,6 +17,7 @@ import { Checkpoint } from "../types/Checkpoint.sol";
 import { Order } from "../types/Order.sol";
 import { Guarantee } from "../types/Guarantee.sol";
 import { Intent } from "../types/Intent.sol";
+import { MarketUpdateTaker } from "../types/MarketUpdateTaker.sol";
 import { VersionAccumulationResult } from "../libs/VersionLib.sol";
 import { CheckpointAccumulationResult } from "../libs/CheckpointLib.sol";
 
@@ -160,6 +161,7 @@ interface IMarket is IInstance {
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
     function update(address account, Intent calldata intent, bytes memory signature) external;
+    function update(address account, MarketUpdateTaker calldata update, bytes memory signature) external;
     function update(address account, Fixed6 amount, Fixed6 collateral, address referrer) external;
     function update(address account, Fixed6 makerAmount, Fixed6 takerAmount, Fixed6 collateral, address referrer) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;

--- a/packages/core/contracts/interfaces/IMarket.sol
+++ b/packages/core/contracts/interfaces/IMarket.sol
@@ -17,7 +17,7 @@ import { Checkpoint } from "../types/Checkpoint.sol";
 import { Order } from "../types/Order.sol";
 import { Guarantee } from "../types/Guarantee.sol";
 import { Intent } from "../types/Intent.sol";
-import { MarketUpdateTaker } from "../types/MarketUpdateTaker.sol";
+import { Take } from "../types/Take.sol";
 import { VersionAccumulationResult } from "../libs/VersionLib.sol";
 import { CheckpointAccumulationResult } from "../libs/CheckpointLib.sol";
 
@@ -161,7 +161,7 @@ interface IMarket is IInstance {
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
     function update(address account, Intent calldata intent, bytes memory signature) external;
-    function update(MarketUpdateTaker calldata update, bytes memory signature) external;
+    function update(Take calldata update, bytes memory signature) external;
     function update(address account, Fixed6 amount, Fixed6 collateral, address referrer) external;
     function update(address account, Fixed6 makerAmount, Fixed6 takerAmount, Fixed6 collateral, address referrer) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;

--- a/packages/core/contracts/interfaces/IMarket.sol
+++ b/packages/core/contracts/interfaces/IMarket.sol
@@ -161,7 +161,7 @@ interface IMarket is IInstance {
     function guaranteeReferrers(address account, uint256 id) external view returns (address);
     function settle(address account) external;
     function update(address account, Intent calldata intent, bytes memory signature) external;
-    function update(address account, MarketUpdateTaker calldata update, bytes memory signature) external;
+    function update(MarketUpdateTaker calldata update, bytes memory signature) external;
     function update(address account, Fixed6 amount, Fixed6 collateral, address referrer) external;
     function update(address account, Fixed6 makerAmount, Fixed6 takerAmount, Fixed6 collateral, address referrer) external;
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect) external;

--- a/packages/core/contracts/interfaces/IVerifier.sol
+++ b/packages/core/contracts/interfaces/IVerifier.sol
@@ -4,12 +4,14 @@ pragma solidity ^0.8.13;
 import { IVerifierBase } from "@equilibria/root/verifier/interfaces/IVerifierBase.sol";
 import { Common } from "@equilibria/root/verifier/types/Common.sol";
 import { Intent } from "../types/Intent.sol";
+import { MarketUpdateTaker } from "../types/MarketUpdateTaker.sol";
 import { OperatorUpdate } from "../types/OperatorUpdate.sol";
 import { SignerUpdate } from "../types/SignerUpdate.sol";
 import { AccessUpdateBatch } from "../types/AccessUpdateBatch.sol";
 
 interface IVerifier is IVerifierBase {
     function verifyIntent(Intent calldata intent, bytes calldata signature) external;
+    function verifyMarketUpdateTaker(MarketUpdateTaker calldata marketUpdateTaker, bytes calldata signature) external;
     function verifyOperatorUpdate(OperatorUpdate calldata operatorUpdate, bytes calldata signature) external;
     function verifySignerUpdate(SignerUpdate calldata signerUpdate, bytes calldata signature) external;
     function verifyAccessUpdateBatch(AccessUpdateBatch calldata accessUpdateBatch, bytes calldata signature) external;

--- a/packages/core/contracts/interfaces/IVerifier.sol
+++ b/packages/core/contracts/interfaces/IVerifier.sol
@@ -4,14 +4,14 @@ pragma solidity ^0.8.13;
 import { IVerifierBase } from "@equilibria/root/verifier/interfaces/IVerifierBase.sol";
 import { Common } from "@equilibria/root/verifier/types/Common.sol";
 import { Intent } from "../types/Intent.sol";
-import { MarketUpdateTaker } from "../types/MarketUpdateTaker.sol";
+import { Take } from "../types/Take.sol";
 import { OperatorUpdate } from "../types/OperatorUpdate.sol";
 import { SignerUpdate } from "../types/SignerUpdate.sol";
 import { AccessUpdateBatch } from "../types/AccessUpdateBatch.sol";
 
 interface IVerifier is IVerifierBase {
     function verifyIntent(Intent calldata intent, bytes calldata signature) external;
-    function verifyMarketUpdateTaker(MarketUpdateTaker calldata marketUpdateTaker, bytes calldata signature) external;
+    function verifyTake(Take calldata marketUpdateTaker, bytes calldata signature) external;
     function verifyOperatorUpdate(OperatorUpdate calldata operatorUpdate, bytes calldata signature) external;
     function verifySignerUpdate(SignerUpdate calldata signerUpdate, bytes calldata signature) external;
     function verifyAccessUpdateBatch(AccessUpdateBatch calldata accessUpdateBatch, bytes calldata signature) external;

--- a/packages/core/contracts/types/MarketUpdateTaker.sol
+++ b/packages/core/contracts/types/MarketUpdateTaker.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
+import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
+import { Common, CommonLib } from "@equilibria/root/verifier/types/Common.sol";
+
+/// @notice Market update which modifies the taker's position without collateral change
+struct MarketUpdateTaker {
+    /// @dev Taker delta (positive for long, negative for short)
+    Fixed6 amount;
+    /// @dev Recipient of referral fee
+    address referrer;
+    /// @dev Information shared across all EIP712 market actions
+    ///      common.account - identifies the user
+    ///      common.signer  - user or delegate signing the transaction
+    ///      common.domain  - identifies the market
+    ///      common.nonce   - per-user unique message identifier
+    ///      common.group   - may be used to cancel multiple updates which have not been executed
+    ///      common.expiry  - update becomes invalid at and after this time
+    Common common;
+}
+using MarketUpdateTakerLib for MarketUpdateTaker global;
+
+/// @notice Library used to hash requests and verify message signatures
+library MarketUpdateTakerLib {
+    /// @dev Used to verify a signed message
+    bytes32 constant public STRUCT_HASH = keccak256(
+        "MarketUpdateTaker(int256 amount,address referrer,Common common)"
+        "Common(address account,address signer,address domain,uint256 nonce,uint256 group,uint256 expiry)"
+    );
+
+    /// @dev Used to create a signed message
+    function hash(MarketUpdateTaker memory self) internal pure returns (bytes32) {
+        return keccak256(abi.encode(STRUCT_HASH, self.amount, self.referrer, CommonLib.hash(self.common)));
+    }
+}

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -80,7 +80,7 @@ library OrderLib {
             (UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
     }
 
-    /// @notice Creates a new order from the an intent order request
+    /// @notice Creates a new order from an intent order request or market update message
     /// @param timestamp The current timestamp
     /// @param position The current position
     /// @param makerAmount The magnitude and direction of maker position

--- a/packages/core/contracts/types/Take.sol
+++ b/packages/core/contracts/types/Take.sol
@@ -6,7 +6,7 @@ import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
 import { Common, CommonLib } from "@equilibria/root/verifier/types/Common.sol";
 
 /// @notice Market update which modifies the taker's position without collateral change
-struct MarketUpdateTaker {
+struct Take {
     /// @dev Taker delta (positive for long, negative for short)
     Fixed6 amount;
     /// @dev Recipient of referral fee
@@ -20,18 +20,18 @@ struct MarketUpdateTaker {
     ///      common.expiry  - update becomes invalid at and after this time
     Common common;
 }
-using MarketUpdateTakerLib for MarketUpdateTaker global;
+using TakeLib for Take global;
 
 /// @notice Library used to hash requests and verify message signatures
-library MarketUpdateTakerLib {
+library TakeLib {
     /// @dev Used to verify a signed message
     bytes32 constant public STRUCT_HASH = keccak256(
-        "MarketUpdateTaker(int256 amount,address referrer,Common common)"
+        "Take(int256 amount,address referrer,Common common)"
         "Common(address account,address signer,address domain,uint256 nonce,uint256 group,uint256 expiry)"
     );
 
     /// @dev Used to create a signed message
-    function hash(MarketUpdateTaker memory self) internal pure returns (bytes32) {
+    function hash(Take memory self) internal pure returns (bytes32) {
         return keccak256(abi.encode(STRUCT_HASH, self.amount, self.referrer, CommonLib.hash(self.common)));
     }
 }

--- a/packages/core/test/helpers/erc712.ts
+++ b/packages/core/test/helpers/erc712.ts
@@ -4,6 +4,7 @@ import {
   CommonStruct,
   GroupCancellationStruct,
   IntentStruct,
+  MarketUpdateTakerStruct,
   OperatorUpdateStruct,
   SignerUpdateStruct,
 } from '../../types/generated/contracts/Verifier'
@@ -19,20 +20,24 @@ export function erc721Domain(verifier: IVerifier | Verifier | FakeContract<IVeri
   }
 }
 
+const commonType = {
+  Common: [
+    { name: 'account', type: 'address' },
+    { name: 'signer', type: 'address' },
+    { name: 'domain', type: 'address' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'group', type: 'uint256' },
+    { name: 'expiry', type: 'uint256' },
+  ],
+}
+
 export async function signCommon(
   signer: SignerWithAddress,
   verifier: IVerifier | Verifier | FakeContract<IVerifier>,
   common: CommonStruct,
 ): Promise<string> {
   const types = {
-    Common: [
-      { name: 'account', type: 'address' },
-      { name: 'signer', type: 'address' },
-      { name: 'domain', type: 'address' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'group', type: 'uint256' },
-      { name: 'expiry', type: 'uint256' },
-    ],
+    ...commonType,
   }
 
   return await signer._signTypedData(erc721Domain(verifier), types, common)
@@ -44,14 +49,7 @@ export async function signIntent(
   intent: IntentStruct,
 ): Promise<string> {
   const types = {
-    Common: [
-      { name: 'account', type: 'address' },
-      { name: 'signer', type: 'address' },
-      { name: 'domain', type: 'address' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'group', type: 'uint256' },
-      { name: 'expiry', type: 'uint256' },
-    ],
+    ...commonType,
     Intent: [
       { name: 'amount', type: 'int256' },
       { name: 'price', type: 'int256' },
@@ -66,20 +64,30 @@ export async function signIntent(
   return await signer._signTypedData(erc721Domain(verifier), types, intent)
 }
 
+export async function signMarketUpdateTaker(
+  signer: SignerWithAddress,
+  verifier: IVerifier | Verifier | FakeContract<IVerifier>,
+  marketUpdate: MarketUpdateTakerStruct,
+): Promise<string> {
+  const types = {
+    ...commonType,
+    MarketUpdateTaker: [
+      { name: 'amount', type: 'int256' },
+      { name: 'referrer', type: 'address' },
+      { name: 'common', type: 'Common' },
+    ],
+  }
+
+  return await signer._signTypedData(erc721Domain(verifier), types, marketUpdate)
+}
+
 export async function signGroupCancellation(
   signer: SignerWithAddress,
   verifier: Verifier | FakeContract<IVerifier>,
   groupCancellation: GroupCancellationStruct,
 ): Promise<string> {
   const types = {
-    Common: [
-      { name: 'account', type: 'address' },
-      { name: 'signer', type: 'address' },
-      { name: 'domain', type: 'address' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'group', type: 'uint256' },
-      { name: 'expiry', type: 'uint256' },
-    ],
+    ...commonType,
     GroupCancellation: [
       { name: 'group', type: 'uint256' },
       { name: 'common', type: 'Common' },
@@ -95,14 +103,7 @@ export async function signOperatorUpdate(
   operatorUpdate: OperatorUpdateStruct,
 ): Promise<string> {
   const types = {
-    Common: [
-      { name: 'account', type: 'address' },
-      { name: 'signer', type: 'address' },
-      { name: 'domain', type: 'address' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'group', type: 'uint256' },
-      { name: 'expiry', type: 'uint256' },
-    ],
+    ...commonType,
     AccessUpdate: [
       { name: 'accessor', type: 'address' },
       { name: 'approved', type: 'bool' },
@@ -122,14 +123,7 @@ export async function signSignerUpdate(
   signerUpdate: SignerUpdateStruct,
 ): Promise<string> {
   const types = {
-    Common: [
-      { name: 'account', type: 'address' },
-      { name: 'signer', type: 'address' },
-      { name: 'domain', type: 'address' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'group', type: 'uint256' },
-      { name: 'expiry', type: 'uint256' },
-    ],
+    ...commonType,
     AccessUpdate: [
       { name: 'accessor', type: 'address' },
       { name: 'approved', type: 'bool' },
@@ -149,14 +143,7 @@ export async function signAccessUpdateBatch(
   accessUpdateBatch: AccessUpdateBatchStruct,
 ): Promise<string> {
   const types = {
-    Common: [
-      { name: 'account', type: 'address' },
-      { name: 'signer', type: 'address' },
-      { name: 'domain', type: 'address' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'group', type: 'uint256' },
-      { name: 'expiry', type: 'uint256' },
-    ],
+    ...commonType,
     AccessUpdate: [
       { name: 'accessor', type: 'address' },
       { name: 'approved', type: 'bool' },

--- a/packages/core/test/helpers/erc712.ts
+++ b/packages/core/test/helpers/erc712.ts
@@ -4,7 +4,7 @@ import {
   CommonStruct,
   GroupCancellationStruct,
   IntentStruct,
-  MarketUpdateTakerStruct,
+  TakeStruct,
   OperatorUpdateStruct,
   SignerUpdateStruct,
 } from '../../types/generated/contracts/Verifier'
@@ -64,14 +64,14 @@ export async function signIntent(
   return await signer._signTypedData(erc721Domain(verifier), types, intent)
 }
 
-export async function signMarketUpdateTaker(
+export async function signTake(
   signer: SignerWithAddress,
   verifier: IVerifier | Verifier | FakeContract<IVerifier>,
-  marketUpdate: MarketUpdateTakerStruct,
+  marketUpdate: TakeStruct,
 ): Promise<string> {
   const types = {
     ...commonType,
-    MarketUpdateTaker: [
+    Take: [
       { name: 'amount', type: 'int256' },
       { name: 'referrer', type: 'address' },
       { name: 'common', type: 'Common' },

--- a/packages/core/test/integration/core/happyPath.test.ts
+++ b/packages/core/test/integration/core/happyPath.test.ts
@@ -26,8 +26,14 @@ import { Market__factory } from '../../../types/generated'
 import { CHAINLINK_CUSTOM_CURRENCIES } from '@perennial/v2-oracle/util/constants'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { ChainlinkContext } from '../helpers/chainlinkHelpers'
-import { IntentStruct, RiskParameterStruct } from '../../../types/generated/contracts/Market'
-import { signAccessUpdateBatch, signIntent, signOperatorUpdate, signSignerUpdate } from '../../helpers/erc712'
+import { IntentStruct, MarketUpdateTakerStruct, RiskParameterStruct } from '../../../types/generated/contracts/Market'
+import {
+  signAccessUpdateBatch,
+  signIntent,
+  signMarketUpdateTaker,
+  signOperatorUpdate,
+  signSignerUpdate,
+} from '../../helpers/erc712'
 
 export const TIMESTAMP_0 = 1631112429
 export const TIMESTAMP_1 = 1631112904
@@ -39,7 +45,13 @@ export const TIMESTAMP_5 = 1631118731
 export const PRICE_0 = parse6decimal('113.882975')
 export const PRICE_1 = parse6decimal('113.796498')
 export const PRICE_2 = parse6decimal('115.046259')
+export const PRICE_3 = parse6decimal('116.284753')
 export const PRICE_4 = parse6decimal('117.462552')
+
+const COMMON_PROTOTYPE = '(address,address,address,uint256,uint256,uint256)'
+const MARKET_UPDATE_ABSOLUTE_PROTOTYPE = 'update(address,uint256,uint256,uint256,int256,bool)'
+const MARKET_UPDATE_DELTA_PROTOTYPE = 'update(address,int256,int256,address)'
+const MARKET_UPDATE_TAKER_PROTOTYPE = `update((int256,address,${COMMON_PROTOTYPE}),bytes)`
 
 describe('Happy Path', () => {
   let instanceVars: InstanceVars
@@ -2089,6 +2101,196 @@ describe('Happy Path', () => {
     expectVersionEq(await market.versions(TIMESTAMP_0), {
       ...DEFAULT_VERSION,
       price: PRICE_0,
+    })
+  })
+
+  it('opens, reduces, and closes a long position w/ signed message', async () => {
+    const POSITION = parse6decimal('10')
+    const COLLATERAL = parse6decimal('1000')
+    const { owner, user, userB, userC, dsu, marketFactory, verifier, chainlink } = instanceVars
+    const market = await createMarket(instanceVars)
+
+    // establish a referral fee
+    await expect(marketFactory.connect(owner).updateReferralFee(owner.address, parse6decimal('0.0125')))
+      .to.emit(marketFactory, 'ReferralFeeUpdated')
+      .withArgs(owner.address, parse6decimal('0.0125'))
+
+    // user opens a maker position adding liquidity to the market
+    await dsu.connect(user).approve(market.address, COLLATERAL.mul(1e12).mul(2))
+    await market.connect(user)[MARKET_UPDATE_ABSOLUTE_PROTOTYPE](user.address, POSITION, 0, 0, COLLATERAL, false)
+
+    // userB deposits some collateral
+    await dsu.connect(userB).approve(market.address, COLLATERAL.mul(1e12).mul(2))
+    await market.connect(userB)[MARKET_UPDATE_DELTA_PROTOTYPE](userB.address, 0, COLLATERAL, constants.AddressZero)
+
+    // settle user's maker position
+    await chainlink.next()
+    await settle(market, user)
+
+    // userB signs message to open a long position
+    const initialPosition = POSITION.mul(2).div(3) // 6.666666
+    let message: MarketUpdateTakerStruct = {
+      amount: initialPosition,
+      referrer: owner.address,
+      common: {
+        account: userB.address,
+        signer: userB.address,
+        domain: market.address,
+        nonce: 2,
+        group: 0,
+        expiry: constants.MaxUint256,
+      },
+    }
+    let signature = await signMarketUpdateTaker(userB, verifier, message)
+
+    // userC executes the update
+    let expectedTakerReferral = parse6decimal('0.083333') // referralFee * takerAmount = 0.0125 * |initialPosition|
+    await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_2,
+          orders: 1,
+          longPos: initialPosition,
+          takerReferral: expectedTakerReferral,
+        },
+        DEFAULT_GUARANTEE,
+        constants.AddressZero,
+        owner.address, // referrer
+        constants.AddressZero,
+      )
+
+    // confirm the pending order
+    expectOrderEq(await market.pendingOrder(2), {
+      ...DEFAULT_ORDER,
+      timestamp: TIMESTAMP_2,
+      orders: 1,
+      collateral: 0,
+      makerPos: 0,
+      longPos: initialPosition,
+      takerReferral: expectedTakerReferral,
+    })
+
+    // settle userB's long position
+    await chainlink.next()
+    await settle(market, userB)
+
+    // check userB state
+    expectLocalEq(await market.locals(userB.address), {
+      ...DEFAULT_LOCAL,
+      currentId: 2,
+      latestId: 2,
+      collateral: COLLATERAL,
+    })
+    expectOrderEq(await market.pendingOrders(userB.address, 3), DEFAULT_ORDER)
+    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_2), {
+      ...DEFAULT_CHECKPOINT,
+      collateral: COLLATERAL,
+    })
+    expectPositionEq(await market.positions(userB.address), {
+      ...DEFAULT_POSITION,
+      timestamp: TIMESTAMP_2,
+      long: initialPosition,
+    })
+
+    // userB signs message to reduce their long position
+    const positionDelta = POSITION.div(-3) // -3.333333
+    message = { ...message, amount: positionDelta, common: { ...message.common, nonce: 3 } }
+    signature = await signMarketUpdateTaker(userB, verifier, message)
+
+    // userC again executes the update
+    expectedTakerReferral = parse6decimal('0.041666') // referralFee * takerAmount = 0.0125 * |positionDelta|
+    await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_3,
+          orders: 1,
+          longNeg: positionDelta.mul(-1),
+          takerReferral: expectedTakerReferral,
+        },
+        DEFAULT_GUARANTEE,
+        constants.AddressZero,
+        owner.address, // referrer
+        constants.AddressZero,
+      )
+
+    // settle userB's reduced position and check state
+    await chainlink.next()
+    await settle(market, userB)
+    // pnl = priceDelta * longSocialized = (116.284753-115.046259) * 6.666666 = 8.256626
+    // interestLong = -0.003015
+    // collateralChange = pnl + interestLong = 8.256626 - 0.003015 = 8.253611
+    let collateralChange = parse6decimal('8.253611').sub(12) // loss of precision
+    const collateral3 = COLLATERAL.add(collateralChange)
+    expectLocalEq(await market.locals(userB.address), {
+      ...DEFAULT_LOCAL,
+      currentId: 3,
+      latestId: 3,
+      collateral: collateral3,
+    })
+    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_3), {
+      ...DEFAULT_CHECKPOINT,
+      collateral: collateral3,
+    })
+    expectPositionEq(await market.positions(userB.address), {
+      ...DEFAULT_POSITION,
+      timestamp: TIMESTAMP_3,
+      long: POSITION.div(3),
+    })
+
+    // userB signs message to close their position, this time with no referrer
+    const currentPosition = (await market.positions(userB.address)).long // 3.333333
+    message = {
+      ...message,
+      amount: currentPosition.mul(-1),
+      referrer: constants.AddressZero,
+      common: { ...message.common, nonce: 4 },
+    }
+    signature = await signMarketUpdateTaker(userB, verifier, message)
+
+    // userC executes the request to close
+    await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+      .to.emit(market, 'OrderCreated')
+      .withArgs(
+        userB.address,
+        {
+          ...DEFAULT_ORDER,
+          timestamp: TIMESTAMP_4,
+          orders: 1,
+          longNeg: currentPosition,
+        },
+        DEFAULT_GUARANTEE,
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
+      )
+
+    // settle userB's closed position and check state
+    await chainlink.next()
+    await settle(market, userB)
+    // pnl = priceDelta * longSocialized = (117.462552-116.284753) * 3.333333 = 3.925996
+    // interestLong = -0.005596
+    // collateralChange = pnl + interestLong = 3.925996 - 0.005596 = 3.9204
+    collateralChange = parse6decimal('3.9204').sub(4) // loss of precision
+    const collateral4 = collateral3.add(collateralChange)
+    expectLocalEq(await market.locals(userB.address), {
+      ...DEFAULT_LOCAL,
+      currentId: 4,
+      latestId: 4,
+      collateral: collateral4,
+    })
+    expectCheckpointEq(await market.checkpoints(userB.address, TIMESTAMP_4), {
+      ...DEFAULT_CHECKPOINT,
+      collateral: collateral4,
+    })
+    expectPositionEq(await market.positions(userB.address), {
+      ...DEFAULT_POSITION,
+      timestamp: TIMESTAMP_4,
     })
   })
 

--- a/packages/core/test/integration/core/happyPath.test.ts
+++ b/packages/core/test/integration/core/happyPath.test.ts
@@ -45,7 +45,7 @@ export const PRICE_4 = parse6decimal('117.462552')
 const COMMON_PROTOTYPE = '(address,address,address,uint256,uint256,uint256)'
 const MARKET_UPDATE_ABSOLUTE_PROTOTYPE = 'update(address,uint256,uint256,uint256,int256,bool)'
 const MARKET_UPDATE_DELTA_PROTOTYPE = 'update(address,int256,int256,address)'
-const MARKET_UPDATE_TAKER_PROTOTYPE = `update((int256,address,${COMMON_PROTOTYPE}),bytes)`
+const MARKET_UPDATE_TAKE_PROTOTYPE = `update((int256,address,${COMMON_PROTOTYPE}),bytes)`
 
 describe('Happy Path', () => {
   let instanceVars: InstanceVars
@@ -2139,7 +2139,7 @@ describe('Happy Path', () => {
 
     // userC executes the update
     let expectedTakerReferral = parse6decimal('0.083333') // referralFee * takerAmount = 0.0125 * |initialPosition|
-    await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+    await expect(market.connect(userC)[MARKET_UPDATE_TAKE_PROTOTYPE](message, signature))
       .to.emit(market, 'OrderCreated')
       .withArgs(
         userB.address,
@@ -2196,7 +2196,7 @@ describe('Happy Path', () => {
 
     // userC again executes the update
     expectedTakerReferral = parse6decimal('0.041666') // referralFee * takerAmount = 0.0125 * |positionDelta|
-    await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+    await expect(market.connect(userC)[MARKET_UPDATE_TAKE_PROTOTYPE](message, signature))
       .to.emit(market, 'OrderCreated')
       .withArgs(
         userB.address,
@@ -2248,7 +2248,7 @@ describe('Happy Path', () => {
     signature = await signTake(userB, verifier, message)
 
     // userC executes the request to close
-    await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+    await expect(market.connect(userC)[MARKET_UPDATE_TAKE_PROTOTYPE](message, signature))
       .to.emit(market, 'OrderCreated')
       .withArgs(
         userB.address,

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -24986,8 +24986,6 @@ describe('Market', () => {
           await settle(market, user)
           await settle(market, userB)
 
-          await debugDumpActorState()
-
           // check user state
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -50,7 +50,7 @@ import {
   IMarket,
   IntentStruct,
   MarketParameterStruct,
-  MarketUpdateTakerStruct,
+  TakeStruct,
   RiskParameterStruct,
 } from '../../../types/generated/contracts/Market'
 
@@ -24936,7 +24936,7 @@ describe('Market', () => {
             ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
 
           // user signs message to open a long position
-          const message: MarketUpdateTakerStruct = {
+          const message: TakeStruct = {
             amount: POSITION.div(2),
             referrer: owner.address,
             common: {

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -53,7 +53,6 @@ import {
   MarketUpdateTakerStruct,
   RiskParameterStruct,
 } from '../../../types/generated/contracts/Market'
-import { signMarketUpdateTaker } from '../../helpers/erc712'
 
 const { ethers } = HRE
 
@@ -24949,13 +24948,12 @@ describe('Market', () => {
               expiry: constants.MaxUint256,
             },
           }
-          const signature = await signMarketUpdateTaker(user, verifier, message)
 
           // userC executes the update on behalf of user
           factory.authorization
             .whenCalledWith(user.address, userC.address, user.address, owner.address)
             .returns([false, true, parse6decimal('0.20')])
-          await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, signature))
+          await expect(market.connect(userC)[MARKET_UPDATE_TAKER_PROTOTYPE](message, DEFAULT_SIGNATURE))
             .to.emit(market, 'OrderCreated')
             .withArgs(
               user.address,

--- a/packages/core/test/unit/verifier/Verifier.test.ts
+++ b/packages/core/test/unit/verifier/Verifier.test.ts
@@ -14,6 +14,7 @@ import {
   signSignerUpdate,
   signAccessUpdateBatch,
   signCommon,
+  signMarketUpdateTaker,
 } from '../../helpers/erc712'
 
 const { ethers } = HRE
@@ -35,7 +36,7 @@ describe('Verifier', () => {
 
     marketFactory = await smock.fake<IMarketFactorySigners>('IMarketFactorySigners')
     verifier = await new Verifier__factory(owner).deploy()
-    verifier.initialize(marketFactory.address)
+    await verifier.initialize(marketFactory.address)
     scSigner = await smock.fake<IERC1271>('IERC1271')
 
     marketFactory.signers.whenCalledWith(caller.address, scSigner.address).returns(true)
@@ -325,7 +326,7 @@ describe('Verifier', () => {
       expect(await verifier.nonces(caller.address, 17)).to.eq(true)
     })
 
-    it('should reject intent w/ invalid nonce', async () => {
+    it('should reject intent w/ invalid group', async () => {
       const intent = {
         ...DEFAULT_INTENT,
         common: {
@@ -344,6 +345,226 @@ describe('Verifier', () => {
         verifier,
         'VerifierInvalidGroupError',
       )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+  })
+
+  describe('#verifyMarketUpdateTaker', () => {
+    const DEFAULT_MARKET_UPDATE_TAKER = {
+      amount: parse6decimal('20'),
+      referrer: constants.AddressZero,
+      common: {
+        account: constants.AddressZero,
+        signer: constants.AddressZero,
+        domain: constants.AddressZero,
+        nonce: 0,
+        group: 0,
+        expiry: constants.MaxUint256,
+      },
+    }
+
+    it('should verify MarketUpdateTaker message', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        referrer: constants.AddressZero, //.address,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: market.address,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await expect(verifier.connect(market).verifyMarketUpdateTaker(marketUpdateTaker, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should verify MarketUpdateTaker message w/ sc signer', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: scSigner.address,
+          domain: caller.address,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      scSigner.isValidSignature.returns(0x1626ba7e)
+
+      await expect(verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid signer', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: market.address,
+          domain: caller.address,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidSignerError')
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid sc signer', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: scSigner.address,
+          domain: caller.address,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      scSigner.isValidSignature.returns(false)
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidSignerError')
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should verify MarketUpdateTaker message w/ expiry', async () => {
+      const now = await time.latest()
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          expiry: now + 3,
+        },
+      } // callstatic & call each take one second
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await expect(verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid expiry', async () => {
+      const now = await time.latest()
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          expiry: now - 1,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidExpiryError')
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid domain', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: market.address,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidDomainError')
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid signature', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+        },
+      }
+      const signature = '0x885b1eefff8ef92e3acee19ba145266137cb5bc1191f796b08e3375a8b8c9458'
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidSignatureError')
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid nonce', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          nonce: 22,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await verifier.connect(caller).cancelNonce(22)
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidNonceError')
+
+      expect(await verifier.nonces(caller.address, 22)).to.eq(true)
+    })
+
+    it('should reject MarketUpdateTaker message w/ invalid group', async () => {
+      const marketUpdateTaker = {
+        ...DEFAULT_MARKET_UPDATE_TAKER,
+        common: {
+          ...DEFAULT_MARKET_UPDATE_TAKER.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          group: 14,
+        },
+      }
+      const signature = await signMarketUpdateTaker(caller, verifier, marketUpdateTaker)
+
+      await verifier.connect(caller).cancelGroup(14)
+
+      await expect(
+        verifier.connect(caller).verifyMarketUpdateTaker(marketUpdateTaker, signature),
+      ).to.revertedWithCustomError(verifier, 'VerifierInvalidGroupError')
 
       expect(await verifier.nonces(caller.address, 0)).to.eq(false)
     })


### PR DESCRIPTION
# Purpose
Establishes a foundation by which users may change their position through a signed message without using an intent order.  The message implemented in this PR limits users to changing their taker position without collateral change.

# Scope
Explicitly out-of-scope for this PR is relaying of this message.

# Status
- [x] Check coverage of affected contracts
- [x] Self-review
- [x] Confirm CI runs clean