### PR TITLE
Relax singled sided invariant

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - v2.4-mini
+      - britz-invalidation-semaphore
   workflow_dispatch:
 
 env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - v2.4-mini
-      - britz-invalidation-semaphore
   workflow_dispatch:
 
 env:

--- a/packages/core/contracts/libs/InvariantLib.sol
+++ b/packages/core/contracts/libs/InvariantLib.sol
@@ -32,26 +32,21 @@ library InvariantLib {
             updateContext.guaranteeReferrer
         );
 
-        if (context.pendingLocal.neg().gt(context.latestPositionLocal.magnitude())) // total pending close is greater than latest position
-            revert IMarket.MarketOverCloseError();
+        if (
+            context.pendingLocal.invalidation != 0 &&                              // pending orders are partially invalidatable
+            context.pendingLocal.neg().gt(context.latestPositionLocal.magnitude()) // total pending close is greater than latest position
+        ) revert IMarket.MarketOverCloseError();
 
-        if (newOrder.protected() && (
-            !context.pendingLocal.neg().eq(context.latestPositionLocal.magnitude()) ||  // total pending close is not equal to latest position
-            context.latestPositionLocal.maintained(                                     // latest position is properly maintained
-                context.latestOracleVersion,
-                context.riskParameter,
-                context.local.collateral
-            ) ||
-            !newOrder.collateral.eq(Fixed6Lib.ZERO)                                     // the order is modifying collateral
-        )) revert IMarket.MarketInvalidProtectionError();
+        if (newOrder.protected() && !_validateProtection(context, newOrder))
+            revert IMarket.MarketInvalidProtectionError();
 
         if (
-            !(updateContext.currentPositionLocal.magnitude().isZero() && context.latestPositionLocal.magnitude().isZero()) &&       // sender has no position
-            !(newOrder.isEmpty() && newOrder.collateral.gte(Fixed6Lib.ZERO)) &&                                                     // sender is depositing zero or more into account, without position change
+            !(context.latestPositionLocal.magnitude().isZero() && context.pendingLocal.isEmpty()) &&    // sender has no position
+            !(newOrder.isEmpty() && newOrder.collateral.gte(Fixed6Lib.ZERO)) &&                         // sender is depositing zero or more into account, without position change
             (
                 !context.latestOracleVersion.valid ||
                 context.currentTimestamp - context.latestOracleVersion.timestamp >= context.riskParameter.staleAfter
-            )                                                                                                                       // price is not stale
+            )                                                                                           // price is not stale
         ) revert IMarket.MarketStalePriceError();
 
         if (context.marketParameter.closed && newOrder.increasesPosition())
@@ -62,12 +57,15 @@ library InvariantLib {
             newOrder.increasesMaker()
         ) revert IMarket.MarketMakerOverLimitError();
 
+        if (!updateContext.currentPositionLocal.singleSided()) revert IMarket.MarketNotSingleSidedError();
+
         if (
-            !updateContext.currentPositionLocal.singleSided() || (                                              // current position is not single-sided with order applied
-                context.latestPositionLocal.direction() != updateContext.currentPositionLocal.direction() &&    // latest and current positions are not in the same direction
-                (!context.latestPositionLocal.empty() && !updateContext.currentPositionLocal.empty())           // both latest and current positions are non-empty
-            )
+            (!context.latestPositionLocal.maker.isZero() && !updateContext.currentPositionLocal.skew().isZero()) ||
+            (!context.latestPositionLocal.skew().isZero() && !updateContext.currentPositionLocal.maker.isZero())
         ) revert IMarket.MarketNotSingleSidedError();
+
+        if (context.pendingLocal.invalidation != 0 && context.pendingLocal.crossesZero())
+            revert IMarket.MarketNotSingleSidedError();
 
         if (newGuarantee.priceDeviation(context.latestOracleVersion.price).gt(context.marketParameter.maxPriceDeviation))
             revert IMarket.MarketIntentPriceDeviationError();
