### PR TITLE
Add rebalance to SolverVault

### DIFF
--- a/packages/vault/contracts/MakerVault.sol
+++ b/packages/vault/contracts/MakerVault.sol
@@ -5,13 +5,14 @@ import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
 import { Vault } from "./Vault.sol";
 import { Target } from "./types/Target.sol";
 import { MakerStrategyLib } from "./libs/MakerStrategyLib.sol";
+import { IMakerVault } from "./interfaces/IMakerVault.sol";
 
 /// @title MakerVault
 /// @notice Deploys underlying capital by weight in maker positions across registered markets
 /// @dev Vault deploys and rebalances collateral between the registered markets, while attempting to
 ///      maintain `targetLeverage` with its open maker positions at any given time. Deposits are only gated in so much
 ///      as to cap the maximum amount of assets in the vault.
-contract MakerVault is Vault {
+contract MakerVault is IMakerVault, Vault {
     function _vaultName() internal pure override returns (string memory) {
         return "Perennial Maker Vault";
     }

--- a/packages/vault/contracts/SolverVault.sol
+++ b/packages/vault/contracts/SolverVault.sol
@@ -2,17 +2,21 @@
 pragma solidity 0.8.24;
 
 import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
+import { Fixed6, Fixed6Lib } from "@equilibria/root/number/types/Fixed6.sol";
 import { Vault } from "./Vault.sol";
 import { Target } from "./types/Target.sol";
 import { SolverStrategyLib } from "./libs/SolverStrategyLib.sol";
 import { IVaultFactory } from "./interfaces/IVaultFactory.sol";
+import { IMarket } from "@perennial/v2-core/contracts/interfaces/IMarket.sol";
+import { ISolverVault } from "./interfaces/ISolverVault.sol";
+import { IVault } from "./interfaces/IVault.sol";
 
 /// @title SolverVault
 /// @notice Allows the coordinator trade on behalf of the vault via signature.
 /// @dev Vault deploys collateral pro-rata with current collateral distribution on deposit / withdraw.
 ///      Coordinator is able to trade on behalf of the vault via signature, as well as rebalance collateral between markets.
 ///      Coordinator can set the maximum leverage per market, with which the Vault will autoleverage on withdraw if necessary.
-contract SolverVault is Vault {
+contract SolverVault is ISolverVault, Vault {
     function _vaultName() internal pure override returns (string memory) {
         return "Perennial Solver Vault";
     }
@@ -26,10 +30,21 @@ contract SolverVault is Vault {
         return SolverStrategyLib.allocate(context.registrations, deposit, withdrawal, ineligible);
     }
 
-    function updateCoordinator(address newCoordinator) public override onlyOwner {
+    function updateCoordinator(address newCoordinator) public override(IVault, Vault) onlyOwner {
         IVaultFactory(address(factory())).marketFactory().updateSigner(coordinator, false);
         IVaultFactory(address(factory())).marketFactory().updateSigner(newCoordinator, true);
 
         super.updateCoordinator(newCoordinator);
+    }
+
+    function rebalance(IMarket from, IMarket to, UFixed6 amount) external onlyCoordinator {
+        if (!_isRegistered(from) || !_isRegistered(to)) revert SolverVaultNotRegisteredError();
+        from.update(address(this), Fixed6Lib.ZERO, Fixed6Lib.from(-1, amount), address(0));
+        to.update(address(this), Fixed6Lib.ZERO, Fixed6Lib.from(1, amount), address(0));
+    }
+
+    modifier onlyCoordinator {
+        if (msg.sender != coordinator) revert SolverVaultNotCoordinatorError();
+        _;
     }
 }

--- a/packages/vault/contracts/Vault.sol
+++ b/packages/vault/contracts/Vault.sol
@@ -164,11 +164,16 @@ abstract contract Vault is IVault, Instance {
     function register(IMarket market) external onlyOwner {
         rebalance(address(0));
 
-        for (uint256 marketId; marketId < totalMarkets; marketId++) {
-            if (_registrations[marketId].read().market == market) revert VaultMarketExistsError();
-        }
+        if (_isRegistered(market)) revert VaultMarketExistsError();
 
         _register(market);
+    }
+
+    function _isRegistered(IMarket market) internal view returns (bool) {
+        for (uint256 marketId; marketId < totalMarkets; marketId++) {
+            if (_registrations[marketId].read().market == market) return true;
+        }
+        return false;
     }
 
     /// @notice Handles the registration for a new market

--- a/packages/vault/contracts/interfaces/IMakerVault.sol
+++ b/packages/vault/contracts/interfaces/IMakerVault.sol
@@ -1,0 +1,11 @@
+//SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { IVault } from "./IVault.sol";
+
+interface IMakerVault is IVault {
+    // sig: 0xf90641dc
+    error MakerStrategyInsufficientCollateralError();
+    // sig: 0xb86270e3
+    error MakerStrategyInsufficientAssetsError();
+}

--- a/packages/vault/contracts/interfaces/ISolverVault.sol
+++ b/packages/vault/contracts/interfaces/ISolverVault.sol
@@ -1,0 +1,17 @@
+//SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { UFixed6 } from "@equilibria/root/number/types/UFixed6.sol";
+import { IVault } from "./IVault.sol";
+import { IMarket } from "@perennial/v2-core/contracts/interfaces/IMarket.sol";
+
+interface ISolverVault is IVault {
+    // sig: 0xfadba457
+    error SolverStrategyPendingTradeError();
+    // sig: 0xea51dc6e
+    error SolverVaultNotRegisteredError();
+    // sig: 0x96a28ccd
+    error SolverVaultNotCoordinatorError();
+
+    function rebalance(IMarket from, IMarket to, UFixed6 amount) external;
+}

--- a/packages/vault/contracts/interfaces/IVault.sol
+++ b/packages/vault/contracts/interfaces/IVault.sol
@@ -74,12 +74,6 @@ interface IVault is IInstance {
     error RegistrationStorageInvalidError();
     // sig: 0x0f9f8b19
     error VaultParameterStorageInvalidError();
-    // sig: 0x97635122
-    error StrategyLibInsufficientCollateralError();
-    // sig: 0xfd9cbca5
-    error StrategyLibInsufficientAssetsError();
-    // sig: 0xfadba457
-    error SolverStrategyPendingTradeError();
 
     function initialize(Token18 asset, IMarket initialMaker, UFixed6 initialAmount, string calldata name_) external;
     function name() external view returns (string memory);

--- a/packages/vault/contracts/libs/MakerStrategyLib.sol
+++ b/packages/vault/contracts/libs/MakerStrategyLib.sol
@@ -69,8 +69,10 @@ struct MarketMakerStrategyContext {
 ///      - Deploys collateral first to satisfy the margin of each market, then deploys the rest by weight.
 ///      - Positions are then targeted based on the amount of collateral that ends up deployed to each market.
 library MakerStrategyLib {
-    error StrategyLibInsufficientCollateralError();
-    error StrategyLibInsufficientAssetsError();
+    // sig: 0xf90641dc
+    error MakerStrategyInsufficientCollateralError();
+    // sig: 0xb86270e3
+    error MakerStrategyInsufficientAssetsError();
 
     /// @dev The maximum multiplier that is allowed for leverage
     UFixed6 public constant LEVERAGE_BUFFER = UFixed6.wrap(1.2e6);
@@ -91,8 +93,8 @@ library MakerStrategyLib {
         UFixed6 collateral = UFixed6Lib.unsafeFrom(context.totalCollateral).add(deposit).unsafeSub(withdrawal);
         UFixed6 assets = collateral.unsafeSub(ineligible);
 
-        if (collateral.lt(context.totalMargin)) revert StrategyLibInsufficientCollateralError();
-        if (assets.lt(context.minAssets)) revert StrategyLibInsufficientAssetsError();
+        if (collateral.lt(context.totalMargin)) revert MakerStrategyInsufficientCollateralError();
+        if (assets.lt(context.minAssets)) revert MakerStrategyInsufficientAssetsError();
 
         targets = new Target[](context.markets.length);
         UFixed6 totalMarketCollateral;

--- a/packages/vault/test/integration/vault/MakerVault.test.ts
+++ b/packages/vault/test/integration/vault/MakerVault.test.ts
@@ -1203,7 +1203,7 @@ describe('MakerVault', () => {
 
       await expect(vault.connect(user).update(user.address, 0, maxRedeem, 0)).to.be.revertedWithCustomError(
         vault,
-        'StrategyLibInsufficientAssetsError',
+        'MakerStrategyInsufficientAssetsError',
       )
       await expect(vault.connect(user).update(user.address, 0, maxRedeem.sub(parse6decimal('1')), 0)).to.not.be.reverted
     })
@@ -1243,7 +1243,7 @@ describe('MakerVault', () => {
 
       await expect(vault.connect(user).update(user.address, 0, maxRedeem, 0)).to.be.revertedWithCustomError(
         vault,
-        'StrategyLibInsufficientAssetsError',
+        'MakerStrategyInsufficientAssetsError',
       )
       await expect(vault.connect(user).update(user.address, 0, maxRedeem.sub(parse6decimal('1')), 0)).to.not.be.reverted
     })
@@ -2130,11 +2130,14 @@ describe('MakerVault', () => {
           // Ensure the full amount cannot be redeemed.
           await expect(vault.connect(user).update(user.address, 0, depositAmount, 0)).to.be.revertedWithCustomError(
             vault,
-            'StrategyLibInsufficientCollateralError',
+            'MakerStrategyInsufficientCollateralError',
           )
 
           // Ensure a small amount cannot be redeemed.
-          await expect(smallRedeem(user)).to.be.revertedWithCustomError(vault, 'StrategyLibInsufficientCollateralError')
+          await expect(smallRedeem(user)).to.be.revertedWithCustomError(
+            vault,
+            'MakerStrategyInsufficientCollateralError',
+          )
         })
 
         it('recovers from a liquidation', async () => {

--- a/packages/vault/test/integration/vault/MakerVault.test.ts
+++ b/packages/vault/test/integration/vault/MakerVault.test.ts
@@ -13,8 +13,8 @@ import {
   IOracleProvider,
   VaultFactory__factory,
   IVaultFactory,
-  IVault__factory,
-  IVault,
+  IMakerVault__factory,
+  IMakerVault,
   IVaultFactory__factory,
   IOracleFactory,
   IMarketFactory,
@@ -34,7 +34,7 @@ const ETH_PRICE_FEE_ID = '0x0000000000000000000000000000000000000000000000000000
 const BTC_PRICE_FEE_ID = '0x0000000000000000000000000000000000000000000000000000000000000002'
 
 describe('MakerVault', () => {
-  let vault: IVault
+  let vault: IMakerVault
   let asset: IERC20Metadata
   let vaultFactory: IVaultFactory
   let factory: IMarketFactory
@@ -274,7 +274,7 @@ describe('MakerVault', () => {
 
     await fundWallet(asset, owner)
     await asset.approve(vaultFactory.address, ethers.constants.MaxUint256)
-    vault = IVault__factory.connect(
+    vault = IMakerVault__factory.connect(
       await vaultFactory.callStatic.create(instanceVars.dsu.address, market.address, 'Blue Chip'),
       owner,
     )
@@ -1752,7 +1752,7 @@ describe('MakerVault', () => {
 
       await fundWallet(asset, owner)
       await asset.approve(vaultFactory2.address, ethers.utils.parseEther('1'))
-      const vault2 = IVault__factory.connect(
+      const vault2 = IMakerVault__factory.connect(
         await vaultFactory2.callStatic.create(asset.address, market.address, 'Blue Chip'),
         owner,
       )
@@ -1797,7 +1797,7 @@ describe('MakerVault', () => {
 
       await fundWallet(asset, owner)
       await asset.approve(vaultFactory2.address, ethers.utils.parseEther('1'))
-      const vault2 = IVault__factory.connect(
+      const vault2 = IMakerVault__factory.connect(
         await vaultFactory2.callStatic.create(asset.address, market.address, 'Blue Chip'),
         owner,
       )

--- a/packages/vault/test/integration/vault/SolverVault.test.ts
+++ b/packages/vault/test/integration/vault/SolverVault.test.ts
@@ -13,8 +13,8 @@ import {
   IOracleProvider,
   VaultFactory__factory,
   IVaultFactory,
-  IVault__factory,
-  IVault,
+  ISolverVault__factory,
+  ISolverVault,
   IVaultFactory__factory,
   IOracleFactory,
   IMarketFactory,
@@ -42,7 +42,7 @@ const ETH_PRICE_FEE_ID = '0x0000000000000000000000000000000000000000000000000000
 const BTC_PRICE_FEE_ID = '0x0000000000000000000000000000000000000000000000000000000000000002'
 
 describe('SolverVault', () => {
-  let vault: IVault
+  let vault: ISolverVault
   let asset: IERC20Metadata
   let vaultFactory: IVaultFactory
   let factory: IMarketFactory
@@ -150,7 +150,7 @@ describe('SolverVault', () => {
     return currentPosition
   }
 
-  async function currentPositionLocal(market: IMarket, vault: IVault) {
+  async function currentPositionLocal(market: IMarket, vault: ISolverVault) {
     const currentPosition = { ...(await market.positions(vault.address)) }
     const pending = await market.pendings(vault.address)
 
@@ -162,7 +162,7 @@ describe('SolverVault', () => {
   }
 
   async function placeIntentOrder(
-    vault: IVault,
+    vault: ISolverVault,
     taker: SignerWithAddress,
     maker: SignerWithAddress,
     market: IMarket,
@@ -333,7 +333,7 @@ describe('SolverVault', () => {
 
     await fundWallet(asset, owner)
     await asset.approve(vaultFactory.address, ethers.constants.MaxUint256)
-    vault = IVault__factory.connect(
+    vault = ISolverVault__factory.connect(
       await vaultFactory.callStatic.create(instanceVars.dsu.address, market.address, 'Blue Chip'),
       owner,
     )
@@ -723,7 +723,7 @@ describe('SolverVault', () => {
       expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
       expect(await vault.totalAssets()).to.equal(0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       const checkpoint1 = await vault.checkpoints(1)
       expect(checkpoint1.deposit).to.equal(smallDeposit)
@@ -836,7 +836,7 @@ describe('SolverVault', () => {
       expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
       expect(await vault.totalAssets()).to.equal(0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       const checkpoint1 = await vault.checkpoints(1)
       expect(checkpoint1.deposit).to.equal(smallDeposit)
@@ -856,7 +856,7 @@ describe('SolverVault', () => {
       expect(await vault.convertToAssets(parse6decimal('10'))).to.equal(parse6decimal('10'))
       expect(await vault.convertToShares(parse6decimal('10'))).to.equal(parse6decimal('10'))
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       const checkpoint2 = await vault.checkpoints(2)
       expect(checkpoint2.deposit).to.equal(largeDeposit)
       expect(checkpoint2.assets).to.equal(smallDeposit)
@@ -905,7 +905,7 @@ describe('SolverVault', () => {
       expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('10010'))
       await vault.connect(user).update(user.address, 0, (await vault.accounts(user.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       // We should have closed all positions.
       expect(await position()).to.equal(0)
@@ -981,7 +981,7 @@ describe('SolverVault', () => {
       )
 
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       const largeDeposit = parse6decimal('10000')
       await vault.connect(user2).update(user2.address, largeDeposit, 0, 0)
@@ -1007,7 +1007,7 @@ describe('SolverVault', () => {
       )
 
       await updateOracle()
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](user2.address)
 
       // Now we should have opened positions.
       expect(await position()).to.equal(parse6decimal('11'))
@@ -1027,11 +1027,11 @@ describe('SolverVault', () => {
 
       await vault.connect(user).update(user.address, 0, (await vault.accounts(user.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       await vault.connect(user2).update(user2.address, 0, (await vault.accounts(user2.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](user2.address)
 
       // We should have closed all positions.
       expect(await position()).to.equal(0)
@@ -1082,10 +1082,10 @@ describe('SolverVault', () => {
       expect((await vault.accounts(ethers.constants.AddressZero)).assets).to.equal(0)
 
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       await vault.connect(user).update(user.address, smallDeposit, 0, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('1000'))
       expect(await vault.totalAssets()).to.equal(parse6decimal('1000').add(0))
       expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(parse6decimal('1000'))
@@ -1138,7 +1138,7 @@ describe('SolverVault', () => {
       )
 
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       const largeDeposit = parse6decimal('10000')
       await vault.connect(user2).update(user2.address, largeDeposit, 0, 0)
@@ -1164,7 +1164,7 @@ describe('SolverVault', () => {
       )
 
       await updateOracle()
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](user2.address)
 
       // Now we should have opened positions.
       expect(await position()).to.equal(parse6decimal('11'))
@@ -1184,11 +1184,11 @@ describe('SolverVault', () => {
 
       await vault.connect(user).update(user.address, 0, (await vault.accounts(user.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       await vault.connect(user2).update(user2.address, 0, (await vault.accounts(user2.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](user2.address)
 
       // We should have closed all positions.
       expect(await position()).to.equal(0)
@@ -1246,10 +1246,10 @@ describe('SolverVault', () => {
       expect((await vault.accounts(ethers.constants.AddressZero)).assets).to.equal(0)
 
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       await vault.connect(user).update(user.address, smallDeposit, 0, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       expect((await vault.accounts(user.address)).shares).to.equal(parse6decimal('1000'))
       expect(await vault.totalAssets()).to.equal(parse6decimal('1000').add(0))
       expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(parse6decimal('1000'))
@@ -1262,13 +1262,13 @@ describe('SolverVault', () => {
 
       await vault.connect(user).update(user.address, oddDepositAmount, 0, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       expect(await asset.balanceOf(vault.address)).to.equal(0) // deposits everything into markets
       expect((await collateralInVault()).add(await btcCollateralInVault())).to.equal(oddDepositAmount)
 
       await vault.connect(user).update(user.address, oddDepositAmount, 0, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
     })
 
     it('profit shares', async () => {
@@ -1309,7 +1309,7 @@ describe('SolverVault', () => {
       )
 
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       const largeDeposit = parse6decimal('10000')
       await vault.connect(user2).update(user2.address, largeDeposit, 0, 0)
@@ -1335,7 +1335,7 @@ describe('SolverVault', () => {
       )
 
       await updateOracle()
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](user2.address)
 
       // Now we should have opened positions.
       expect(await position()).to.equal(parse6decimal('11'))
@@ -1360,17 +1360,17 @@ describe('SolverVault', () => {
 
       await vault.connect(user).update(user.address, 0, (await vault.accounts(user.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       await vault.connect(user2).update(user2.address, 0, (await vault.accounts(user2.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](user2.address)
 
       await vault
         .connect(coordinator)
         .update(coordinator.address, 0, (await vault.accounts(coordinator.address)).shares, 0)
       await updateOracle()
-      await vault.rebalance(coordinator.address)
+      await vault['rebalance(address)'](coordinator.address)
 
       // We should have closed all positions.
       expect(await position()).to.equal(0)
@@ -1453,16 +1453,16 @@ describe('SolverVault', () => {
       await vault.connect(user).update(user.address, smallDeposit, 0, 0)
       await vault.connect(user2).update(user2.address, largeDeposit, 0, 0)
       await updateOracle()
-      await vault.rebalance(constants.AddressZero)
-      await vault.rebalance(user.address)
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](constants.AddressZero)
+      await vault['rebalance(address)'](user.address)
+      await vault['rebalance(address)'](user2.address)
 
       await vault.connect(user).update(user.address, 0, constants.MaxUint256, 0)
       await vault.connect(user2).update(user2.address, 0, constants.MaxUint256, 0)
       await updateOracle()
-      await vault.rebalance(constants.AddressZero)
-      await vault.rebalance(user.address)
-      await vault.rebalance(user2.address)
+      await vault['rebalance(address)'](constants.AddressZero)
+      await vault['rebalance(address)'](user.address)
+      await vault['rebalance(address)'](user2.address)
 
       const totalAssets = BigNumber.from('11000000000')
       expect((await vault.accounts(constants.AddressZero)).assets).to.equal(totalAssets)
@@ -1479,7 +1479,7 @@ describe('SolverVault', () => {
       expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
       expect(await vault.totalAssets()).to.equal(0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       const checkpoint1 = await vault.checkpoints(1)
       expect(checkpoint1.deposit).to.equal(smallDeposit)
@@ -1499,7 +1499,7 @@ describe('SolverVault', () => {
       expect(await vault.convertToAssets(parse6decimal('10'))).to.equal(parse6decimal('10'))
       expect(await vault.convertToShares(parse6decimal('10'))).to.equal(parse6decimal('10'))
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
       const checkpoint2 = await vault.checkpoints(2)
       expect(checkpoint2.deposit).to.equal(largeDeposit)
       expect(checkpoint2.assets).to.equal(smallDeposit)
@@ -1547,7 +1547,7 @@ describe('SolverVault', () => {
         .connect(user)
         .update(user.address, 0, (await vault.accounts(user.address)).shares.sub(parse6decimal('10')), 0)
       await updateOracle()
-      await vault.rebalance(user.address)
+      await vault['rebalance(address)'](user.address)
 
       // We should have closed all positions.
       expect(await vault.totalAssets()).to.equal(parse6decimal('10.197705')) // non-zero
@@ -1618,5 +1618,174 @@ describe('SolverVault', () => {
         expect(await position()).to.be.equal(0)
       })
     })
+  })
+
+  describe('#rebalance (coordinator)', () => {
+    it('simple rebalance', async () => {
+      expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
+      expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))
+
+      const smallDeposit = parse6decimal('10')
+      await vault.connect(user).update(user.address, smallDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5'))
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      await updateOracle()
+      await vault['rebalance(address)'](user.address)
+
+      const checkpoint1 = await vault.checkpoints(1)
+      expect(checkpoint1.deposit).to.equal(smallDeposit)
+      expect(checkpoint1.deposits).to.equal(1)
+      expect(checkpoint1.timestamp).to.equal((await market.pendingOrders(vault.address, 1)).timestamp)
+
+      // We're underneath the collateral minimum, so we shouldn't have opened any positions.
+      expect(await position()).to.equal(0)
+      expect(await btcPosition()).to.equal(0)
+      const largeDeposit = parse6decimal('10000')
+      await vault.connect(user).update(user.address, largeDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5005'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5005'))
+
+      await vault
+        .connect(coordinator)
+        ['rebalance(address,address,uint256)'](market.address, btcMarket.address, parse6decimal('1000'))
+
+      expect(await collateralInVault()).to.equal(parse6decimal('4005'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('6005'))
+    })
+
+    it('rebalance with position open', async () => {
+      expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
+      expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))
+
+      const smallDeposit = parse6decimal('10')
+      await vault.connect(user).update(user.address, smallDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5'))
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      await updateOracle()
+      await vault['rebalance(address)'](user.address)
+
+      const checkpoint1 = await vault.checkpoints(1)
+      expect(checkpoint1.deposit).to.equal(smallDeposit)
+      expect(checkpoint1.deposits).to.equal(1)
+      expect(checkpoint1.timestamp).to.equal((await market.pendingOrders(vault.address, 1)).timestamp)
+
+      // We're underneath the collateral minimum, so we shouldn't have opened any positions.
+      expect(await position()).to.equal(0)
+      expect(await btcPosition()).to.equal(0)
+      const largeDeposit = parse6decimal('10000')
+      await vault.connect(user).update(user.address, largeDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5005'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5005'))
+
+      expect((await vault.accounts(user.address)).shares).to.equal(smallDeposit)
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(smallDeposit)
+      expect(await vault.totalAssets()).to.equal(smallDeposit)
+      expect(await vault.convertToAssets(parse6decimal('10'))).to.equal(parse6decimal('10'))
+      expect(await vault.convertToShares(parse6decimal('10'))).to.equal(parse6decimal('10'))
+      await updateOracle()
+      await vault.settle(user.address)
+
+      // Solver opens positions via signature
+      await placeIntentOrder(
+        vault,
+        user2,
+        coordinator,
+        market,
+        parse6decimal('-10'),
+        originalOraclePrice.sub(parse6decimal('10')),
+        1,
+      )
+      await placeIntentOrder(
+        vault,
+        btcUser2,
+        coordinator,
+        btcMarket,
+        parse6decimal('-1'),
+        btcOriginalOraclePrice.sub(parse6decimal('100')),
+        2,
+      )
+
+      await updateOracle()
+      await vault.settle(user.address)
+
+      await vault
+        .connect(coordinator)
+        ['rebalance(address,address,uint256)'](market.address, btcMarket.address, parse6decimal('1000'))
+
+      expect(await collateralInVault()).to.equal(parse6decimal('4105'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('6105'))
+    })
+
+    it('reverts if not coordinator', async () => {
+      expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
+      expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))
+
+      const smallDeposit = parse6decimal('10')
+      await vault.connect(user).update(user.address, smallDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5'))
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      await updateOracle()
+      await vault['rebalance(address)'](user.address)
+
+      const checkpoint1 = await vault.checkpoints(1)
+      expect(checkpoint1.deposit).to.equal(smallDeposit)
+      expect(checkpoint1.deposits).to.equal(1)
+      expect(checkpoint1.timestamp).to.equal((await market.pendingOrders(vault.address, 1)).timestamp)
+
+      // We're underneath the collateral minimum, so we shouldn't have opened any positions.
+      expect(await position()).to.equal(0)
+      expect(await btcPosition()).to.equal(0)
+      const largeDeposit = parse6decimal('10000')
+      await vault.connect(user).update(user.address, largeDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5005'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5005'))
+
+      await expect(
+        vault
+          .connect(user)
+          ['rebalance(address,address,uint256)'](market.address, btcMarket.address, parse6decimal('1000')),
+      ).to.be.revertedWithCustomError(vault, 'SolverVaultNotCoordinatorError')
+    })
+
+    it('reverts if not registered', async () => {
+      expect(await vault.convertToAssets(parse6decimal('1'))).to.equal(parse6decimal('1'))
+      expect(await vault.convertToShares(parse6decimal('1'))).to.equal(parse6decimal('1'))
+
+      const smallDeposit = parse6decimal('10')
+      await vault.connect(user).update(user.address, smallDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5'))
+      expect((await vault.accounts(ethers.constants.AddressZero)).shares).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      await updateOracle()
+      await vault['rebalance(address)'](user.address)
+
+      const checkpoint1 = await vault.checkpoints(1)
+      expect(checkpoint1.deposit).to.equal(smallDeposit)
+      expect(checkpoint1.deposits).to.equal(1)
+      expect(checkpoint1.timestamp).to.equal((await market.pendingOrders(vault.address, 1)).timestamp)
+
+      // We're underneath the collateral minimum, so we shouldn't have opened any positions.
+      expect(await position()).to.equal(0)
+      expect(await btcPosition()).to.equal(0)
+      const largeDeposit = parse6decimal('10000')
+      await vault.connect(user).update(user.address, largeDeposit, 0, 0)
+      expect(await collateralInVault()).to.equal(parse6decimal('5005'))
+      expect(await btcCollateralInVault()).to.equal(parse6decimal('5005'))
+
+      await expect(
+        vault
+          .connect(coordinator)
+          ['rebalance(address,address,uint256)'](market.address, coordinator.address, parse6decimal('1000')),
+      ).to.be.revertedWithCustomError(vault, 'SolverVaultNotRegisteredError')
+    })
+
+    // TODO: test adding a market (no collateral), and rebalancing in
   })
 })


### PR DESCRIPTION
Adds a rebalance function to the SolverVault which allows the `coordinator` to move collateral from one registered market to another.