### PR TITLE
Trigger Orders Manager contract to compensate keepers and pay interface fees from collateral accounts rather than market

### DIFF
--- a/packages/periphery/README.md
+++ b/packages/periphery/README.md
@@ -84,7 +84,7 @@ For executing orders and handling signed messages, keepers are compensated from 
 ### Usage
 
 #### Users
-All operations may be performed in a gasless manner using signed messages. Users must first deposit collateral into the market in which they wish to interact. This can be done directly or through an extension like _Collateral Accounts_.
+All operations may be performed in a gasless manner using signed messages. Users must create and fund a _Collateral Account_, which will be used to compensate keepers for processing signed messages and for executing orders.  Users must also approve the trigger order _Manager_ contract as an operator for themselves (not for their collateral account).
 
 ##### Actions
 

--- a/packages/periphery/contracts/CollateralAccounts/Controller.sol
+++ b/packages/periphery/contracts/CollateralAccounts/Controller.sol
@@ -8,6 +8,7 @@ import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { Token18 } from "@equilibria/root/token/types/Token18.sol";
 import { Fixed6, Fixed6Lib } from "@equilibria/root/number/types/Fixed6.sol";
 import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
+import { UFixed18, UFixed18Lib } from "@equilibria/root/number/types/UFixed18.sol";
 import { IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
 
 import { IAccount, IMarket } from "./interfaces/IAccount.sol";
@@ -166,6 +167,17 @@ contract Controller is Factory, IController {
         _rebalanceGroup(owner, group);
     }
 
+    /// @inheritdoc IController
+    function chargeFee(address owner, UFixed6 amount) virtual external onlyOperator(owner, msg.sender) {
+        address account = getAccountAddress(owner);
+        UFixed18 transferAmount = UFixed18Lib.from(amount);
+
+        // if the account has insufficient DSU to pay the fee, wrap
+        IAccount(account).wrapIfNecessary(transferAmount, false);
+        // transfer DSU from account to the caller
+        DSU.pullTo(account, msg.sender, transferAmount);
+    }
+
     function _changeRebalanceConfigWithSignature(RebalanceConfigChange calldata configChange, bytes calldata signature) internal {
         // ensure the message was signed by the owner or a delegated signer
         verifier.verifyRebalanceConfigChange(configChange, signature);
@@ -306,5 +318,11 @@ contract Controller is Factory, IController {
             revert ControllerInvalidRebalanceTargetsError();
 
         emit RebalanceGroupConfigured(owner, message.group, message.markets.length);
+    }
+
+    /// @notice Only an operator can call
+    modifier onlyOperator(address owner, address operator) {
+        if (!marketFactory.operators(owner, operator)) revert ControllerNotOperatorError();
+        _;
     }
 }

--- a/packages/periphery/contracts/CollateralAccounts/interfaces/IController.sol
+++ b/packages/periphery/contracts/CollateralAccounts/interfaces/IController.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { Fixed6 } from "@equilibria/root/number/types/Fixed6.sol";
+import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
 import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { Token18 } from "@equilibria/root/token/types/Token18.sol";
 import { IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
@@ -48,6 +49,10 @@ interface IController {
     // sig: 0xdc72f280
     /// @custom:error Group is balanced and ineligible for rebalance
     error ControllerGroupBalancedError();
+
+    // sig: 0x191c84f2
+    /// @custom:error Caller has not be authorized as an operator of the owner of the collateral account
+    error ControllerNotOperatorError();
 
     // sig: 0xbd3648e9
     /// @custom:error A RebalanceConfigChange message had a mismatch in number of markets and configs
@@ -157,4 +162,9 @@ interface IController {
     /// @param withdrawal Message requesting a withdrawal
     /// @param signature ERC712 message signature
     function withdrawWithSignature(Withdrawal calldata withdrawal, bytes calldata signature) external;
+
+    /// @notice Allows an operator to withdraw funds from the owner's account to pay fees
+    /// @param owner Used to determine the collateral account to charge
+    /// @param amount Quantity of DSU to transfer to the sender
+    function chargeFee(address owner, UFixed6 amount) external;
 }

--- a/packages/periphery/contracts/TriggerOrders/Manager.sol
+++ b/packages/periphery/contracts/TriggerOrders/Manager.sol
@@ -266,7 +266,7 @@ abstract contract Manager is IManager, Kept {
 
     /// @notice Only the account or an operator can call
     modifier onlyOperator(address account, address operator) {
-        if (account != operator && !marketFactory.operators(account, operator)) revert ManagerInvalidOperatorError();
+        if (account != operator && !marketFactory.operators(account, operator)) revert ManagerNotOperatorError();
         _;
     }
 }

--- a/packages/periphery/contracts/TriggerOrders/Manager.sol
+++ b/packages/periphery/contracts/TriggerOrders/Manager.sol
@@ -190,7 +190,6 @@ abstract contract Manager is IManager, Kept {
         (IMarket market, address account, UFixed6 maxFee) = abi.decode(data, (IMarket, address, UFixed6));
         UFixed6 raisedKeeperFee = UFixed6Lib.from(amount, true).min(maxFee);
 
-        // _marketWithdraw(market, account, raisedKeeperFee);
         _collateralAccountWithdraw(account, raisedKeeperFee);
 
         return UFixed18Lib.from(raisedKeeperFee);
@@ -217,8 +216,7 @@ abstract contract Manager is IManager, Kept {
             order.interfaceFee.amount :
             order.notionalValue(market, account).mul(order.interfaceFee.amount);
 
-        _marketWithdraw(market, account, feeAmount);
-        //_collateralAccountWithdraw(account, feeAmount);
+        _collateralAccountWithdraw(account, feeAmount);
 
         claimable[order.interfaceFee.receiver] = claimable[order.interfaceFee.receiver].add(feeAmount);
 
@@ -230,12 +228,6 @@ abstract contract Manager is IManager, Kept {
     /// @param amount Quantity of DSU to transfer, converted to 18-decimal by callee
     function _collateralAccountWithdraw(address account, UFixed6 amount) private {
         controller.chargeFee(account, amount);
-    }
-
-    // TODO: replace this method with _collateralAccountWithdraw
-    /// @notice Transfers DSU from market to manager to pay keeper or interface fee
-    function _marketWithdraw(IMarket market, address account, UFixed6 amount) private {
-        market.update(account, UFixed6Lib.MAX, UFixed6Lib.MAX, UFixed6Lib.MAX, Fixed6Lib.from(-1, amount), false);
     }
 
     function _placeOrder(IMarket market, address account, uint256 orderId, TriggerOrder calldata order) private {

--- a/packages/periphery/contracts/TriggerOrders/Manager.sol
+++ b/packages/periphery/contracts/TriggerOrders/Manager.sol
@@ -9,6 +9,7 @@ import { UFixed18, UFixed18Lib } from "@equilibria/root/number/types/UFixed18.so
 import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { IMarket, IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
 
+import { IAccount, IController } from "../CollateralAccounts/interfaces/IController.sol";
 import { IManager } from "./interfaces/IManager.sol";
 import { IOrderVerifier } from "./interfaces/IOrderVerifier.sol";
 import { Action } from "./types/Action.sol";
@@ -35,6 +36,9 @@ abstract contract Manager is IManager, Kept {
     /// @dev Verifies EIP712 messages for this extension
     IOrderVerifier public immutable verifier;
 
+    /// @dev Used for keeper compensation
+    IController public immutable controller;
+
     /// @dev Configuration used for keeper compensation
     KeepConfig public keepConfig;
 
@@ -55,18 +59,21 @@ abstract contract Manager is IManager, Kept {
     /// @param reserve_ DSU reserve contract used for unwrapping
     /// @param marketFactory_ Contract used to validate fee claims
     /// @param verifier_ Used to validate EIP712 signatures
+    /// @param controller_ Collateral Account Controller used for compensating keeper and paying interface fees
     constructor(
         Token6 usdc_,
         Token18 dsu_,
         IEmptySetReserve reserve_,
         IMarketFactory marketFactory_,
-        IOrderVerifier verifier_
+        IOrderVerifier verifier_,
+        IController controller_
     ) {
         USDC = usdc_;
         DSU = dsu_;
         reserve = reserve_;
         marketFactory = marketFactory_;
         verifier = verifier_;
+        controller = controller_;
     }
 
     /// @notice Initialize the contract
@@ -184,6 +191,7 @@ abstract contract Manager is IManager, Kept {
         UFixed6 raisedKeeperFee = UFixed6Lib.from(amount, true).min(maxFee);
 
         _marketWithdraw(market, account, raisedKeeperFee);
+        // _collateralAccountWithdraw(account, raisedKeeperFee);
 
         return UFixed18Lib.from(raisedKeeperFee);
     }
@@ -216,6 +224,13 @@ abstract contract Manager is IManager, Kept {
         return true;
     }
 
+    function _collateralAccountWithdraw(address account, UFixed6 amount) private {
+        IAccount collateralAccount = IAccount(controller.getAccountAddress(account));
+        // TODO: need to do this through Controller and establish trust between Manager and Controller
+        collateralAccount.withdraw(amount, false);
+    }
+
+    // TODO: replace this method with _collateralAccountWithdraw
     /// @notice Transfers DSU from market to manager to pay keeper or interface fee
     function _marketWithdraw(IMarket market, address account, UFixed6 amount) private {
         market.update(account, UFixed6Lib.MAX, UFixed6Lib.MAX, UFixed6Lib.MAX, Fixed6Lib.from(-1, amount), false);

--- a/packages/periphery/contracts/TriggerOrders/Manager_Arbitrum.sol
+++ b/packages/periphery/contracts/TriggerOrders/Manager_Arbitrum.sol
@@ -6,6 +6,7 @@ import { Kept, Kept_Arbitrum, Token18, UFixed18 } from "@equilibria/root/attribu
 import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
 
+import { IController } from "../CollateralAccounts/interfaces/IController.sol";
 import { IOrderVerifier, Manager } from "./Manager.sol";
 
 contract Manager_Arbitrum is Manager, Kept_Arbitrum {
@@ -15,8 +16,9 @@ contract Manager_Arbitrum is Manager, Kept_Arbitrum {
         Token18 dsu,
         IEmptySetReserve reserve,
         IMarketFactory marketFactory,
-        IOrderVerifier verifier
-    ) Manager(usdc, dsu, reserve, marketFactory, verifier) {}
+        IOrderVerifier verifier,
+        IController controller
+    ) Manager(usdc, dsu, reserve, marketFactory, verifier, controller) {}
 
     /// @dev Use the Kept_Arbitrum implementation for calculating the dynamic fee
     function _calldataFee(

--- a/packages/periphery/contracts/TriggerOrders/Manager_Optimism.sol
+++ b/packages/periphery/contracts/TriggerOrders/Manager_Optimism.sol
@@ -6,6 +6,7 @@ import { Kept, Kept_Optimism, Token18, UFixed18 } from "@equilibria/root/attribu
 import { Token6 } from "@equilibria/root/token/types/Token6.sol";
 import { IMarketFactory } from "@perennial/v2-core/contracts/interfaces/IMarketFactory.sol";
 
+import { IController } from "../CollateralAccounts/interfaces/IController.sol";
 import { IOrderVerifier, Manager } from "./Manager.sol";
 
 contract Manager_Optimism is Manager, Kept_Optimism {
@@ -15,8 +16,9 @@ contract Manager_Optimism is Manager, Kept_Optimism {
         Token18 dsu,
         IEmptySetReserve reserve,
         IMarketFactory marketFactory,
-        IOrderVerifier verifier
-    ) Manager(usdc, dsu, reserve, marketFactory, verifier) {}
+        IOrderVerifier verifier,
+        IController controller
+    ) Manager(usdc, dsu, reserve, marketFactory, verifier, controller) {}
 
     /// @dev Use the Kept_Optimism implementation for calculating the dynamic fee
     function _calldataFee(

--- a/packages/periphery/contracts/TriggerOrders/interfaces/IManager.sol
+++ b/packages/periphery/contracts/TriggerOrders/interfaces/IManager.sol
@@ -60,9 +60,9 @@ interface IManager {
     /// @custom:error Signer is not authorized to interact with markets for the specified user
     error ManagerInvalidSignerError();
 
-    // sig: 0x63c7e7fd
+    // sig: 0x13722df5
     /// @custom:error Operator is not authorized to interact with markets for the specified user
-    error ManagerInvalidOperatorError();
+    error ManagerNotOperatorError();
 
     /// @notice Store a new trigger order or replace an existing trigger order
     /// @param market Perennial market in which user wants to change their position

--- a/packages/periphery/test/integration/l2/TriggerOrders/Manager.test.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/Manager.test.ts
@@ -96,17 +96,7 @@ export function RunManagerTests(
       // cost of transaction
       const keeperGasCostInUSD = keeperEthSpentOnGas.mul(2603)
       // keeper should be compensated between 100-200% of actual gas cost
-      // please retain below for debugging purposes
-      console.log(
-        'keeperFeesPaid',
-        keeperFeesPaid.div(1e9).toNumber() / 1e9,
-        'keeperGasCostInUSD',
-        keeperGasCostInUSD.div(1e9).toNumber() / 1e9,
-        'keeperGasUpperLimit',
-        keeperGasCostInUSD.mul(5).div(2e9).toNumber() / 1e9,
-      )
-      // FIXME: need to adjust gas config and rerun
-      // expect(keeperFeesPaid).to.be.within(keeperGasCostInUSD, keeperGasCostInUSD.mul(2))
+      expect(keeperFeesPaid).to.be.within(keeperGasCostInUSD, keeperGasCostInUSD.mul(2))
     }
 
     // commits an oracle version and advances time 10 seconds
@@ -188,14 +178,15 @@ export function RunManagerTests(
           await expect(tx)
             .to.emit(manager, 'TriggerOrderInterfaceFeeCharged')
             .withArgs(user.address, market.address, order.interfaceFee)
+          const collateralAccountAddress = await controller.getAccountAddress(user.address)
           if (order.interfaceFee.unwrap) {
             await expect(tx)
               .to.emit(dsu, 'Transfer')
-              .withArgs(market.address, manager.address, expectedInterfaceFee.mul(1e12))
+              .withArgs(collateralAccountAddress, manager.address, expectedInterfaceFee.mul(1e12))
           } else {
             await expect(tx)
               .to.emit(dsu, 'Transfer')
-              .withArgs(market.address, manager.address, expectedInterfaceFee.mul(1e12))
+              .withArgs(collateralAccountAddress, manager.address, expectedInterfaceFee.mul(1e12))
           }
         }
       }

--- a/packages/periphery/test/integration/l2/TriggerOrders/Manager_Arbitrum.test.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/Manager_Arbitrum.test.ts
@@ -8,16 +8,11 @@ import HRE from 'hardhat'
 import {
   ArbGasInfo,
   IEmptySetReserve__factory,
-  IERC20Metadata,
   IERC20Metadata__factory,
-  IManager,
-  IMarket,
-  IMarketFactory,
   Manager_Arbitrum__factory,
   OrderVerifier__factory,
 } from '../../../../types/generated'
 import { impersonate } from '../../../../../common/testutil'
-import { parse6decimal } from '../../../../../common/testutil/types'
 import {
   createMarketETH,
   deployController,
@@ -73,13 +68,13 @@ const fixture = async (): Promise<FixtureVars> => {
 
   const keepConfig = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 950_000, // buffer for withdrawing keeper fee from market
+    bufferBase: 250_000, // buffer for withdrawing keeper fee from market
     multiplierCalldata: 0,
     bufferCalldata: 0,
   }
   const keepConfigBuffered = {
     multiplierBase: ethers.utils.parseEther('1.05'),
-    bufferBase: 1_875_000, // for price commitment
+    bufferBase: 1_275_000, // for price commitment
     multiplierCalldata: ethers.utils.parseEther('1.05'),
     bufferCalldata: 35_200,
   }

--- a/packages/periphery/test/integration/l2/TriggerOrders/Manager_Arbitrum.test.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/Manager_Arbitrum.test.ts
@@ -19,7 +19,12 @@ import {
 import { impersonate } from '../../../../../common/testutil'
 import { parse6decimal } from '../../../../../common/testutil/types'
 import { transferCollateral } from '../../../helpers/marketHelpers'
-import { createMarketETH, deployProtocol, deployPythOracleFactory } from '../../../helpers/setupHelpers'
+import {
+  createMarketETH,
+  deployController,
+  deployProtocol,
+  deployPythOracleFactory,
+} from '../../../helpers/setupHelpers'
 import { RunManagerTests } from './Manager.test'
 import { FixtureVars } from './setupTypes'
 import {
@@ -75,12 +80,14 @@ const fixture = async (): Promise<FixtureVars> => {
 
   // deploy the order manager
   const verifier = await new OrderVerifier__factory(owner).deploy(marketFactory.address)
+  const controller = await deployController(owner, usdc.address, dsu.address, reserve.address, marketFactory.address)
   const manager = await new Manager_Arbitrum__factory(owner).deploy(
     USDC_ADDRESS,
     dsu.address,
     DSU_RESERVE,
     marketFactory.address,
     verifier.address,
+    controller.address,
   )
 
   const keepConfig = {

--- a/packages/periphery/test/integration/l2/TriggerOrders/Manager_Optimism.test.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/Manager_Optimism.test.ts
@@ -19,7 +19,12 @@ import {
 import { impersonate } from '../../../../../common/testutil'
 import { parse6decimal } from '../../../../../common/testutil/types'
 import { transferCollateral } from '../../../helpers/marketHelpers'
-import { createMarketETH, deployProtocol, deployPythOracleFactory } from '../../../helpers/setupHelpers'
+import {
+  createMarketETH,
+  deployController,
+  deployProtocol,
+  deployPythOracleFactory,
+} from '../../../helpers/setupHelpers'
 import { RunManagerTests } from './Manager.test'
 import { FixtureVars } from './setupTypes'
 import {
@@ -93,12 +98,14 @@ const fixture = async (): Promise<FixtureVars> => {
 
   // deploy the order manager
   const verifier = await new OrderVerifier__factory(owner).deploy(marketFactory.address)
+  const controller = await deployController(owner, usdc.address, dsu.address, reserve.address, marketFactory.address)
   const manager = await new Manager_Optimism__factory(owner).deploy(
     USDC_ADDRESS,
     dsu.address,
     DSU_RESERVE,
     marketFactory.address,
     verifier.address,
+    controller.address,
   )
 
   const keepConfig = {

--- a/packages/periphery/test/integration/l2/TriggerOrders/Manager_Optimism.test.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/Manager_Optimism.test.ts
@@ -17,7 +17,6 @@ import {
   OrderVerifier__factory,
 } from '../../../../types/generated'
 import { impersonate } from '../../../../../common/testutil'
-import { parse6decimal } from '../../../../../common/testutil/types'
 import { transferCollateral } from '../../../helpers/marketHelpers'
 import {
   createMarketETH,
@@ -110,13 +109,13 @@ const fixture = async (): Promise<FixtureVars> => {
 
   const keepConfig = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 750_000, // buffer for withdrawing keeper fee from market
+    bufferBase: 250_000, // buffer for withdrawing keeper fee from market
     multiplierCalldata: 0,
     bufferCalldata: 0,
   }
   const keepConfigBuffered = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 900_000, // for price commitment
+    bufferBase: 650_000, // for price commitment
     multiplierCalldata: ethers.utils.parseEther('1'),
     bufferCalldata: 0,
   }

--- a/packages/periphery/test/integration/l2/TriggerOrders/Manager_Optimism.test.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/Manager_Optimism.test.ts
@@ -122,13 +122,6 @@ const fixture = async (): Promise<FixtureVars> => {
   }
   await manager.initialize(CHAINLINK_ETH_USD_FEED, keepConfig, keepConfigBuffered)
 
-  // fund accounts and deposit all into market
-  const amount = parse6decimal('100000')
-  await setupUser(dsu, marketFactory, market, manager, userA, amount)
-  await setupUser(dsu, marketFactory, market, manager, userB, amount)
-  await setupUser(dsu, marketFactory, market, manager, userC, amount)
-  await setupUser(dsu, marketFactory, market, manager, userD, amount)
-
   await mockGasInfo()
 
   return {
@@ -141,6 +134,7 @@ const fixture = async (): Promise<FixtureVars> => {
     market,
     oracle: marketWithOracle.oracle,
     verifier,
+    controller,
     owner,
     userA,
     userB,
@@ -166,4 +160,4 @@ async function mockGasInfo() {
   gasInfo.decimals.returns(6)
 }
 
-if (process.env.FORK_NETWORK === 'base') RunManagerTests('Manager_Optimism', getFixture)
+if (process.env.FORK_NETWORK === 'base') RunManagerTests('Manager_Optimism', getFixture, fundWalletDSU)

--- a/packages/periphery/test/integration/l2/TriggerOrders/setupTypes.ts
+++ b/packages/periphery/test/integration/l2/TriggerOrders/setupTypes.ts
@@ -1,5 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import {
+  IController,
   IEmptySetReserve,
   IERC20Metadata,
   IKeeperOracle,
@@ -20,6 +21,7 @@ export interface FixtureVars {
   market: IMarket
   oracle: IOracleProvider
   verifier: IOrderVerifier
+  controller: IController
   owner: SignerWithAddress
   userA: SignerWithAddress
   userB: SignerWithAddress

--- a/packages/periphery/test/unit/CollateralAccounts/Controller.test.ts
+++ b/packages/periphery/test/unit/CollateralAccounts/Controller.test.ts
@@ -29,6 +29,10 @@ import { deployController, mockMarket } from '../../helpers/setupHelpers'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { IMarket } from '@perennial/v2-oracle/types/generated'
 import { IMarketFactory } from '@perennial/v2-core/types/generated'
+import {
+  RebalanceConfigChangeStruct,
+  RebalanceConfigStruct,
+} from '../../../types/generated/contracts/CollateralAccounts/AccountVerifier'
 
 const { ethers } = HRE
 
@@ -36,6 +40,9 @@ describe('Controller', () => {
   let controller: Controller
   let marketFactory: FakeContract<IMarketFactory>
   let verifier: IAccountVerifier
+  let usdc: FakeContract<IERC20>
+  let dsu: FakeContract<IERC20>
+  let reserve: FakeContract<IEmptySetReserve>
   let owner: SignerWithAddress
   let userA: SignerWithAddress
   let userB: SignerWithAddress
@@ -86,9 +93,9 @@ describe('Controller', () => {
 
   const fixture = async () => {
     ;[owner, userA, userB, keeper] = await ethers.getSigners()
-    const usdc = await smock.fake<IERC20>('IERC20')
-    const dsu = await smock.fake<IERC20>('IERC20')
-    const reserve = await smock.fake<IEmptySetReserve>('IEmptySetReserve')
+    usdc = await smock.fake<IERC20>('IERC20')
+    dsu = await smock.fake<IERC20>('IERC20')
+    reserve = await smock.fake<IEmptySetReserve>('IEmptySetReserve')
     marketFactory = await smock.fake<IMarketFactory>('IMarketFactory')
 
     controller = await deployController(owner, usdc.address, dsu.address, reserve.address, marketFactory.address)
@@ -219,7 +226,7 @@ describe('Controller', () => {
       return eventArgs.group
     }
 
-    function verifyConfig(actual: RebalanceConfigStructOutput, expected: { target: BigNumber; threshold: BigNumber }) {
+    function verifyConfig(actual: RebalanceConfigStruct, expected: { target: BigNumber; threshold: BigNumber }) {
       expect(actual.target).to.equal(expected.target)
       expect(actual.threshold).to.equal(expected.threshold)
     }
@@ -696,7 +703,7 @@ describe('Controller', () => {
       const market = await mockMarket(weth.address)
 
       // create a collateral account
-      createCollateralAccount(userA)
+      await createCollateralAccount(userA)
 
       // attempt a market transfer to the unsupported market
       const marketTransferMessage = {
@@ -713,6 +720,33 @@ describe('Controller', () => {
       await expect(
         controller.connect(keeper).marketTransferWithSignature(marketTransferMessage, signature),
       ).to.be.revertedWithCustomError(controller, 'ControllerUnsupportedMarketError')
+    })
+
+    it('allows operator to charge a fee', async () => {
+      // create a collateral account
+      const accountA = await createCollateralAccount(userA)
+
+      // reverts if caller is not an operator
+      const FEE = parse6decimal('0.1')
+      marketFactory.operators.whenCalledWith(userA.address, userB.address).returns(false)
+      await expect(controller.connect(userB).chargeFee(userA.address, FEE)).to.be.revertedWithCustomError(
+        controller,
+        'ControllerNotOperatorError',
+      )
+
+      // transfers DSU to caller if balance is sufficient
+      marketFactory.operators.whenCalledWith(userA.address, userB.address).returns(true)
+      dsu.balanceOf.whenCalledWith(accountA.address).returns(FEE.mul(1e12))
+      dsu.transferFrom.whenCalledWith(accountA.address, userB.address, FEE.mul(1e12)).returns(true)
+      await expect(controller.connect(userB).chargeFee(userA.address, FEE)).to.not.be.reverted
+      expect(dsu.transferFrom).to.have.been.calledWith(accountA.address, userB.address, FEE.mul(1e12))
+
+      // wraps USDC if balance is insufficient
+      usdc.balanceOf.whenCalledWith(accountA.address).returns(FEE.mul(2).div(3)) // 2/3 of the fee
+      dsu.balanceOf.whenCalledWith(accountA.address).returns(FEE.mul(1e12).div(2)) // half of the fee
+      await controller.connect(userB).chargeFee(userA.address, FEE)
+      expect(reserve.mint).to.have.been.calledWith(FEE.mul(1e12) /*.div(2)*/) // TODO: div(2) when merging to v2.4 branch
+      expect(dsu.transferFrom).to.have.been.calledWith(accountA.address, userB.address, FEE.mul(1e12))
     })
   })
 

--- a/packages/periphery/test/unit/TriggerOrders/Manager.test.ts
+++ b/packages/periphery/test/unit/TriggerOrders/Manager.test.ts
@@ -408,6 +408,59 @@ describe('Manager', () => {
     })
   })
 
+  describe('#interface-fees', () => {
+    const FIXED_FEE_AMOUNT = parse6decimal('0.25')
+
+    beforeEach(async () => {
+      expect(await manager.claimable(userB.address)).to.equal(0)
+      // userA places an order with an interface fee
+      const orderId = advanceOrderId()
+      const makerOrderWithFee = {
+        ...MAKER_ORDER,
+        interfaceFee: {
+          amount: FIXED_FEE_AMOUNT,
+          receiver: userB.address,
+          fixedFee: true,
+          unwrap: false,
+        },
+      }
+      await manager.connect(userA).placeOrder(market.address, orderId, makerOrderWithFee)
+
+      // keeper executes the order, userB earns their fee
+      await manager.connect(keeper).executeOrder(market.address, userA.address, orderId)
+      expect(await manager.claimable(userB.address)).to.equal(FIXED_FEE_AMOUNT)
+    })
+
+    it('recipient can claim fee', async () => {
+      await manager.connect(userB).claim(userB.address, false)
+      expect(dsu.transfer).to.have.been.calledWith(userB.address, FIXED_FEE_AMOUNT.mul(1e12))
+    })
+
+    it('operator can claim fee', async () => {
+      marketFactory.operators.whenCalledWith(userB.address, userA.address).returns(true)
+      await manager.connect(userA).claim(userB.address, false)
+      expect(dsu.transfer).to.have.been.calledWith(userA.address, FIXED_FEE_AMOUNT.mul(1e12))
+    })
+
+    it('non-operator can not claim fee', async () => {
+      marketFactory.operators.whenCalledWith(userB.address, userA.address).returns(false)
+      await expect(manager.connect(userA).claim(userB.address, false)).to.be.revertedWithCustomError(
+        manager,
+        'ManagerNotOperatorError',
+      )
+    })
+
+    it('fee can be unwrapped', async () => {
+      usdc.balanceOf.reset()
+      usdc.balanceOf.returnsAtCall(0, 0)
+      usdc.balanceOf.returnsAtCall(1, FIXED_FEE_AMOUNT)
+      usdc.transfer.returns(true)
+      await manager.connect(userB).claim(userB.address, true)
+      expect(reserve.redeem).to.have.been.calledWith(FIXED_FEE_AMOUNT.mul(1e12))
+      expect(usdc.transfer).to.have.been.calledWith(userB.address, FIXED_FEE_AMOUNT)
+    })
+  })
+
   describe('#signed-messages', () => {
     let currentTime: BigNumber
     let lastNonce = 0
@@ -416,7 +469,7 @@ describe('Manager', () => {
       currentTime = BigNumber.from(await currentBlockTimestamp())
     })
 
-    function createActionMessage(userAddress = userA.address, signerAddress = userAddress, expiresInSeconds = 18) {
+    function createActionMessage(userAddress = userA.address, signerAddress = userAddress, expiresInSeconds = 30) {
       return {
         action: {
           market: market.address,


### PR DESCRIPTION
To reduce price commitments, have _Manager_ contract use collateral accounts for compensating keepers and paying interface fees.  Since `IAccount.withdraw` cannot be used for this purposes, `IController` has been extended with a `chargeFee` method only callable from an operator.  This facility also wraps USDC if necessary.  Since trigger order `Manager` already needs to be a manager to interact with markets on behalf of the user, no new entitlements are required.  

## Deployment notes
Trigger order users must create and fund their collateral account prior to using the new version.