### PR TITLE
Fill intent order via signed message

### DIFF
--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -178,7 +178,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
         bytes memory solverSignature
     ) external nonReentrant whenNotPaused {
         if (fill.intent.fee.gt(UFixed6Lib.ONE)) revert MarketInvalidIntentFeeError();
-        // TODO: confirm market on Fill and Intent matches
 
         verifier.verifyIntent(fill.intent, traderSignature);
         verifier.verifyFill(fill, solverSignature);
@@ -192,7 +191,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             address(0),
             UFixed6Lib.ZERO,
             UFixed6Lib.ZERO,
-            true, // TODO: remove after PR#529 merged
             false
         ); // solver
         _updateIntent(
@@ -204,7 +202,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             fill.intent.solver,
             fill.intent.fee,
             fill.intent.collateralization,
-            false, // TODO: remove after PR#529 merged
             true
         ); // trader
     }

--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -20,6 +20,7 @@ import { Version, VersionStorage } from "./types/Version.sol";
 import { Order, OrderLib, OrderStorageGlobal, OrderStorageLocal } from "./types/Order.sol";
 import { Guarantee, GuaranteeLib, GuaranteeStorageGlobal, GuaranteeStorageLocal } from "./types/Guarantee.sol";
 import { Checkpoint, CheckpointStorage } from "./types/Checkpoint.sol";
+import { Fill } from "./types/Fill.sol";
 import { Intent } from "./types/Intent.sol";
 import { Take } from "./types/Take.sol";
 import { OracleVersion } from "./types/OracleVersion.sol";
@@ -171,6 +172,43 @@ contract Market is IMarket, Instance, ReentrancyGuard {
             false,
             true
         ); // signer
+    }
+
+    function update(
+        Fill calldata fill,
+        bytes memory traderSignature,
+        bytes memory solverSignature
+    ) external nonReentrant whenNotPaused {
+        if (fill.intent.fee.gt(UFixed6Lib.ONE)) revert MarketInvalidIntentFeeError();
+        // TODO: confirm market on Fill and Intent matches
+
+        verifier.verifyIntent(fill.intent, traderSignature);
+        verifier.verifyFill(fill, solverSignature);
+
+        _updateIntent(
+            fill.common.account,
+            fill.common.signer,
+            fill.intent.amount.mul(Fixed6Lib.NEG_ONE),
+            fill.intent.price,
+            address(0),
+            address(0),
+            UFixed6Lib.ZERO,
+            UFixed6Lib.ZERO,
+            true, // TODO: remove after PR#529 merged
+            false
+        ); // solver
+        _updateIntent(
+            fill.intent.common.account,
+            fill.intent.common.signer,
+            fill.intent.amount,
+            fill.intent.price,
+            fill.intent.originator,
+            fill.intent.solver,
+            fill.intent.fee,
+            fill.intent.collateralization,
+            false, // TODO: remove after PR#529 merged
+            true
+        ); // trader
     }
 
     /// @notice Updates the account's taker position without collateral change

--- a/packages/core/contracts/Verifier.sol
+++ b/packages/core/contracts/Verifier.sol
@@ -9,6 +9,7 @@ import { Initializable } from "@equilibria/root/attribute/Initializable.sol";
 
 import { IVerifier } from "./interfaces/IVerifier.sol";
 import { IMarketFactorySigners } from "./interfaces/IMarketFactorySigners.sol";
+import { Fill, FillLib } from "./types/Fill.sol";
 import { Intent, IntentLib } from "./types/Intent.sol";
 import { Take, TakeLib } from "./types/Take.sol";
 import { OperatorUpdate, OperatorUpdateLib } from "./types/OperatorUpdate.sol";
