### PR TITLE
Relayer support for delta update with signature

### DIFF
--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -170,6 +170,29 @@ export interface SettlementContext {
   orderOracleVersion: OracleVersion
 }
 
+export type Common = {
+  account: string
+  signer: string
+  domain: string
+  nonce: BigNumberish
+  group: BigNumberish
+  expiry: BigNumberish
+}
+
+export interface Take {
+  amount: BigNumberish
+  referrer: string
+  common: Common
+}
+
+export interface SignerUpdate {
+  access: {
+    accessor: string
+    approved: boolean
+  }
+  common: Common
+}
+
 export function expectCheckpointEq(a: Checkpoint, b: Checkpoint): void {
   expect(a.tradeFee).to.equal(b.tradeFee, 'Checkpoint:TradeFee')
   expect(a.settlementFee).to.equal(b.settlementFee, 'Checkpoint:SettlementFee')
@@ -239,6 +262,27 @@ export function expectVersionEq(a: Version, b: Version): void {
   expect(a.takerNegOffset._value).to.equal(b.takerNegOffset._value, 'Version:TakerNegOffset')
   expect(a.settlementFee._value).to.equal(b.settlementFee._value, 'Version:SettlementFee')
   expect(a.liquidationFee._value).to.equal(b.liquidationFee._value, 'Version:LiquidationFee')
+}
+
+export function expectCommonEq(a: Common, b: Common): void {
+  expect(a.account).to.equal(b.account, 'Common:Account')
+  expect(a.signer).to.equal(b.signer, 'Common:Signer')
+  expect(a.domain).to.equal(b.domain, 'Common:Domain')
+  expect(a.nonce).to.equal(b.nonce, 'Common:Nonce')
+  expect(a.group).to.equal(b.group, 'Common:Group')
+  expect(a.expiry).to.equal(b.expiry, 'Common:Expiry')
+}
+
+export function expectTakeEq(a: Take, b: Take): void {
+  expect(a.amount).to.equal(b.amount, 'Take:Amount')
+  expect(a.referrer).to.equal(b.referrer, 'Take:Referrer')
+  expectCommonEq(a.common, b.common)
+}
+
+export function expectSignerUpdateEq(a: SignerUpdate, b: SignerUpdate): void {
+  expect(a.access.accessor).to.equal(b.access.accessor, 'SignerUpdate:Accessor')
+  expect(a.access.approved).to.equal(b.access.approved, 'SignerUpdate:Approved')
+  expectCommonEq(a.common, b.common)
 }
 
 export function parse6decimal(amount: string): BigNumber {

--- a/packages/common/testutil/types.ts
+++ b/packages/common/testutil/types.ts
@@ -185,6 +185,17 @@ export interface Take {
   common: Common
 }
 
+export interface AccessUpdate {
+  accessor: string
+  approved: boolean
+}
+
+export interface AccessUpdateBatch {
+  operators: AccessUpdate[]
+  signers: AccessUpdate[]
+  common: Common
+}
+
 export interface SignerUpdate {
   access: {
     accessor: string
@@ -276,6 +287,20 @@ export function expectCommonEq(a: Common, b: Common): void {
 export function expectTakeEq(a: Take, b: Take): void {
   expect(a.amount).to.equal(b.amount, 'Take:Amount')
   expect(a.referrer).to.equal(b.referrer, 'Take:Referrer')
+  expectCommonEq(a.common, b.common)
+}
+
+export function expectAccessUpdateBatchEq(a: AccessUpdateBatch, b: AccessUpdateBatch): void {
+  expect(a.operators.length).to.equal(b.operators.length, 'AccessUpdateBatch:Operators:length')
+  for (let i = 0; i < a.operators.length; i++) {
+    expect(a.operators[i].accessor).to.equal(b.operators[i].accessor, 'AccessUpdateBatch:Operator:Accessor')
+    expect(a.operators[i].approved).to.equal(b.operators[i].approved, 'AccessUpdateBatch:Operator:Approved')
+  }
+  expect(a.signers.length).to.equal(b.signers.length, 'AccessUpdateBatch:Signers:length')
+  for (let i = 0; i < a.signers.length; i++) {
+    expect(a.signers[i].accessor).to.equal(b.signers[i].accessor, 'AccessUpdateBatch:Signer:Accessor')
+    expect(a.signers[i].approved).to.equal(b.signers[i].approved, 'AccessUpdateBatch:Signer:Approved')
+  }
   expectCommonEq(a.common, b.common)
 }
 

--- a/packages/periphery/contracts/CollateralAccounts/AccountVerifier.sol
+++ b/packages/periphery/contracts/CollateralAccounts/AccountVerifier.sol
@@ -13,6 +13,7 @@ import { DeployAccount, DeployAccountLib } from "./types/DeployAccount.sol";
 import { MarketTransfer, MarketTransferLib } from "./types/MarketTransfer.sol";
 import { RebalanceConfigChange, RebalanceConfigChangeLib } from "./types/RebalanceConfigChange.sol";
 import { Withdrawal, WithdrawalLib } from "./types/Withdrawal.sol";
+import { RelayedTake, RelayedTakeLib } from "./types/RelayedTake.sol";
 import { RelayedNonceCancellation, RelayedNonceCancellationLib } from "./types/RelayedNonceCancellation.sol";
 import { RelayedGroupCancellation, RelayedGroupCancellationLib } from "./types/RelayedGroupCancellation.sol";
 import { RelayedOperatorUpdate, RelayedOperatorUpdateLib } from "./types/RelayedOperatorUpdate.sol";
@@ -33,8 +34,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     /// @inheritdoc IAccountVerifier
     function verifyAction(Action calldata action, bytes calldata signature)
         external
-        validateAndCancel(action.common, signature)
-    {
+        validateAndCancel(action.common, signature) {
         if (!SignatureChecker.isValidSignatureNow(
             action.common.signer,
             _hashTypedDataV4(ActionLib.hash(action)),
@@ -45,8 +45,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     /// @inheritdoc IAccountVerifier
     function verifyDeployAccount(DeployAccount calldata deployAccount, bytes calldata signature)
         external
-        validateAndCancel(deployAccount.action.common, signature)
-    {
+        validateAndCancel(deployAccount.action.common, signature) {
         if (!SignatureChecker.isValidSignatureNow(
             deployAccount.action.common.signer,
             _hashTypedDataV4(DeployAccountLib.hash(deployAccount)),
@@ -57,8 +56,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     /// @inheritdoc IAccountVerifier
     function verifyMarketTransfer(MarketTransfer calldata marketTransfer, bytes calldata signature)
         external
-        validateAndCancel(marketTransfer.action.common, signature)
-    {
+        validateAndCancel(marketTransfer.action.common, signature) {
         if (!SignatureChecker.isValidSignatureNow(
             marketTransfer.action.common.signer,
             _hashTypedDataV4(MarketTransferLib.hash(marketTransfer)),
@@ -69,8 +67,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     /// @inheritdoc IAccountVerifier
     function verifyRebalanceConfigChange(RebalanceConfigChange calldata change, bytes calldata signature)
         external
-        validateAndCancel(change.action.common, signature)
-    {
+        validateAndCancel(change.action.common, signature) {
         if (!SignatureChecker.isValidSignatureNow(
             change.action.common.signer,
             _hashTypedDataV4(RebalanceConfigChangeLib.hash(change)),
@@ -81,8 +78,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     /// @inheritdoc IAccountVerifier
     function verifyWithdrawal(Withdrawal calldata withdrawal, bytes calldata signature)
         external
-        validateAndCancel(withdrawal.action.common, signature)
-    {
+        validateAndCancel(withdrawal.action.common, signature) {
         if (!SignatureChecker.isValidSignatureNow(
             withdrawal.action.common.signer,
             _hashTypedDataV4(WithdrawalLib.hash(withdrawal)),
@@ -91,11 +87,22 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     }
 
     /// @inheritdoc IRelayVerifier
+    function verifyRelayedTake(
+        RelayedTake calldata message,
+        bytes calldata outerSignature
+    ) external validateAndCancel(message.action.common, outerSignature) {
+        if (!SignatureChecker.isValidSignatureNow(
+            message.action.common.signer,
+            _hashTypedDataV4(RelayedTakeLib.hash(message)),
+            outerSignature
+        )) revert VerifierInvalidSignerError();
+    }
+
+    /// @inheritdoc IRelayVerifier
     function verifyRelayedNonceCancellation(
         RelayedNonceCancellation calldata message,
         bytes calldata outerSignature
-    ) external validateAndCancel(message.action.common, outerSignature)
-    {
+    ) external validateAndCancel(message.action.common, outerSignature) {
         if (!SignatureChecker.isValidSignatureNow(
             message.action.common.signer,
             _hashTypedDataV4(RelayedNonceCancellationLib.hash(message)),
@@ -107,8 +114,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     function verifyRelayedGroupCancellation(
         RelayedGroupCancellation calldata message,
         bytes calldata outerSignature
-    ) external validateAndCancel(message.action.common, outerSignature)
-    {
+    ) external validateAndCancel(message.action.common, outerSignature) {
         if (!SignatureChecker.isValidSignatureNow(
             message.action.common.signer,
             _hashTypedDataV4(RelayedGroupCancellationLib.hash(message)),
@@ -120,8 +126,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     function verifyRelayedOperatorUpdate(
         RelayedOperatorUpdate calldata message,
         bytes calldata outerSignature
-    ) external validateAndCancel(message.action.common, outerSignature)
-    {
+    ) external validateAndCancel(message.action.common, outerSignature) {
         if (!SignatureChecker.isValidSignatureNow(
             message.action.common.signer,
             _hashTypedDataV4(RelayedOperatorUpdateLib.hash(message)),
@@ -133,8 +138,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     function verifyRelayedSignerUpdate(
         RelayedSignerUpdate calldata message,
         bytes calldata outerSignature
-    ) external validateAndCancel(message.action.common, outerSignature)
-    {
+    ) external validateAndCancel(message.action.common, outerSignature) {
         if (!SignatureChecker.isValidSignatureNow(
             message.action.common.signer,
             _hashTypedDataV4(RelayedSignerUpdateLib.hash(message)),
@@ -146,8 +150,7 @@ contract AccountVerifier is VerifierBase, IAccountVerifier {
     function verifyRelayedAccessUpdateBatch(
         RelayedAccessUpdateBatch calldata message,
         bytes calldata outerSignature
-    ) external validateAndCancel(message.action.common, outerSignature)
-    {
+    ) external validateAndCancel(message.action.common, outerSignature) {
         if (!SignatureChecker.isValidSignatureNow(
             message.action.common.signer,
             _hashTypedDataV4(RelayedAccessUpdateBatchLib.hash(message)),

--- a/packages/periphery/contracts/CollateralAccounts/interfaces/IRelayVerifier.sol
+++ b/packages/periphery/contracts/CollateralAccounts/interfaces/IRelayVerifier.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { IVerifierBase } from "@equilibria/root/verifier/interfaces/IVerifierBase.sol";
+import { RelayedTake } from "../types/RelayedTake.sol";
 import { RelayedNonceCancellation } from "../types/RelayedNonceCancellation.sol";
 import { RelayedGroupCancellation } from "../types/RelayedGroupCancellation.sol";
 import { RelayedOperatorUpdate } from "../types/RelayedOperatorUpdate.sol";
@@ -10,6 +11,14 @@ import { RelayedAccessUpdateBatch } from "../types/RelayedAccessUpdateBatch.sol"
 
 /// @notice EIP712 signed message verifier for relaying messages through Collateral Accounts Controller.
 interface IRelayVerifier is IVerifierBase {
+    /// @dev Verifies a request to relay an update to a taker position in a market
+    /// @param message Wrapped message adding details needed for keeper compensation
+    /// @param outerSignature EIP712 signature for the preceeding message
+    function verifyRelayedTake(
+        RelayedTake calldata message,
+        bytes calldata outerSignature
+    ) external;
+
     /// @dev Verifies a request to relay a nonce cancellation request
     /// @param message Wrapped message adding details needed for keeper compensation
     /// @param outerSignature EIP712 signature for the preceeding message

--- a/packages/periphery/contracts/CollateralAccounts/interfaces/IRelayer.sol
+++ b/packages/periphery/contracts/CollateralAccounts/interfaces/IRelayer.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import { RelayedTake } from "../types/RelayedTake.sol";
 import { RelayedNonceCancellation } from "../types/RelayedNonceCancellation.sol";
 import { RelayedGroupCancellation } from "../types/RelayedGroupCancellation.sol";
 import { RelayedOperatorUpdate } from "../types/RelayedOperatorUpdate.sol";
@@ -9,6 +10,16 @@ import { RelayedAccessUpdateBatch } from "../types/RelayedAccessUpdateBatch.sol"
 
 // @notice Relays messages to downstream handlers, compensating keepers for the transaction
 interface IRelayer {
+    /// @notice Relays a message to a Market to update a taker position
+    /// @param message Request with details needed for keeper compensation
+    /// @param outerSignature Signature of the RelayedTake message
+    /// @param innerSignature Signature of the embedded Take message, signed by the solver
+    function relayTake(
+        RelayedTake calldata message,
+        bytes calldata outerSignature,
+        bytes calldata innerSignature
+    ) external;
+
     /// @notice Relays a message to Verifier extension to invalidate a nonce
     /// @param message Request with details needed for keeper compensation
     /// @param outerSignature Signature of the RelayedNonceCancellation message

--- a/packages/periphery/contracts/CollateralAccounts/types/RelayedTake.sol
+++ b/packages/periphery/contracts/CollateralAccounts/types/RelayedTake.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { Take, TakeLib } from "@perennial/v2-core/contracts/types/Take.sol";
+import { Action, ActionLib } from "./Action.sol";
+
+/// @notice Relays an update to a taker position using a delta
+struct RelayedTake {
+    /// @dev Message to relay to Market
+    Take take;
+    /// @dev Common information for relayed actions
+    ///      Populate common.domain with the AccountVerifier contract associated with the
+    ///      collateral account Controller.
+    Action action;
+}
+using RelayedTakeLib for RelayedTake global;
+
+library RelayedTakeLib {
+    /// @dev Used to verify a signed message
+    bytes32 constant public STRUCT_HASH = keccak256(
+        "RelayedTake(Take take,Action action)"
+        "Action(uint256 maxFee,Common common)"
+        "Common(address account,address signer,address domain,uint256 nonce,uint256 group,uint256 expiry)"
+        "Take(int256 amount,address referrer,Common common)"
+    );
+
+    /// @dev Used to create a signed message
+    function hash(RelayedTake memory self) internal pure returns (bytes32) {
+        return keccak256(abi.encode(STRUCT_HASH, TakeLib.hash(self.take), ActionLib.hash(self.action)));
+    }
+}

--- a/packages/periphery/test/helpers/CollateralAccounts/eip712.ts
+++ b/packages/periphery/test/helpers/CollateralAccounts/eip712.ts
@@ -14,6 +14,7 @@ import {
   RelayedGroupCancellationStruct,
   RelayedOperatorUpdateStruct,
   RelayedSignerUpdateStruct,
+  RelayedTakeStruct,
 } from '../../../types/generated/contracts/CollateralAccounts/Controller_Incentivized'
 
 function erc721Domain(verifier: IAccountVerifier | FakeContract<IAccountVerifier>): {
@@ -137,6 +138,28 @@ export async function signWithdrawal(
     ],
     ...actionType,
     ...commonType,
+  }
+
+  return await signer._signTypedData(erc721Domain(verifier), types, message)
+}
+
+export async function signRelayedTake(
+  signer: SignerWithAddress,
+  verifier: IAccountVerifier | FakeContract<IAccountVerifier>,
+  message: RelayedTakeStruct,
+): Promise<string> {
+  const types = {
+    RelayedTake: [
+      { name: 'take', type: 'Take' },
+      { name: 'action', type: 'Action' },
+    ],
+    ...actionType,
+    ...commonType,
+    Take: [
+      { name: 'amount', type: 'int256' },
+      { name: 'referrer', type: 'address' },
+      { name: 'common', type: 'Common' },
+    ],
   }
 
   return await signer._signTypedData(erc721Domain(verifier), types, message)

--- a/packages/periphery/test/integration/l2/CollateralAccounts/Arbitrum.test.ts
+++ b/packages/periphery/test/integration/l2/CollateralAccounts/Arbitrum.test.ts
@@ -65,7 +65,7 @@ async function deployController(
 
   const keepConfig = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 357_500, // buffer for handling the keeper fee
+    bufferBase: 385_000, // buffer for handling the keeper fee
     multiplierCalldata: ethers.utils.parseEther('1'),
     bufferCalldata: 0,
   }

--- a/packages/periphery/test/integration/l2/CollateralAccounts/Controller_Incentivized.test.ts
+++ b/packages/periphery/test/integration/l2/CollateralAccounts/Controller_Incentivized.test.ts
@@ -769,7 +769,7 @@ export function RunIncentivizedTests(
         const COLLATERAL_A = parse6decimal('5000')
         await ethMarket
           .connect(userA)
-          [MARKET_UPDATE_DELTA_PROTOTYPE](userA.address, 0, COLLATERAL_A, constants.AddressZero)
+          [MARKET_UPDATE_DELTA_PROTOTYPE](userA.address, 0, COLLATERAL_A, constants.AddressZero, TX_OVERRIDES)
         // userB deposits and opens maker position, adding liquidity to market
         const COLLATERAL_B = parse6decimal('10000')
         const POSITION_B = parse6decimal('2')
@@ -777,7 +777,7 @@ export function RunIncentivizedTests(
         await deployment.fundWalletDSU(userB, utils.parseEther('10000'), TX_OVERRIDES)
         await ethMarket
           .connect(userB)
-          [MARKET_UPDATE_ABSOLUTE_PROTOTYPE](userB.address, POSITION_B, 0, 0, COLLATERAL_B, false)
+          [MARKET_UPDATE_ABSOLUTE_PROTOTYPE](userB.address, POSITION_B, 0, 0, COLLATERAL_B, false, TX_OVERRIDES)
         expectOrderEq(await ethMarket.pending(), {
           ...DEFAULT_ORDER,
           orders: 1,

--- a/packages/periphery/test/integration/l2/CollateralAccounts/Controller_Incentivized.test.ts
+++ b/packages/periphery/test/integration/l2/CollateralAccounts/Controller_Incentivized.test.ts
@@ -8,7 +8,13 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { advanceBlock, currentBlockTimestamp } from '../../../../../common/testutil/time'
 import { getEventArguments } from '../../../../../common/testutil/transaction'
 
-import { parse6decimal } from '../../../../../common/testutil/types'
+import {
+  DEFAULT_GUARANTEE,
+  DEFAULT_ORDER,
+  expectOrderEq,
+  parse6decimal,
+  Take,
+} from '../../../../../common/testutil/types'
 import {
   Account,
   Account__factory,
@@ -29,6 +35,7 @@ import {
   signRelayedNonceCancellation,
   signRelayedOperatorUpdate,
   signRelayedSignerUpdate,
+  signRelayedTake,
   signWithdrawal,
 } from '../../../helpers/CollateralAccounts/eip712'
 import {
@@ -37,15 +44,20 @@ import {
   signCommon as signNonceCancellation,
   signOperatorUpdate,
   signSignerUpdate,
+  signTake,
 } from '@perennial/v2-core/test/helpers/erc712'
 import { Verifier, Verifier__factory } from '@perennial/v2-core/types/generated'
 import { AggregatorV3Interface } from '@perennial/v2-oracle/types/generated'
 import { DeploymentVars } from './setupTypes'
 import { advanceToPrice } from '../../../helpers/oracleHelpers'
+import { RelayedTakeStruct } from '../../../../types/generated/contracts/CollateralAccounts/AccountVerifier'
 
 const { ethers } = HRE
 
 const DEFAULT_MAX_FEE = parse6decimal('0.5')
+
+const MARKET_UPDATE_ABSOLUTE_PROTOTYPE = 'update(address,uint256,uint256,uint256,int256,bool)'
+const MARKET_UPDATE_DELTA_PROTOTYPE = 'update(address,int256,int256,address)'
 
 // hack around issues estimating gas for instrumented contracts when running tests under coverage
 // also, need higher gasLimit to deploy incentivized controllers with optimizer disabled
@@ -227,6 +239,7 @@ export function RunIncentivizedTests(
 
       // fund userA
       await dsu.connect(userA).approve(ethMarket.address, constants.MaxUint256, { maxFeePerGas: 100000000 })
+      await deployment.fundWalletDSU(userA, utils.parseEther('5000'), TX_OVERRIDES)
       await deployment.fundWalletUSDC(userA, parse6decimal('50000'), { maxFeePerGas: 100000000 })
     }
 
@@ -749,6 +762,79 @@ export function RunIncentivizedTests(
       afterEach(async () => {
         // confirm keeper earned their fee
         await checkCompensation()
+      })
+
+      it('relays take messages', async () => {
+        // user deposits into the market
+        const COLLATERAL_A = parse6decimal('5000')
+        await ethMarket
+          .connect(userA)
+          [MARKET_UPDATE_DELTA_PROTOTYPE](userA.address, 0, COLLATERAL_A, constants.AddressZero)
+        // userB deposits and opens maker position, adding liquidity to market
+        const COLLATERAL_B = parse6decimal('10000')
+        const POSITION_B = parse6decimal('2')
+        await dsu.connect(userB).approve(ethMarket.address, constants.MaxUint256, TX_OVERRIDES)
+        await deployment.fundWalletDSU(userB, utils.parseEther('10000'), TX_OVERRIDES)
+        await ethMarket
+          .connect(userB)
+          [MARKET_UPDATE_ABSOLUTE_PROTOTYPE](userB.address, POSITION_B, 0, 0, COLLATERAL_B, false)
+        expectOrderEq(await ethMarket.pending(), {
+          ...DEFAULT_ORDER,
+          orders: 1,
+          collateral: COLLATERAL_A.add(COLLATERAL_B),
+          makerPos: POSITION_B,
+        })
+
+        // userA signs a message to establish a long position
+        const POSITION_A = parse6decimal('1.5')
+        const take: Take = {
+          amount: POSITION_A,
+          referrer: constants.AddressZero,
+          common: {
+            account: userA.address,
+            signer: userA.address,
+            domain: ethMarket.address,
+            nonce: nextNonce(),
+            group: 0,
+            expiry: (await currentBlockTimestamp()) + 12,
+          },
+        }
+        const innerSignature = await signTake(userA, downstreamVerifier, take)
+
+        // userA signs a request to relay the take message
+        const relayedTake: RelayedTakeStruct = {
+          take: take,
+          ...createAction(userA.address, userA.address),
+        }
+        const outerSignature = await signRelayedTake(userA, accountVerifier, relayedTake)
+
+        // perform the action
+        await expect(controller.connect(keeper).relayTake(relayedTake, outerSignature, innerSignature, TX_OVERRIDES))
+          .to.emit(ethMarket, 'OrderCreated')
+          .withArgs(
+            userA.address,
+            anyValue,
+            { ...DEFAULT_GUARANTEE },
+            constants.AddressZero,
+            constants.AddressZero,
+            constants.AddressZero,
+          )
+          .to.emit(controller, 'KeeperCall')
+          .withArgs(keeper.address, anyValue, 0, anyValue, anyValue, anyValue)
+
+        expectOrderEq(await ethMarket.pending(), {
+          ...DEFAULT_ORDER,
+          orders: 2,
+          collateral: COLLATERAL_A.add(COLLATERAL_B),
+          makerPos: POSITION_B,
+          longPos: POSITION_A,
+        })
+        expectOrderEq(await ethMarket.pendings(userA.address), {
+          ...DEFAULT_ORDER,
+          orders: 1,
+          collateral: COLLATERAL_A,
+          longPos: POSITION_A,
+        })
       })
 
       it('relays nonce cancellation messages', async () => {

--- a/packages/periphery/test/unit/CollateralAccounts/Controller_Incentivized.test.ts
+++ b/packages/periphery/test/unit/CollateralAccounts/Controller_Incentivized.test.ts
@@ -1,0 +1,181 @@
+import HRE from 'hardhat'
+import { expect } from 'chai'
+import { Address } from 'hardhat-deploy/dist/types'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { FakeContract, smock } from '@defi-wonderland/smock'
+import { BigNumber, constants, utils } from 'ethers'
+
+import { signTake } from '@perennial/v2-core/test/helpers/erc712'
+import { IMarket, IMarketFactory, IVerifier } from '@perennial/v2-core/types/generated'
+import { TakeStruct } from '@perennial/v2-core/types/generated/contracts/Market'
+
+import { currentBlockTimestamp } from '../../../../common/testutil/time'
+import { getEventArguments } from '../../../../common/testutil/transaction'
+import { parse6decimal } from '../../../../common/testutil/types'
+import { signDeployAccount, signRelayedTake } from '../../helpers/CollateralAccounts/eip712'
+import {
+  IAccount,
+  IAccount__factory,
+  IERC20,
+  IERC20Metadata,
+  IEmptySetReserve,
+  IAccountVerifier,
+  AccountVerifier__factory,
+  Controller_Incentivized,
+  Account__factory,
+  Controller_Arbitrum__factory,
+  AggregatorV3Interface,
+  ArbGasInfo,
+} from '../../../types/generated'
+import { RelayedTakeStruct } from '../../../types/generated/contracts/CollateralAccounts/AccountVerifier'
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs'
+const { ethers } = HRE
+
+const COMMON_PROTOTYPE = '(address,address,address,uint256,uint256,uint256)'
+const KEEP_CONFIG = '(uint256,uint256,uint256,uint256)'
+const MARKET_UPDATE_TAKE_PROTOTYPE = `update((int256,address,${COMMON_PROTOTYPE}),bytes)`
+
+describe('Controller', () => {
+  let controller: Controller_Incentivized
+  let marketFactory: FakeContract<IMarketFactory>
+  let marketVerifier: FakeContract<IVerifier>
+  let verifier: IAccountVerifier
+  let owner: SignerWithAddress
+  let userA: SignerWithAddress
+  let userB: SignerWithAddress
+  let lastNonce = 0
+
+  // create a default action for the specified user with reasonable fee and expiry
+  async function createAction(
+    userAddress: Address,
+    signerAddress = userAddress,
+    maxFee = utils.parseEther('0.2'),
+    expiresInSeconds = 6,
+  ) {
+    return {
+      action: {
+        maxFee: maxFee,
+        common: {
+          account: userAddress,
+          signer: signerAddress,
+          domain: controller.address,
+          nonce: nextNonce(),
+          group: 0,
+          expiry: (await currentBlockTimestamp()) + expiresInSeconds,
+        },
+      },
+    }
+  }
+
+  // deploys a collateral account for the specified user and returns the address
+  async function createCollateralAccount(user: SignerWithAddress): Promise<IAccount> {
+    const deployAccountMessage = {
+      ...(await createAction(user.address)),
+    }
+    const signatureCreate = await signDeployAccount(user, verifier, deployAccountMessage)
+    const tx = await controller.connect(user).deployAccountWithSignature(deployAccountMessage, signatureCreate)
+    // verify the address from event arguments
+    const creationArgs = await getEventArguments(tx, 'AccountDeployed')
+    const accountAddress = await controller.getAccountAddress(user.address)
+    expect(creationArgs.account).to.equal(accountAddress)
+    return IAccount__factory.connect(accountAddress, user)
+  }
+
+  // create a serial nonce for testing purposes; real users may choose a nonce however they please
+  function nextNonce(): BigNumber {
+    lastNonce += 1
+    return BigNumber.from(lastNonce)
+  }
+
+  const fixture = async () => {
+    ;[owner, userA, userB] = await ethers.getSigners()
+    const usdc = await smock.fake<IERC20>('IERC20')
+    const dsu = await smock.fake<IERC20>('IERC20')
+    const reserve = await smock.fake<IEmptySetReserve>('IEmptySetReserve')
+    marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
+    marketVerifier = await smock.fake<IVerifier>('IVerifier')
+
+    const accountImpl = await new Account__factory(owner).deploy(usdc.address, dsu.address, reserve.address)
+    accountImpl.initialize(constants.AddressZero)
+    controller = await new Controller_Arbitrum__factory(owner).deploy(
+      accountImpl.address,
+      marketFactory.address,
+      await marketFactory.verifier(),
+    )
+
+    // fake arbitrum gas calls used by Kept, required for Controller_Arbitrum,
+    // a concrete implementation of abstract Controller_Incentivized contract
+    const gasInfo = await smock.fake<ArbGasInfo>('ArbGasInfo', {
+      address: '0x000000000000000000000000000000000000006C',
+    })
+    gasInfo.getL1BaseFeeEstimate.returns(1)
+
+    const chainlink = await smock.fake<AggregatorV3Interface>('AggregatorV3Interface')
+    verifier = await new AccountVerifier__factory(owner).deploy(marketFactory.address)
+    const keepConfig = {
+      multiplierBase: ethers.utils.parseEther('1'),
+      bufferBase: 0,
+      multiplierCalldata: ethers.utils.parseEther('1'),
+      bufferCalldata: 0,
+    }
+
+    await controller[`initialize(address,address,${KEEP_CONFIG},${KEEP_CONFIG},${KEEP_CONFIG})`](
+      verifier.address,
+      chainlink.address,
+      keepConfig,
+      keepConfig,
+      keepConfig,
+    )
+
+    // assume all token transfers are successful, including those used to compensate keepers
+    dsu.transferFrom.returns(true)
+    dsu.transfer.returns(true)
+  }
+
+  beforeEach(async () => {
+    await loadFixture(fixture)
+  })
+
+  describe('#relayer', () => {
+    it('relays a message for a taker to update their market position with a delta', async () => {
+      // create a collateral account for the taker
+      const account = await createCollateralAccount(userA)
+      // create a market in which taker position should be adjusted
+      const dsu = await smock.fake<IERC20Metadata>('IERC20Metadata')
+      const market = await smock.fake<IMarket>('IMarket')
+
+      // taker (userA) creates and signs the inner message
+      const take: TakeStruct = {
+        amount: parse6decimal('7.5'),
+        referrer: constants.AddressZero,
+        common: {
+          account: userA.address,
+          signer: userA.address,
+          domain: market.address,
+          nonce: nextNonce(),
+          group: 0,
+          expiry: (await currentBlockTimestamp()) + 12,
+        },
+      }
+      const innerSignature = await signTake(userA, marketVerifier, take)
+
+      // relayer (userB) creates and signs the outer message
+      const relayTake: RelayedTakeStruct = {
+        take: take,
+        ...(await createAction(userB.address)),
+      }
+      const outerSignature = await signRelayedTake(userB, verifier, relayTake)
+
+      // relayer relays the message
+      expect(await controller.connect(userB).relayTake(relayTake, outerSignature, innerSignature)).to.not.be.reverted
+
+      // TODO: find a cleaner way to compare these structs, maybe using the expectEq pattern
+      const actualTake = market[MARKET_UPDATE_TAKE_PROTOTYPE].getCall(0).args[0] as TakeStruct
+      expect(actualTake.amount).to.equal(take.amount)
+      expect(actualTake.referrer).to.equal(take.referrer)
+      //expect(actualTake.common).to.deep.contain(take.common) // FIXME: this doesn't work
+      expect(market[MARKET_UPDATE_TAKE_PROTOTYPE].getCall(0).args[1]).to.equal(innerSignature)
+    })
+  })
+})

--- a/packages/periphery/test/unit/CollateralAccounts/Verifier.test.ts
+++ b/packages/periphery/test/unit/CollateralAccounts/Verifier.test.ts
@@ -17,6 +17,7 @@ import {
   signRelayedNonceCancellation,
   signRelayedOperatorUpdate,
   signRelayedSignerUpdate,
+  signRelayedTake,
   signWithdrawal,
 } from '../../helpers/CollateralAccounts/eip712'
 import {
@@ -25,12 +26,17 @@ import {
   signCommon as signNonceCancellation,
   signOperatorUpdate,
   signSignerUpdate,
+  signTake,
 } from '@perennial/v2-core/test/helpers/erc712'
 import { impersonate } from '../../../../common/testutil'
 import { currentBlockTimestamp } from '../../../../common/testutil/time'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { Verifier, Verifier__factory } from '@perennial/v2-core/types/generated'
 import { AccountVerifier, AccountVerifier__factory, IController, IMarketFactory } from '../../../types/generated'
+import {
+  RelayedTakeStruct,
+  TakeStruct,
+} from '../../../types/generated/contracts/CollateralAccounts/interfaces/IRelayVerifier'
 
 const { ethers } = HRE
 
@@ -38,8 +44,10 @@ describe('Verifier', () => {
   let accountVerifier: AccountVerifier
   let accountVerifierSigner: SignerWithAddress
   let controller: FakeContract<IController>
-  let marketFactory: FakeContract<IMarketFactory>
   let controllerSigner: SignerWithAddress
+  let marketFactory: FakeContract<IMarketFactory>
+  let market: FakeContract<IMarket>
+  let marketSigner: SignerWithAddress
   let owner: SignerWithAddress
   let userA: SignerWithAddress
   let userB: SignerWithAddress
@@ -82,6 +90,8 @@ describe('Verifier', () => {
     accountVerifier = await new AccountVerifier__factory(owner).deploy(marketFactory.address)
     accountVerifierSigner = await impersonate.impersonateWithBalance(accountVerifier.address, utils.parseEther('10'))
     controllerSigner = await impersonate.impersonateWithBalance(controller.address, utils.parseEther('10'))
+    market = await smock.fake('IMarket')
+    marketSigner = await impersonate.impersonateWithBalance(market.address, utils.parseEther('10'))
   }
 
   beforeEach(async () => {
@@ -296,6 +306,37 @@ describe('Verifier', () => {
     beforeEach(async () => {
       downstreamVerifier = await new Verifier__factory(owner).deploy()
       await downstreamVerifier.initialize(marketFactory.address)
+    })
+
+    it('verifies relayedTake messages', async () => {
+      const take: TakeStruct = {
+        amount: parse6decimal('15'),
+        referrer: userC.address,
+        common: {
+          account: userB.address,
+          signer: userB.address,
+          domain: market.address,
+          nonce: 1,
+          group: 0,
+          expiry: currentTime.add(60),
+        },
+      }
+      const innerSignature = await signTake(userB, downstreamVerifier, take)
+      // ensure downstream verification will succeed
+      await expect(downstreamVerifier.connect(marketSigner).verifyTake(take, innerSignature))
+        .to.emit(downstreamVerifier, 'NonceCancelled')
+        .withArgs(userB.address, take.common.nonce)
+
+      // create and sign the outer messsage
+      const relayedTake: RelayedTakeStruct = {
+        take: take,
+        ...createAction(userA.address),
+      }
+      const outerSignature = await signRelayedTake(userA, accountVerifier, relayedTake)
+      // ensure outer message verification succeeds
+      await expect(accountVerifier.connect(controllerSigner).verifyRelayedTake(relayedTake, outerSignature))
+        .to.emit(accountVerifier, 'NonceCancelled')
+        .withArgs(userA.address, relayedTake.action.common.nonce)
     })
 
     it('verifies relayedNonceCancellation messages', async () => {


### PR DESCRIPTION
This PR extends Collateral Accounts incentivized controller to relay a delta take update to the market specified in the inner `Take` message's _domain_ field.  Note that, per requirements, the keeper submitting the transaction is compensated from the collateral account for which the (inner) market update occurs, not from the signer of the outer `RelayedTake` message.  Other relayed messages pay the keeper from the collateral account of the (outer) wrapped message.