@@ -87,7 +85,7 @@ library InvariantLib {
 
         if (
             !PositionLib.margined(
-                context.latestPositionLocal.magnitude().add(context.pendingLocal.pos()),
+                updateContext.currentPositionLocal.magnitude(),
                 context.latestOracleVersion,
                 context.riskParameter,
                 updateContext.collateralization,
@@ -114,5 +112,23 @@ library InvariantLib {
 
         if (context.local.collateral.lt(Fixed6Lib.ZERO))
             revert IMarket.MarketInsufficientCollateralError();
+    }
+
+    function _validateProtection(IMarket.Context memory context, Order memory newOrder) private pure returns (bool) {
+        if (context.pendingLocal.crossesZero()) {
+            if (!newOrder.isEmpty()) return false; // pending zero-cross, liquidate (lock) with no-op order
+        } else {
+            if (!context.pendingLocal.neg().eq(context.latestPositionLocal.magnitude())) return false; // no pending zero-cross, liquidate with full close
+        }
+
+        if (context.latestPositionLocal.maintained(
+            context.latestOracleVersion,
+            context.riskParameter,
+            context.local.collateral
+        )) return false; // latest position is properly maintained
+
+        if (!newOrder.collateral.eq(Fixed6Lib.ZERO)) return false; // the order is modifying collateral
+
+        return true;
     }
 }

--- a/packages/core/contracts/libs/MagicValueLib.sol
+++ b/packages/core/contracts/libs/MagicValueLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
+import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
 import { Fixed6, Fixed6Lib } from "@equilibria/root/number/types/Fixed6.sol";
 import { IMarket } from "../interfaces/IMarket.sol";
 
@@ -52,11 +52,10 @@ library MagicValueLib {
         UFixed6 currentPosition,
         UFixed6 newPosition
     ) private pure returns (UFixed6) {
-        if (newPosition.eq(MAGIC_VALUE_UNCHANGED_POSITION))
-            return currentPosition;
+        if (newPosition.eq(MAGIC_VALUE_UNCHANGED_POSITION)) return currentPosition;
         if (newPosition.eq(MAGIC_VALUE_FULLY_CLOSED_POSITION)) {
-            if (currentPosition.isZero()) return currentPosition;
-            return currentPosition.sub(context.latestPositionLocal.magnitude().sub(context.pendingLocal.neg()));
+            if (context.pendingLocal.invalidation == 0) return UFixed6Lib.ZERO;
+            else return context.pendingLocal.pos();
         }
         return newPosition;
     }

--- a/packages/core/contracts/libs/MagicValueLib.sol
+++ b/packages/core/contracts/libs/MagicValueLib.sol
@@ -54,8 +54,9 @@ library MagicValueLib {
     ) private pure returns (UFixed6) {
         if (newPosition.eq(MAGIC_VALUE_UNCHANGED_POSITION)) return currentPosition;
         if (newPosition.eq(MAGIC_VALUE_FULLY_CLOSED_POSITION)) {
-            if (context.pendingLocal.invalidation == 0) return UFixed6Lib.ZERO;
-            else return context.pendingLocal.pos();
+            if (currentPosition.isZero()) return UFixed6Lib.ZERO;           // side is empty
+            if (context.pendingLocal.crossesZero()) return currentPosition; // pending zero-cross, max close is no-op
+            return context.pendingLocal.pos().min(currentPosition);         // minimum position is pending open, or current position if smaller (due to intents)
         }
         return newPosition;
     }

--- a/packages/core/contracts/test/OrderTester.sol
+++ b/packages/core/contracts/test/OrderTester.sol
@@ -50,6 +50,10 @@ abstract contract OrderTester {
         return read().isEmpty();
     }
 
+    function crossesZero() external view returns (bool) {
+        return read().crossesZero();
+    }
+
     function from(
         uint256 timestamp,
         Position memory position,

--- a/packages/core/contracts/test/OrderTester.sol
+++ b/packages/core/contracts/test/OrderTester.sol
@@ -50,10 +50,6 @@ abstract contract OrderTester {
         return read().isEmpty();
     }
 
-    function magnitude() external view returns (Fixed6) {
-        return read().magnitude();
-    }
-
     function from(
         uint256 timestamp,
         Position memory position,

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -262,12 +262,12 @@ library OrderLib {
         return Fixed6Lib.from(self.makerPos).sub(Fixed6Lib.from(self.makerNeg));
     }
 
-    /// @notice Returns the taker delta of the order
-    /// @param self The order object to check
-    /// @return The taker delta of the order
-    function taker(Order memory self) internal pure returns (Fixed6) {
-        return long(self).sub(short(self));
-    }
+    // /// @notice Returns the taker delta of the order
+    // /// @param self The order object to check
+    // /// @return The taker delta of the order
+    // function taker(Order memory self) internal pure returns (Fixed6) {
+    //     return long(self).sub(short(self));
+    // }
 
     /// @notice Returns the long delta of the order
     /// @param self The order object to check

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -220,7 +220,9 @@ library OrderLib {
         return !self.makerNeg.isZero() || currentMajor.gt(latestMajor);
     }
 
-    // TODO
+    /// @notice Returns whether the order crosses zero (has delta on both the long and short sides)
+    /// @param self The Order object to check
+    /// @return Whether the order crosses zero
     function crossesZero(Order memory self) internal pure returns (bool) {
         return !self.longPos.add(self.longNeg).isZero() && !self.shortPos.add(self.shortNeg).isZero();
     }
@@ -261,13 +263,6 @@ library OrderLib {
     function maker(Order memory self) internal pure returns (Fixed6) {
         return Fixed6Lib.from(self.makerPos).sub(Fixed6Lib.from(self.makerNeg));
     }
-
-    // /// @notice Returns the taker delta of the order
-    // /// @param self The order object to check
-    // /// @return The taker delta of the order
-    // function taker(Order memory self) internal pure returns (Fixed6) {
-    //     return long(self).sub(short(self));
-    // }
 
     /// @notice Returns the long delta of the order
     /// @param self The order object to check

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -54,7 +54,7 @@ struct Order {
 using OrderLib for Order global;
 struct OrderStorageGlobal { uint256 slot0; uint256 slot1; uint256 slot2; } // SECURITY: must remain at (3) slots
 using OrderStorageGlobalLib for OrderStorageGlobal global;
-struct OrderStorageLocal { uint256 slot0; uint256 slot1; } // SECURITY: must remain at (2) slots
+struct OrderStorageLocal { uint256 slot0; uint256 slot1; uint256 slot2; }
 using OrderStorageLocalLib for OrderStorageLocal global;
 
 /// @title Order
@@ -220,6 +220,11 @@ library OrderLib {
         return !self.makerNeg.isZero() || currentMajor.gt(latestMajor);
     }
 
+    // TODO
+    function crossesZero(Order memory self) internal pure returns (bool) {
+        return !self.longPos.add(self.longNeg).isZero() && !self.shortPos.add(self.shortNeg).isZero();
+    }
+
     /// @notice Returns whether the order is applicable for liquidity checks
     /// @param self The Order object to check
     /// @param marketParameter The market parameter
@@ -247,25 +252,7 @@ library OrderLib {
     /// @param self The order object to check
     /// @return Whether the order is empty
     function isEmpty(Order memory self) internal pure returns (bool) {
-        return pos(self).isZero() && neg(self).isZero();
-    }
-
-     /// @notice Returns the direction of the order
-    /// @dev 0 = maker, 1 = long, 2 = short
-    /// @param self The position object to check
-    /// @return The direction of the position
-    function direction(Order memory self) internal pure returns (uint256) {
-        if (!self.longPos.isZero() || !self.longNeg.isZero()) return 1;
-        if (!self.shortPos.isZero() || !self.shortNeg.isZero()) return 2;
-
-        return 0;
-    }
-
-    /// @notice Returns the magnitude of the order
-    /// @param self The order object to check
-    /// @return The magnitude of the order
-    function magnitude(Order memory self) internal pure returns (Fixed6) {
-        return maker(self).add(long(self)).add(short(self));
+        return makerTotal(self).isZero() && takerTotal(self).isZero();
     }
 
     /// @notice Returns the maker delta of the order
@@ -273,6 +260,13 @@ library OrderLib {
     /// @return The maker delta of the order
     function maker(Order memory self) internal pure returns (Fixed6) {
         return Fixed6Lib.from(self.makerPos).sub(Fixed6Lib.from(self.makerNeg));
+    }
+
+    /// @notice Returns the taker delta of the order
+    /// @param self The order object to check
+    /// @return The taker delta of the order
+    function taker(Order memory self) internal pure returns (Fixed6) {
+        return long(self).sub(short(self));
     }
 
     /// @notice Returns the long delta of the order
@@ -424,13 +418,6 @@ library OrderStorageGlobalLib {
     function store(OrderStorageGlobal storage self, Order memory newValue) internal {
         OrderStorageLib.validate(newValue);
 
-        if (newValue.makerPos.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
-        if (newValue.makerNeg.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
-        if (newValue.longPos.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
-        if (newValue.longNeg.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
-        if (newValue.shortPos.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
-        if (newValue.shortNeg.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
-
         uint256 encoded0 =
             uint256(newValue.timestamp << (256 - 32)) >> (256 - 32) |
             uint256(newValue.orders << (256 - 32)) >> (256 - 32 - 32) |
@@ -461,49 +448,46 @@ library OrderStorageGlobalLib {
 ///         uint32 timestamp;
 ///         uint32 orders;
 ///         int64 collateral;
-///         uint2 direction;
-///         uint62 magnitudePos;
-///         uint62 magnitudeNeg;
-///         uint1 protection;
+///         uint64 makerPos;
+///         uint64 makerNeg;
 ///
 ///         /* slot 1 */
+///         uint64 longPos;
+///         uint64 longNeg;
+///         uint64 shortPos;
+///         uint64 shortNeg;
+///
+///         /* slot 2 */
 ///         uint64 takerReferral;
 ///         uint64 makerReferral;
+///         uint1 protection;
 ///         uint8 invalidation;
 ///     }
 ///
 library OrderStorageLocalLib {
     function read(OrderStorageLocal storage self) internal view returns (Order memory) {
-        (uint256 slot0, uint256 slot1) = (self.slot0, self.slot1);
-
-        uint256 direction = uint256(slot0 << (256 - 32 - 32 - 64 - 2)) >> (256 - 2);
-        UFixed6 magnitudePos = UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 62)) >> (256 - 62));
-        UFixed6 magnitudeNeg = UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 62 - 62)) >> (256 - 62));
+        (uint256 slot0, uint256 slot1, uint256 slot2) = (self.slot0, self.slot1, self.slot2);
 
         return Order(
             uint256(slot0 << (256 - 32)) >> (256 - 32),
             uint256(slot0 << (256 - 32 - 32)) >> (256 - 32),
             Fixed6.wrap(int256(slot0 << (256 - 32 - 32 - 64)) >> (256 - 64)),
-            direction == 0 ? magnitudePos : UFixed6Lib.ZERO,
-            direction == 0 ? magnitudeNeg : UFixed6Lib.ZERO,
-            direction == 1 ? magnitudePos : UFixed6Lib.ZERO,
-            direction == 1 ? magnitudeNeg : UFixed6Lib.ZERO,
-            direction == 2 ? magnitudePos : UFixed6Lib.ZERO,
-            direction == 2 ? magnitudeNeg : UFixed6Lib.ZERO,
-            uint256(slot0 << (256 - 32 - 32 - 64 - 2 - 62 - 62 - 1)) >> (256 - 1),
-            uint256(slot1 << (256 - 64 - 64 - 8)) >> (256 - 8),
+            UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot0 << (256 - 32 - 32 - 64 - 64 - 64)) >> (256 - 64)),
             UFixed6.wrap(uint256(slot1 << (256 - 64)) >> (256 - 64)),
-            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64)) >> (256 - 64))
+            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot1 << (256 - 64 - 64 - 64 - 64)) >> (256 - 64)),
+            uint256(slot2 << (256 - 64 - 64 - 1)) >> (256 - 1),
+            uint256(slot2 << (256 - 64 - 64 - 1 - 8)) >> (256 - 8),
+            UFixed6.wrap(uint256(slot2 << (256 - 64)) >> (256 - 64)),
+            UFixed6.wrap(uint256(slot2 << (256 - 64 - 64)) >> (256 - 64))
         );
     }
 
     function store(OrderStorageLocal storage self, Order memory newValue) internal {
         OrderStorageLib.validate(newValue);
 
-        (UFixed6 magnitudePos, UFixed6 magnitudeNeg) = (newValue.pos(), newValue.neg());
-
-        if (magnitudePos.gt(UFixed6.wrap(2 ** 62 - 1))) revert OrderStorageLib.OrderStorageInvalidError();
-        if (magnitudeNeg.gt(UFixed6.wrap(2 ** 62 - 1))) revert OrderStorageLib.OrderStorageInvalidError();
         if (newValue.protection > 1) revert OrderStorageLib.OrderStorageInvalidError();
         if (newValue.invalidation > type(uint8).max) revert OrderStorageLib.OrderStorageInvalidError();
 
@@ -511,18 +495,23 @@ library OrderStorageLocalLib {
             uint256(newValue.timestamp << (256 - 32)) >> (256 - 32) |
             uint256(newValue.orders << (256 - 32)) >> (256 - 32 - 32) |
             uint256(Fixed6.unwrap(newValue.collateral) << (256 - 64)) >> (256 - 32 - 32 - 64) |
-            uint256(newValue.direction() << (256 - 2)) >> (256 - 32 - 32 - 64 - 2) |
-            uint256(UFixed6.unwrap(magnitudePos) << (256 - 62)) >> (256 - 32 - 32 - 64 - 2 - 62) |
-            uint256(UFixed6.unwrap(magnitudeNeg) << (256 - 62)) >> (256 - 32 - 32 - 64 - 2 - 62 - 62) |
-            uint256(newValue.protection << (256 - 1)) >> (256 - 32 - 32 - 64 - 2 - 62 - 62 - 1);
+            uint256(UFixed6.unwrap(newValue.makerPos) << (256 - 64)) >> (256 - 32 - 32 - 64 - 64) |
+            uint256(UFixed6.unwrap(newValue.makerNeg) << (256 - 64)) >> (256 - 32 - 32 - 64 - 64 - 64);
         uint256 encoded1 =
+            uint256(UFixed6.unwrap(newValue.longPos) << (256 - 64)) >> (256 - 64) |
+            uint256(UFixed6.unwrap(newValue.longNeg) << (256 - 64)) >> (256 - 64 - 64) |
+            uint256(UFixed6.unwrap(newValue.shortPos) << (256 - 64)) >> (256 - 64 - 64 - 64) |
+            uint256(UFixed6.unwrap(newValue.shortNeg) << (256 - 64)) >> (256 - 64 - 64 - 64 - 64);
+        uint256 encoded2 =
             uint256(UFixed6.unwrap(newValue.makerReferral) << (256 - 64)) >> (256 - 64) |
             uint256(UFixed6.unwrap(newValue.takerReferral) << (256 - 64)) >> (256 - 64 - 64) |
-            uint256(newValue.invalidation << (256 - 8)) >> (256 - 64 - 64 - 8);
+            uint256(newValue.protection << (256 - 1)) >> (256 - 64 - 64 - 1) |
+            uint256(newValue.invalidation << (256 - 8)) >> (256 - 64 - 64 - 1 - 8);
 
         assembly {
             sstore(self.slot, encoded0)
             sstore(add(self.slot, 1), encoded1)
+            sstore(add(self.slot, 2), encoded2)
         }
     }
 }
@@ -538,5 +527,11 @@ library OrderStorageLib {
         if (newValue.collateral.lt(Fixed6.wrap(type(int64).min))) revert OrderStorageInvalidError();
         if (newValue.makerReferral.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageInvalidError();
         if (newValue.takerReferral.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageInvalidError();
+        if (newValue.makerPos.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
+        if (newValue.makerNeg.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
+        if (newValue.longPos.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
+        if (newValue.longNeg.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
+        if (newValue.shortPos.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
+        if (newValue.shortNeg.gt(UFixed6.wrap(type(uint64).max))) revert OrderStorageLib.OrderStorageInvalidError();
     }
 }

--- a/packages/core/test/integration/core/liquidate.test.ts
+++ b/packages/core/test/integration/core/liquidate.test.ts
@@ -116,7 +116,7 @@ describe('Liquidate', () => {
           userBCollateral.mul(-1).sub(1),
           false,
         ),
-    ).to.be.revertedWithCustomError(market, 'MarketInsufficientMarginError') // underflow
+    ).to.be.revertedWithCustomError(market, 'MarketInsufficientCollateralError') // underflow
 
     await market.connect(userB)['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true) // liquidate
 

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -15866,14 +15866,6 @@ describe('Market', () => {
             dsu.balanceOf.whenCalledWith(market.address).returns(COLLATERAL.mul(1e12))
           })
 
-          it('it reverts if not protected', async () => {
-            await expect(
-              market
-                .connect(userB)
-                ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, 0, 0, 0, 0, false),
-            ).to.be.revertedWithCustomError(market, 'MarketInsufficientMarginError')
-          })
-
           it('it reverts if already liquidated', async () => {
             await market
               .connect(liquidator)

--- a/packages/core/test/unit/types/Order.test.ts
+++ b/packages/core/test/unit/types/Order.test.ts
@@ -107,7 +107,7 @@ describe('Order', () => {
           expect(value.protection).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if protection out of range', async () => {
           await expect(
             orderLocal.store({
               ...DEFAULT_ORDER,
@@ -128,7 +128,7 @@ describe('Order', () => {
           expect(value.invalidation).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if invalidation out of range', async () => {
           await expect(
             orderLocal.store({
               ...DEFAULT_ORDER,
@@ -493,7 +493,7 @@ describe('Order', () => {
           expect(value.timestamp).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if timestamp out of range', async () => {
           await expect(
             order.store({
               ...validStoredOrder,
@@ -514,7 +514,7 @@ describe('Order', () => {
           expect(value.orders).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if orders out of range', async () => {
           await expect(
             order.store({
               ...validStoredOrder,
@@ -574,7 +574,7 @@ describe('Order', () => {
           expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if makerPos out of range', async () => {
           await expect(
             order.store({
               ...DEFAULT_ORDER,
@@ -595,7 +595,7 @@ describe('Order', () => {
           expect(value.makerNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if makerNeg out of range', async () => {
           await expect(
             order.store({
               ...DEFAULT_ORDER,
@@ -616,7 +616,7 @@ describe('Order', () => {
           expect(value.longPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if longPos out of range', async () => {
           await expect(
             order.store({
               ...DEFAULT_ORDER,
@@ -631,17 +631,17 @@ describe('Order', () => {
         it('saves if in range', async () => {
           await order.store({
             ...DEFAULT_ORDER,
-            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+            longNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
           })
           const value = await order.read()
-          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+          expect(value.longNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if longNeg out of range', async () => {
           await expect(
             order.store({
               ...DEFAULT_ORDER,
-              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
+              longNeg: BigNumber.from(2).pow(STORAGE_SIZE),
             }),
           ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
         })
@@ -658,7 +658,7 @@ describe('Order', () => {
           expect(value.shortPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if shortPos out of range', async () => {
           await expect(
             order.store({
               ...DEFAULT_ORDER,
@@ -679,7 +679,7 @@ describe('Order', () => {
           expect(value.shortNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if shortNeg out of range', async () => {
           await expect(
             order.store({
               ...DEFAULT_ORDER,
@@ -700,7 +700,7 @@ describe('Order', () => {
           expect(value.makerReferral).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if makerReferral out of range', async () => {
           await expect(
             order.store({
               ...validStoredOrder,
@@ -721,7 +721,7 @@ describe('Order', () => {
           expect(value.takerReferral).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
         })
 
-        it('reverts if currentId out of range', async () => {
+        it('reverts if takerReferral out of range', async () => {
           await expect(
             order.store({
               ...validStoredOrder,
@@ -1132,13 +1132,13 @@ describe('Order', () => {
         expect(await order.crossesZero()).to.equal(true)
       })
 
-      it('doesnt crosses zero (long)', async () => {
+      it('doesnt cross zero (long)', async () => {
         await order.store({ ...DEFAULT_ORDER, longPos: 4, longNeg: 5 })
         expect(await order.crossesZero()).to.equal(false)
       })
 
-      it('doesnt crosses zero (short)', async () => {
-        await order.store({ ...DEFAULT_ORDER, longPos: 4, longNeg: 5 })
+      it('doesnt cross zero (short)', async () => {
+        await order.store({ ...DEFAULT_ORDER, shortPos: 7, shortNeg: 8 })
         expect(await order.crossesZero()).to.equal(false)
       })
     })

--- a/packages/core/test/unit/types/Order.test.ts
+++ b/packages/core/test/unit/types/Order.test.ts
@@ -52,146 +52,6 @@ describe('Order', () => {
     describe('common behavoir', () => {
       shouldBehaveLike(() => ({ order: orderGlobal, validStoredOrder: VALID_STORED_ORDER }))
     })
-
-    describe('#store', () => {
-      it('stores a new value', async () => {
-        await orderGlobal.store(VALID_STORED_ORDER)
-
-        const value = await orderGlobal.read()
-        expect(value.makerPos).to.equal(3)
-        expect(value.makerNeg).to.equal(4)
-        expect(value.longPos).to.equal(5)
-        expect(value.longNeg).to.equal(6)
-        expect(value.shortPos).to.equal(7)
-        expect(value.shortNeg).to.equal(8)
-      })
-
-      context('.makerPos', async () => {
-        const STORAGE_SIZE = 64
-        it('saves if in range', async () => {
-          await orderGlobal.store({
-            ...DEFAULT_ORDER,
-            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderGlobal.read()
-          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderGlobal.store({
-              ...DEFAULT_ORDER,
-              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderGlobal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.makerNeg', async () => {
-        const STORAGE_SIZE = 64
-        it('saves if in range', async () => {
-          await orderGlobal.store({
-            ...DEFAULT_ORDER,
-            makerNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderGlobal.read()
-          expect(value.makerNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderGlobal.store({
-              ...DEFAULT_ORDER,
-              makerNeg: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderGlobal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.longPos', async () => {
-        const STORAGE_SIZE = 64
-        it('saves if in range', async () => {
-          await orderGlobal.store({
-            ...DEFAULT_ORDER,
-            longPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderGlobal.read()
-          expect(value.longPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderGlobal.store({
-              ...DEFAULT_ORDER,
-              longPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderGlobal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.longNeg', async () => {
-        const STORAGE_SIZE = 64
-        it('saves if in range', async () => {
-          await orderGlobal.store({
-            ...DEFAULT_ORDER,
-            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderGlobal.read()
-          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderGlobal.store({
-              ...DEFAULT_ORDER,
-              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderGlobal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.shortPos', async () => {
-        const STORAGE_SIZE = 64
-        it('saves if in range', async () => {
-          await orderGlobal.store({
-            ...DEFAULT_ORDER,
-            shortPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderGlobal.read()
-          expect(value.shortPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderGlobal.store({
-              ...DEFAULT_ORDER,
-              shortPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderGlobal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.shortNeg', async () => {
-        const STORAGE_SIZE = 64
-        it('saves if in range', async () => {
-          await orderGlobal.store({
-            ...DEFAULT_ORDER,
-            shortNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderGlobal.read()
-          expect(value.shortNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderGlobal.store({
-              ...DEFAULT_ORDER,
-              shortNeg: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderGlobal, 'OrderStorageInvalidError')
-        })
-      })
-    })
   })
 
   describe('local', () => {
@@ -234,132 +94,6 @@ describe('Order', () => {
         expect(value.shortNeg).to.equal(0)
         expect(value.protection).to.equal(1)
         expect(value.invalidation).to.equal(13)
-      })
-
-      context('.makerPos', async () => {
-        const STORAGE_SIZE = 62
-        it('saves if in range', async () => {
-          await orderLocal.store({
-            ...DEFAULT_ORDER,
-            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderLocal.read()
-          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderLocal.store({
-              ...DEFAULT_ORDER,
-              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderLocal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.makerNeg', async () => {
-        const STORAGE_SIZE = 62
-        it('saves if in range', async () => {
-          await orderLocal.store({
-            ...DEFAULT_ORDER,
-            makerNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderLocal.read()
-          expect(value.makerNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderLocal.store({
-              ...DEFAULT_ORDER,
-              makerNeg: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderLocal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.longPos', async () => {
-        const STORAGE_SIZE = 62
-        it('saves if in range', async () => {
-          await orderLocal.store({
-            ...DEFAULT_ORDER,
-            longPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderLocal.read()
-          expect(value.longPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderLocal.store({
-              ...DEFAULT_ORDER,
-              longPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderLocal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.longNeg', async () => {
-        const STORAGE_SIZE = 62
-        it('saves if in range', async () => {
-          await orderLocal.store({
-            ...DEFAULT_ORDER,
-            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderLocal.read()
-          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderLocal.store({
-              ...DEFAULT_ORDER,
-              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderLocal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.shortPos', async () => {
-        const STORAGE_SIZE = 62
-        it('saves if in range', async () => {
-          await orderLocal.store({
-            ...DEFAULT_ORDER,
-            shortPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderLocal.read()
-          expect(value.shortPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderLocal.store({
-              ...DEFAULT_ORDER,
-              shortPos: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderLocal, 'OrderStorageInvalidError')
-        })
-      })
-
-      context('.shortNeg', async () => {
-        const STORAGE_SIZE = 62
-        it('saves if in range', async () => {
-          await orderLocal.store({
-            ...DEFAULT_ORDER,
-            shortNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
-          })
-          const value = await orderLocal.read()
-          expect(value.shortNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
-        })
-
-        it('reverts if currentId out of range', async () => {
-          await expect(
-            orderLocal.store({
-              ...DEFAULT_ORDER,
-              shortNeg: BigNumber.from(2).pow(STORAGE_SIZE),
-            }),
-          ).to.be.revertedWithCustomError(orderLocal, 'OrderStorageInvalidError')
-        })
       })
 
       context('.protection', async () => {
@@ -829,6 +563,132 @@ describe('Order', () => {
         })
       })
 
+      context('.makerPos', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await order.store({
+            ...DEFAULT_ORDER,
+            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await order.read()
+          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if currentId out of range', async () => {
+          await expect(
+            order.store({
+              ...DEFAULT_ORDER,
+              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
+        })
+      })
+
+      context('.makerNeg', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await order.store({
+            ...DEFAULT_ORDER,
+            makerNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await order.read()
+          expect(value.makerNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if currentId out of range', async () => {
+          await expect(
+            order.store({
+              ...DEFAULT_ORDER,
+              makerNeg: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
+        })
+      })
+
+      context('.longPos', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await order.store({
+            ...DEFAULT_ORDER,
+            longPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await order.read()
+          expect(value.longPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if currentId out of range', async () => {
+          await expect(
+            order.store({
+              ...DEFAULT_ORDER,
+              longPos: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
+        })
+      })
+
+      context('.longNeg', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await order.store({
+            ...DEFAULT_ORDER,
+            makerPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await order.read()
+          expect(value.makerPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if currentId out of range', async () => {
+          await expect(
+            order.store({
+              ...DEFAULT_ORDER,
+              makerPos: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
+        })
+      })
+
+      context('.shortPos', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await order.store({
+            ...DEFAULT_ORDER,
+            shortPos: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await order.read()
+          expect(value.shortPos).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if currentId out of range', async () => {
+          await expect(
+            order.store({
+              ...DEFAULT_ORDER,
+              shortPos: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
+        })
+      })
+
+      context('.shortNeg', async () => {
+        const STORAGE_SIZE = 64
+        it('saves if in range', async () => {
+          await order.store({
+            ...DEFAULT_ORDER,
+            shortNeg: BigNumber.from(2).pow(STORAGE_SIZE).sub(1),
+          })
+          const value = await order.read()
+          expect(value.shortNeg).to.equal(BigNumber.from(2).pow(STORAGE_SIZE).sub(1))
+        })
+
+        it('reverts if currentId out of range', async () => {
+          await expect(
+            order.store({
+              ...DEFAULT_ORDER,
+              shortNeg: BigNumber.from(2).pow(STORAGE_SIZE),
+            }),
+          ).to.be.revertedWithCustomError(order, 'OrderStorageInvalidError')
+        })
+      })
+
       context('.makerReferral', async () => {
         const STORAGE_SIZE = 64
         it('saves if in range', async () => {
@@ -1261,20 +1121,25 @@ describe('Order', () => {
       })
     })
 
-    describe('#magnitude', () => {
-      it('calculate order magnitude', async () => {
-        await order.store({
-          ...DEFAULT_ORDER,
-          makerPos: 10,
-          makerNeg: 5,
-          longPos: 10,
-          longNeg: 5,
-          shortPos: 10,
-          shortNeg: 5,
-        })
-        const result = await order.magnitude()
+    describe('#crossesZero', () => {
+      it('crosses zero (long)', async () => {
+        await order.store({ ...DEFAULT_ORDER, longPos: 4, shortPos: 7, shortNeg: 8 })
+        expect(await order.crossesZero()).to.equal(true)
+      })
 
-        expect(result).to.equals(15)
+      it('crosses zero (short)', async () => {
+        await order.store({ ...DEFAULT_ORDER, longPos: 4, longNeg: 5, shortPos: 7 })
+        expect(await order.crossesZero()).to.equal(true)
+      })
+
+      it('doesnt crosses zero (long)', async () => {
+        await order.store({ ...DEFAULT_ORDER, longPos: 4, longNeg: 5 })
+        expect(await order.crossesZero()).to.equal(false)
+      })
+
+      it('doesnt crosses zero (short)', async () => {
+        await order.store({ ...DEFAULT_ORDER, longPos: 4, longNeg: 5 })
+        expect(await order.crossesZero()).to.equal(false)
       })
     })
   }


### PR DESCRIPTION
Relaxes the invariant to allow taker orders to cross zero when there are no local pending amm orders (`.invalidation == 0`).

**Note**: This PR does not enable us to place zero-cross orders yet, so testing is limited to not violating any current specification with existing non-zero-cross flows. The final PR in this series will enable zero-cross orders and contain additional test cases for these.

#### Migration Note
- Must settle up all outstanding local orders