@@ -35,6 +36,18 @@ contract Verifier is VerifierBase, IVerifier, Initializable {
     /// @param marketFactory_ The market factory
     function initialize(IMarketFactorySigners marketFactory_) external initializer(1) {
         marketFactory = marketFactory_;
+    }
+
+    /// @notice Verifies the signature of a request to fill an intent order
+    function verifyFill(Fill calldata fill, bytes calldata signature)
+        external
+        validateAndCancel(fill.common, signature)
+    {
+        if (!SignatureChecker.isValidSignatureNow(
+            fill.common.signer,
+            _hashTypedDataV4(FillLib.hash(fill)),
+            signature
+        )) revert VerifierInvalidSignerError();
     }
 
     /// @notice Verifies the signature of an intent order type

--- a/packages/core/contracts/interfaces/IVerifier.sol
+++ b/packages/core/contracts/interfaces/IVerifier.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import { IVerifierBase } from "@equilibria/root/verifier/interfaces/IVerifierBase.sol";
 import { Common } from "@equilibria/root/verifier/types/Common.sol";
+import { Fill } from "../types/Fill.sol";
 import { Intent } from "../types/Intent.sol";
 import { Take } from "../types/Take.sol";
 import { OperatorUpdate } from "../types/OperatorUpdate.sol";
@@ -10,6 +11,7 @@ import { SignerUpdate } from "../types/SignerUpdate.sol";
 import { AccessUpdateBatch } from "../types/AccessUpdateBatch.sol";
 
 interface IVerifier is IVerifierBase {
+    function verifyFill(Fill calldata fill, bytes calldata signature) external;
     function verifyIntent(Intent calldata intent, bytes calldata signature) external;
     function verifyTake(Take calldata marketUpdateTaker, bytes calldata signature) external;
     function verifyOperatorUpdate(OperatorUpdate calldata operatorUpdate, bytes calldata signature) external;

--- a/packages/core/contracts/types/Fill.sol
+++ b/packages/core/contracts/types/Fill.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
+import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
+import { Common, CommonLib } from "@equilibria/root/verifier/types/Common.sol";
+import { Intent, IntentLib } from "./Intent.sol";
+
+/// @notice Market update which fills an intent using a signed message
+struct Fill {
+    /// @dev Message signed by the trader
+    Intent intent;
+
+    /// @dev Identifies the solver of the intent
+    Common common;
+}
+using FillLib for Fill global;
+
+/// @notice Library used to hash requests and verify message signatures
+library FillLib {
+    /// @dev Used to verify a signed message
+    bytes32 constant public STRUCT_HASH = keccak256(
+        "Fill(Intent intent,Common common)"
+        "Common(address account,address signer,address domain,uint256 nonce,uint256 group,uint256 expiry)"
+        "Intent(int256 amount,int256 price,uint256 fee,address originator,address solver,uint256 collateralization,Common common)"
+    );
+
+    /// @dev Used to create a signed message
+    function hash(Fill memory self) internal pure returns (bytes32) {
+        return keccak256(abi.encode(STRUCT_HASH, IntentLib.hash(self.intent), CommonLib.hash(self.common)));
+    }
+}

--- a/packages/core/test/helpers/erc712.ts
+++ b/packages/core/test/helpers/erc712.ts
@@ -2,6 +2,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import {
   AccessUpdateBatchStruct,
   CommonStruct,
+  FillStruct,
   GroupCancellationStruct,
   IntentStruct,
   TakeStruct,
@@ -20,7 +21,7 @@ export function erc721Domain(verifier: IVerifier | Verifier | FakeContract<IVeri
   }
 }
 
-const commonType = {
+const COMMON_TYPE = {
   Common: [
     { name: 'account', type: 'address' },
     { name: 'signer', type: 'address' },
@@ -31,16 +32,45 @@ const commonType = {
   ],
 }
 
+const INTENT_TYPE = {
+  Intent: [
+    { name: 'amount', type: 'int256' },
+    { name: 'price', type: 'int256' },
+    { name: 'fee', type: 'uint256' },
+    { name: 'originator', type: 'address' },
+    { name: 'solver', type: 'address' },
+    { name: 'collateralization', type: 'uint256' },
+    { name: 'common', type: 'Common' },
+  ],
+}
+
 export async function signCommon(
   signer: SignerWithAddress,
   verifier: IVerifier | Verifier | FakeContract<IVerifier>,
   common: CommonStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
+    ...COMMON_TYPE,
   }
 
   return await signer._signTypedData(erc721Domain(verifier), types, common)
+}
+
+export async function signFill(
+  signer: SignerWithAddress,
+  verifier: IVerifier | Verifier | FakeContract<IVerifier>,
+  fill: FillStruct,
+): Promise<string> {
+  const types = {
+    ...COMMON_TYPE,
+    Fill: [
+      { name: 'intent', type: 'Intent' },
+      { name: 'common', type: 'Common' },
+    ],
+    ...INTENT_TYPE,
+  }
+
+  return await signer._signTypedData(erc721Domain(verifier), types, fill)
 }
 
 export async function signIntent(
@@ -49,16 +79,8 @@ export async function signIntent(
   intent: IntentStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
-    Intent: [
-      { name: 'amount', type: 'int256' },
-      { name: 'price', type: 'int256' },
-      { name: 'fee', type: 'uint256' },
-      { name: 'originator', type: 'address' },
-      { name: 'solver', type: 'address' },
-      { name: 'collateralization', type: 'uint256' },
-      { name: 'common', type: 'Common' },
-    ],
+    ...COMMON_TYPE,
+    ...INTENT_TYPE,
   }
 
   return await signer._signTypedData(erc721Domain(verifier), types, intent)
@@ -70,7 +92,7 @@ export async function signTake(
   marketUpdate: TakeStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
+    ...COMMON_TYPE,
     Take: [
       { name: 'amount', type: 'int256' },
       { name: 'referrer', type: 'address' },
@@ -87,7 +109,7 @@ export async function signGroupCancellation(
   groupCancellation: GroupCancellationStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
+    ...COMMON_TYPE,
     GroupCancellation: [
       { name: 'group', type: 'uint256' },
       { name: 'common', type: 'Common' },
@@ -103,7 +125,7 @@ export async function signOperatorUpdate(
   operatorUpdate: OperatorUpdateStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
+    ...COMMON_TYPE,
     AccessUpdate: [
       { name: 'accessor', type: 'address' },
       { name: 'approved', type: 'bool' },
@@ -123,7 +145,7 @@ export async function signSignerUpdate(
   signerUpdate: SignerUpdateStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
+    ...COMMON_TYPE,
     AccessUpdate: [
       { name: 'accessor', type: 'address' },
       { name: 'approved', type: 'bool' },
@@ -143,7 +165,7 @@ export async function signAccessUpdateBatch(
   accessUpdateBatch: AccessUpdateBatchStruct,
 ): Promise<string> {
   const types = {
-    ...commonType,
+    ...COMMON_TYPE,
     AccessUpdate: [
       { name: 'accessor', type: 'address' },
       { name: 'approved', type: 'bool' },

--- a/packages/core/test/integration/core/happyPath.test.ts
+++ b/packages/core/test/integration/core/happyPath.test.ts
@@ -1967,7 +1967,7 @@ describe('Happy Path', () => {
         },
         {
           ...DEFAULT_GUARANTEE,
-          orders: 0,
+          orders: 1,
           longPos: POSITION.div(4),
           notional: POSITION.div(4).mul(125),
           takerFee: POSITION.div(4),
@@ -2002,7 +2002,7 @@ describe('Happy Path', () => {
     })
     expectGuaranteeEq(await market.guarantees(userB.address, 1), {
       ...DEFAULT_GUARANTEE,
-      orders: 0,
+      orders: 1,
       longPos: POSITION.div(4),
       notional: POSITION.div(4).mul(125),
       takerFee: POSITION.div(4),

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -19388,7 +19388,7 @@ describe('Market', () => {
               },
               {
                 ...DEFAULT_GUARANTEE,
-                orders: 0,
+                orders: 1,
                 shortPos: POSITION.div(2),
                 notional: -POSITION.div(2).mul(125),
                 takerFee: POSITION.div(2),
@@ -19423,7 +19423,7 @@ describe('Market', () => {
           })
           expectGuaranteeEq(await market.guarantees(userB.address, 1), {
             ...DEFAULT_GUARANTEE,
-            orders: 0,
+            orders: 1,
             shortPos: POSITION.div(2),
             notional: -POSITION.div(2).mul(125),
             takerFee: POSITION.div(2),
@@ -19464,9 +19464,7 @@ describe('Market', () => {
           // check user state
           const EXPECTED_PNL = parse6decimal('10') // position * (125-123)
           const EXPECTED_USER_COLLATERAL = COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).sub(EXPECTED_PNL)
-          const EXPECTED_USERB_COLLATERAL = COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2))
-            .add(EXPECTED_PNL)
-            .sub(SETTLEMENT_FEE.div(2))
+          const EXPECTED_USERB_COLLATERAL = COLLATERAL.sub(EXPECTED_INTEREST_10_123_EFF.div(2)).add(EXPECTED_PNL)
           expectLocalEq(await market.locals(user.address), {
             ...DEFAULT_LOCAL,
             currentId: 1,

--- a/packages/core/test/unit/verifier/Verifier.test.ts
+++ b/packages/core/test/unit/verifier/Verifier.test.ts
@@ -14,6 +14,7 @@ import {
   signSignerUpdate,
   signAccessUpdateBatch,
   signCommon,
+  signFill,
   signTake,
 } from '../../helpers/erc712'
 
@@ -76,6 +77,269 @@ describe('Verifier', () => {
       await expect(verifier.connect(caller2).verifyCommon(commonMessage, signature)).to.be.revertedWithCustomError(
         verifier,
         'VerifierInvalidSignerError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+  })
+
+  describe('#verifyFill', () => {
+    let trader: SignerWithAddress
+    let solver: SignerWithAddress
+
+    beforeEach(async () => {
+      trader = signer
+      solver = caller2
+    })
+
+    const DEFAULT_COMMON = {
+      account: constants.AddressZero,
+      signer: constants.AddressZero,
+      domain: constants.AddressZero,
+      nonce: 0,
+      group: 0,
+      expiry: constants.MaxUint256,
+    }
+    const DEFAULT_FILL = {
+      intent: {
+        amount: parse6decimal('4'),
+        price: parse6decimal('151'),
+        fee: parse6decimal('0.25'),
+        originator: constants.AddressZero,
+        solver: constants.AddressZero,
+        collateralization: parse6decimal('0.3'),
+        common: DEFAULT_COMMON,
+      },
+      common: DEFAULT_COMMON,
+    }
+
+    it('should verify fill message', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        intent: {
+          ...DEFAULT_FILL.intent,
+          common: {
+            ...DEFAULT_FILL.intent.common,
+            account: trader.address,
+            signer: trader.address,
+            domain: market.address,
+            nonce: 6,
+          },
+        },
+        common: {
+          ...DEFAULT_FILL.common,
+          account: solver.address,
+          signer: solver.address,
+          domain: market.address,
+          nonce: 66,
+        },
+      }
+
+      // confirm the intent within is verifiable
+      const intentSignature = await signIntent(trader, verifier, fill.intent)
+      await expect(verifier.connect(market).verifyIntent(fill.intent, intentSignature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(trader.address, 6)
+      expect(await verifier.nonces(trader.address, 6)).to.eq(true)
+
+      // confirm the fill is verifiable
+      const signature = await signFill(solver, verifier, fill)
+      await expect(verifier.connect(market).verifyFill(fill, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(solver.address, 66)
+      expect(await verifier.nonces(solver.address, 66)).to.eq(true)
+    })
+
+    it('should verify fill message w/ sc signer', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        intent: {
+          ...DEFAULT_FILL.intent,
+        },
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: scSigner.address,
+          domain: caller.address,
+        },
+      }
+
+      scSigner.isValidSignature.returns(0x1626ba7e)
+
+      const signature = await signFill(caller, verifier, fill)
+      await expect(verifier.connect(caller).verifyFill(fill, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should reject fill w/ invalid signer', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: market.address,
+          domain: caller.address,
+        },
+      }
+      const signature = await signFill(caller, verifier, fill)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidSignerError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject fill w/ invalid sc signer', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: scSigner.address,
+          domain: caller.address,
+        },
+      }
+      const signature = await signFill(caller, verifier, fill)
+
+      scSigner.isValidSignature.returns(false)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidSignerError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should verify fill w/ expiry', async () => {
+      const now = await time.latest()
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          expiry: now + 2,
+        },
+      } // callstatic & call each take one second
+      const signature = await signFill(caller, verifier, fill)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(caller.address, 0)
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should reject fill w/ invalid expiry', async () => {
+      const now = await time.latest()
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          expiry: now,
+        },
+      }
+      const signature = await signFill(caller, verifier, fill)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidExpiryError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject fill w/ invalid domain', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: market.address,
+        },
+      }
+      const signature = await signFill(caller, verifier, fill)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidDomainError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject fill w/ invalid signature', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+        },
+      }
+      const signature = '0x78fd3b7ec5e96f69e2953bb6f9ba0ca4051e2d37699967630642ce1d8f4ac791'
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidSignatureError',
+      )
+
+      expect(await verifier.nonces(caller.address, 0)).to.eq(false)
+    })
+
+    it('should reject fill w/ invalid nonce', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          nonce: 17,
+        },
+      }
+      const signature = await signFill(caller, verifier, fill)
+
+      await verifier.connect(caller).cancelNonce(17)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidNonceError',
+      )
+
+      expect(await verifier.nonces(caller.address, 17)).to.eq(true)
+    })
+
+    it('should reject fill w/ invalid group', async () => {
+      const fill = {
+        ...DEFAULT_FILL,
+        common: {
+          ...DEFAULT_FILL.common,
+          account: caller.address,
+          signer: caller.address,
+          domain: caller.address,
+          group: 4,
+        },
+      }
+      const signature = await signFill(caller, verifier, fill)
+
+      await verifier.connect(caller).cancelGroup(4)
+
+      await expect(verifier.connect(caller).verifyFill(fill, signature)).to.revertedWithCustomError(
+        verifier,
+        'VerifierInvalidGroupError',
       )
 
       expect(await verifier.nonces(caller.address, 0)).to.eq(false)


### PR DESCRIPTION
In the current implementation, a trader submits the signed intent offchain, and the counterparty "solver" calls an update method to fill the intent.  This change adds a message signed by the solver and submitted to a keeper.  The keeper calls a new update method which fill the trader's intent using both the signature from the trader and solver.

# TODO:
- [x] check coverage
- [x] self-review
- [x] merge with recent changes in target branch
- [x] confirm CI runs cleanly
