### PR TITLE
attempt to resolve integration test issue with SolverVault tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
       - main
       - v2.4-mini
       - britz-sender-is-signer
+      - britz-solver-vault
   workflow_dispatch:
 
 env:

--- a/packages/periphery/test/unit/TriggerOrders/Verifier.test.ts
+++ b/packages/periphery/test/unit/TriggerOrders/Verifier.test.ts
@@ -38,7 +38,7 @@ describe('Verifier', () => {
   let lastOrderId = 30
   let currentTime: BigNumber
 
-  function createCommonMessage(userAddress = userA.address, signerAddress = userAddress, expiresInSeconds = 18) {
+  function createCommonMessage(userAddress = userA.address, signerAddress = userAddress, expiresInSeconds = 24) {
     return {
       common: {
         account: userAddress,
@@ -52,7 +52,7 @@ describe('Verifier', () => {
   }
 
   // create a default action for the specified user
-  function createActionMessage(userAddress = userA.address, signerAddress = userAddress, expiresInSeconds = 12) {
+  function createActionMessage(userAddress = userA.address, signerAddress = userAddress, expiresInSeconds = 24) {
     return {
       action: {
         market: market.address,

--- a/packages/vault/test/integration/vault/MakerVault.test.ts
+++ b/packages/vault/test/integration/vault/MakerVault.test.ts
@@ -24,6 +24,7 @@ import { deployProtocol, fundWallet, settle } from '@perennial/v2-core/test/inte
 import { OracleReceipt, DEFAULT_ORACLE_RECEIPT, parse6decimal } from '../../../../common/testutil/types'
 import { MarketFactory, ProxyAdmin, TransparentUpgradeableProxy__factory } from '@perennial/v2-core/types/generated'
 import { IOracle, IOracle__factory, OracleFactory } from '@perennial/v2-oracle/types/generated'
+import { reset } from '../../../../common/testutil/time'
 
 const { ethers } = HRE
 use(smock.matchers)
@@ -409,19 +410,8 @@ describe('MakerVault', () => {
   })
 
   after(async () => {
-    _resetOracleFakes(oracle)
-    _resetOracleFakes(btcOracle)
-    vaultOracleFactory.instances.reset()
-    vaultOracleFactory.oracles.reset()
+    await reset()
   })
-
-  function _resetOracleFakes(oracle: FakeContract<IOracleProvider>): undefined {
-    oracle.status.reset()
-    oracle.request.reset()
-    oracle.latest.reset()
-    oracle.current.reset()
-    oracle.at.reset()
-  }
 
   describe('#initialize', () => {
     it('cant re-initialize', async () => {

--- a/packages/vault/test/integration/vault/MakerVault.test.ts
+++ b/packages/vault/test/integration/vault/MakerVault.test.ts
@@ -408,6 +408,21 @@ describe('MakerVault', () => {
     vaultOracleFactory.oracles.whenCalledWith(BTC_PRICE_FEE_ID).returns(btcOracle.address)
   })
 
+  after(async () => {
+    _resetOracleFakes(oracle)
+    _resetOracleFakes(btcOracle)
+    vaultOracleFactory.instances.reset()
+    vaultOracleFactory.oracles.reset()
+  })
+
+  function _resetOracleFakes(oracle: FakeContract<IOracleProvider>): undefined {
+    oracle.status.reset()
+    oracle.request.reset()
+    oracle.latest.reset()
+    oracle.current.reset()
+    oracle.at.reset()
+  }
+
   describe('#initialize', () => {
     it('cant re-initialize', async () => {
       await expect(vault.initialize(asset.address, market.address, parse6decimal('5'), 'Blue Chip'))


### PR DESCRIPTION
Note the issue was caused by test setup; when all `MakerVault` tests were skipped (except one, either `#initialize` or `#name`), the failure still occurred.  Workaround:
- reset the fork after MakerVault tests
- (unrelated) tweak message expiry for when CI is running slow