### PR TITLE
[Code Size] v2.4 mini

### DIFF
--- a/packages/core/contracts/libs/MagicValueLib.sol
+++ b/packages/core/contracts/libs/MagicValueLib.sol
@@ -20,7 +20,7 @@ library MagicValueLib {
         UFixed6 newMaker,
         UFixed6 newLong,
         UFixed6 newShort
-    ) external pure returns (Fixed6, UFixed6, UFixed6, UFixed6) {
+    ) internal pure returns (Fixed6, UFixed6, UFixed6, UFixed6) {
         return (
             _processCollateralMagicValue(context, collateral),
             _processPositionMagicValue(context, updateContext.currentPositionLocal.maker, newMaker),
@@ -54,7 +54,6 @@ library MagicValueLib {
     ) private pure returns (UFixed6) {
         if (newPosition.eq(MAGIC_VALUE_UNCHANGED_POSITION)) return currentPosition;
         if (newPosition.eq(MAGIC_VALUE_FULLY_CLOSED_POSITION)) {
-            if (currentPosition.isZero()) return UFixed6Lib.ZERO;           // side is empty
             if (context.pendingLocal.crossesZero()) return currentPosition; // pending zero-cross, max close is no-op
             return context.pendingLocal.pos().min(currentPosition);         // minimum position is pending open, or current position if smaller (due to intents)
         }

--- a/packages/core/contracts/types/Guarantee.sol
+++ b/packages/core/contracts/types/Guarantee.sol
@@ -185,7 +185,7 @@ library GuaranteeStorageGlobalLib {
         );
     }
 
-    function store(GuaranteeStorageGlobal storage self, Guarantee memory newValue) internal {
+    function store(GuaranteeStorageGlobal storage self, Guarantee memory newValue) external {
         GuaranteeStorageLib.validate(newValue);
 
         uint256 encoded0 =
@@ -242,7 +242,7 @@ library GuaranteeStorageLocalLib {
         );
     }
 
-    function store(GuaranteeStorageLocal storage self, Guarantee memory newValue) internal {
+    function store(GuaranteeStorageLocal storage self, Guarantee memory newValue) external {
         GuaranteeStorageLib.validate(newValue);
 
         if (newValue.notional.gt(Fixed6.wrap(type(int64).max))) revert GuaranteeStorageLib.GuaranteeStorageInvalidError();

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -403,7 +403,7 @@ library OrderStorageGlobalLib {
         );
     }
 
-    function store(OrderStorageGlobal storage self, Order memory newValue) internal {
+    function store(OrderStorageGlobal storage self, Order memory newValue) external {
         OrderStorageLib.validate(newValue);
 
         uint256 encoded0 =
@@ -473,7 +473,7 @@ library OrderStorageLocalLib {
         );
     }
 
-    function store(OrderStorageLocal storage self, Order memory newValue) internal {
+    function store(OrderStorageLocal storage self, Order memory newValue) external {
         OrderStorageLib.validate(newValue);
 
         if (newValue.protection > 1) revert OrderStorageLib.OrderStorageInvalidError();

--- a/packages/core/test/integration/helpers/setupHelpers.ts
+++ b/packages/core/test/integration/helpers/setupHelpers.ts
@@ -24,6 +24,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
   VersionLib__factory,
   MagicValueLib__factory,
   Verifier,
@@ -128,6 +132,18 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
       ).address,
       'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
       'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
+      'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+        await new GuaranteeStorageLocalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+        await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Order.sol:OrderStorageLocalLib': (
+        await new OrderStorageLocalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Order.sol:OrderStorageGlobalLib': (
+        await new OrderStorageGlobalLib__factory(owner).deploy()
+      ).address,
     },
     owner,
   ).deploy(verifierProxy.address)

--- a/packages/core/test/integration/helpers/setupHelpers.ts
+++ b/packages/core/test/integration/helpers/setupHelpers.ts
@@ -29,7 +29,6 @@ import {
   OrderStorageLocalLib__factory,
   OrderStorageGlobalLib__factory,
   VersionLib__factory,
-  MagicValueLib__factory,
   Verifier,
   Verifier__factory,
 } from '../../../types/generated'
@@ -131,7 +130,6 @@ export async function deployProtocol(chainlinkContext?: ChainlinkContext): Promi
         await new RiskParameterStorageLib__factory(owner).deploy()
       ).address,
       'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
-      'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
       'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
         await new GuaranteeStorageLocalLib__factory(owner).deploy()
       ).address,

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -21,6 +21,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
   VersionLib__factory,
   VersionStorageLib__factory,
   IVerifier,
@@ -558,6 +562,18 @@ describe('Market', () => {
         ).address,
         'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
         'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
+        'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+          await new GuaranteeStorageLocalLib__factory(owner).deploy()
+        ).address,
+        'contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+          await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+        ).address,
+        'contracts/types/Order.sol:OrderStorageLocalLib': (
+          await new OrderStorageLocalLib__factory(owner).deploy()
+        ).address,
+        'contracts/types/Order.sol:OrderStorageGlobalLib': (
+          await new OrderStorageGlobalLib__factory(owner).deploy()
+        ).address,
       },
       owner,
     ).deploy(verifier.address)

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -28,7 +28,6 @@ import {
   VersionLib__factory,
   VersionStorageLib__factory,
   IVerifier,
-  MagicValueLib__factory,
   MockToken,
   MockToken__factory,
 } from '../../../types/generated'
@@ -561,7 +560,6 @@ describe('Market', () => {
           await new RiskParameterStorageLib__factory(owner).deploy()
         ).address,
         'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
-        'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
         'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
           await new GuaranteeStorageLocalLib__factory(owner).deploy()
         ).address,

--- a/packages/core/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/core/test/unit/marketfactory/MarketFactory.test.ts
@@ -21,6 +21,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
   VersionStorageLib__factory,
   IVerifier,
   MagicValueLib__factory,
@@ -78,6 +82,18 @@ describe('MarketFactory', () => {
         ).address,
         'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
         'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
+        'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+          await new GuaranteeStorageLocalLib__factory(owner).deploy()
+        ).address,
+        'contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+          await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+        ).address,
+        'contracts/types/Order.sol:OrderStorageLocalLib': (
+          await new OrderStorageLocalLib__factory(owner).deploy()
+        ).address,
+        'contracts/types/Order.sol:OrderStorageGlobalLib': (
+          await new OrderStorageGlobalLib__factory(owner).deploy()
+        ).address,
       },
       owner,
     ).deploy(verifier.address)

--- a/packages/core/test/unit/marketfactory/MarketFactory.test.ts
+++ b/packages/core/test/unit/marketfactory/MarketFactory.test.ts
@@ -27,7 +27,6 @@ import {
   OrderStorageGlobalLib__factory,
   VersionStorageLib__factory,
   IVerifier,
-  MagicValueLib__factory,
 } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { constants } from 'ethers'
@@ -81,7 +80,6 @@ describe('MarketFactory', () => {
           await new RiskParameterStorageLib__factory(owner).deploy()
         ).address,
         'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
-        'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
         'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
           await new GuaranteeStorageLocalLib__factory(owner).deploy()
         ).address,

--- a/packages/oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -39,7 +39,6 @@ import {
   VersionStorageLib__factory,
   GasOracle,
   GasOracle__factory,
-  MagicValueLib__factory,
 } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { smock } from '@defi-wonderland/smock'
@@ -337,9 +336,6 @@ testOracles.forEach(testOracle => {
           ).address,
           '@perennial/v2-core/contracts/types/Version.sol:VersionStorageLib': (
             await new VersionStorageLib__factory(owner).deploy()
-          ).address,
-          '@perennial/v2-core/contracts/libs/MagicValueLib.sol:MagicValueLib': (
-            await new MagicValueLib__factory(owner).deploy()
           ).address,
           '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
             await new GuaranteeStorageLocalLib__factory(owner).deploy()

--- a/packages/oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
+++ b/packages/oracle/test/integration/metaquants/MetaQuantsOracleFactory.test.ts
@@ -31,6 +31,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
   VersionLib__factory,
   VersionStorageLib__factory,
   GasOracle,
@@ -336,6 +340,18 @@ testOracles.forEach(testOracle => {
           ).address,
           '@perennial/v2-core/contracts/libs/MagicValueLib.sol:MagicValueLib': (
             await new MagicValueLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+            await new GuaranteeStorageLocalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+            await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Order.sol:OrderStorageLocalLib': (
+            await new OrderStorageLocalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Order.sol:OrderStorageGlobalLib': (
+            await new OrderStorageGlobalLib__factory(owner).deploy()
           ).address,
         },
         owner,

--- a/packages/oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -39,7 +39,6 @@ import {
   VersionStorageLib__factory,
   GasOracle,
   GasOracle__factory,
-  MagicValueLib__factory,
 } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { smock } from '@defi-wonderland/smock'
@@ -293,9 +292,6 @@ testOracles.forEach(testOracle => {
           ).address,
           '@perennial/v2-core/contracts/types/Version.sol:VersionStorageLib': (
             await new VersionStorageLib__factory(owner).deploy()
-          ).address,
-          '@perennial/v2-core/contracts/libs/MagicValueLib.sol:MagicValueLib': (
-            await new MagicValueLib__factory(owner).deploy()
           ).address,
           '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
             await new GuaranteeStorageLocalLib__factory(owner).deploy()

--- a/packages/oracle/test/integration/pyth/PythOracleFactory.test.ts
+++ b/packages/oracle/test/integration/pyth/PythOracleFactory.test.ts
@@ -31,6 +31,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
   VersionLib__factory,
   VersionStorageLib__factory,
   GasOracle,
@@ -292,6 +296,18 @@ testOracles.forEach(testOracle => {
           ).address,
           '@perennial/v2-core/contracts/libs/MagicValueLib.sol:MagicValueLib': (
             await new MagicValueLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+            await new GuaranteeStorageLocalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+            await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Order.sol:OrderStorageLocalLib': (
+            await new OrderStorageLocalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Order.sol:OrderStorageGlobalLib': (
+            await new OrderStorageGlobalLib__factory(owner).deploy()
           ).address,
         },
         owner,

--- a/packages/oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -39,7 +39,6 @@ import {
   VersionStorageLib__factory,
   GasOracle,
   GasOracle__factory,
-  MagicValueLib__factory,
 } from '../../../types/generated'
 import { parse6decimal } from '../../../../common/testutil/types'
 import { smock } from '@defi-wonderland/smock'
@@ -304,9 +303,6 @@ testOracles.forEach(testOracle => {
           ).address,
           '@perennial/v2-core/contracts/types/Version.sol:VersionStorageLib': (
             await new VersionStorageLib__factory(owner).deploy()
-          ).address,
-          '@perennial/v2-core/contracts/libs/MagicValueLib.sol:MagicValueLib': (
-            await new MagicValueLib__factory(owner).deploy()
           ).address,
           '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
             await new GuaranteeStorageLocalLib__factory(owner).deploy()

--- a/packages/oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
+++ b/packages/oracle/test/integrationSepolia/chainlink/ChainlinkOracleFactory.test.ts
@@ -31,6 +31,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
   VersionLib__factory,
   VersionStorageLib__factory,
   GasOracle,
@@ -303,6 +307,18 @@ testOracles.forEach(testOracle => {
           ).address,
           '@perennial/v2-core/contracts/libs/MagicValueLib.sol:MagicValueLib': (
             await new MagicValueLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+            await new GuaranteeStorageLocalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+            await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Order.sol:OrderStorageLocalLib': (
+            await new OrderStorageLocalLib__factory(owner).deploy()
+          ).address,
+          '@perennial/v2-core/contracts/types/Order.sol:OrderStorageGlobalLib': (
+            await new OrderStorageGlobalLib__factory(owner).deploy()
           ).address,
         },
         owner,

--- a/packages/periphery/test/helpers/marketHelpers.ts
+++ b/packages/periphery/test/helpers/marketHelpers.ts
@@ -12,6 +12,10 @@ import {
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
   VersionLib__factory,
   VersionStorageLib__factory,
   MagicValueLib__factory,
@@ -103,7 +107,6 @@ export async function deployMarketImplementation(owner: SignerWithAddress, verif
       'contracts/libs/CheckpointLib.sol:CheckpointLib': (await new CheckpointLib__factory(owner).deploy()).address,
       'contracts/libs/InvariantLib.sol:InvariantLib': (await new InvariantLib__factory(owner).deploy()).address,
       'contracts/libs/VersionLib.sol:VersionLib': (await new VersionLib__factory(owner).deploy()).address,
-      'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
       'contracts/types/Checkpoint.sol:CheckpointStorageLib': (
         await new CheckpointStorageLib__factory(owner).deploy()
       ).address,
@@ -121,6 +124,19 @@ export async function deployMarketImplementation(owner: SignerWithAddress, verif
         await new RiskParameterStorageLib__factory(owner).deploy()
       ).address,
       'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
+      'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
+      'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+        await new GuaranteeStorageLocalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+        await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Order.sol:OrderStorageLocalLib': (
+        await new OrderStorageLocalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Order.sol:OrderStorageGlobalLib': (
+        await new OrderStorageGlobalLib__factory(owner).deploy()
+      ).address,
     },
     owner,
   ).deploy(verifierAddress)

--- a/packages/periphery/test/helpers/marketHelpers.ts
+++ b/packages/periphery/test/helpers/marketHelpers.ts
@@ -18,7 +18,6 @@ import {
   OrderStorageGlobalLib__factory,
   VersionLib__factory,
   VersionStorageLib__factory,
-  MagicValueLib__factory,
 } from '@perennial/v2-core/types/generated'
 import { IOracle } from '@perennial/v2-oracle/types/generated'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -124,7 +123,6 @@ export async function deployMarketImplementation(owner: SignerWithAddress, verif
         await new RiskParameterStorageLib__factory(owner).deploy()
       ).address,
       'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
-      'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
       'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
         await new GuaranteeStorageLocalLib__factory(owner).deploy()
       ).address,

--- a/packages/periphery/test/helpers/setupHelpers.ts
+++ b/packages/periphery/test/helpers/setupHelpers.ts
@@ -23,7 +23,6 @@ import {
   InvariantLib__factory,
   IOracleProvider,
   IVerifier,
-  MagicValueLib__factory,
   Market__factory,
   MarketFactory,
   MarketFactory__factory,
@@ -255,7 +254,6 @@ export async function mockMarket(token: Address): Promise<IMarket> {
         await new RiskParameterStorageLib__factory(owner).deploy()
       ).address,
       'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
-      'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
       'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
         await new GuaranteeStorageLocalLib__factory(owner).deploy()
       ).address,

--- a/packages/periphery/test/helpers/setupHelpers.ts
+++ b/packages/periphery/test/helpers/setupHelpers.ts
@@ -30,8 +30,12 @@ import {
   MarketParameterStorageLib__factory,
   PositionStorageGlobalLib__factory,
   PositionStorageLocalLib__factory,
-  ProxyAdmin__factory,
   RiskParameterStorageLib__factory,
+  GuaranteeStorageLocalLib__factory,
+  GuaranteeStorageGlobalLib__factory,
+  OrderStorageLocalLib__factory,
+  OrderStorageGlobalLib__factory,
+  ProxyAdmin__factory,
   TransparentUpgradeableProxy__factory,
   Verifier__factory,
   VersionLib__factory,
@@ -252,6 +256,18 @@ export async function mockMarket(token: Address): Promise<IMarket> {
       ).address,
       'contracts/types/Version.sol:VersionStorageLib': (await new VersionStorageLib__factory(owner).deploy()).address,
       'contracts/libs/MagicValueLib.sol:MagicValueLib': (await new MagicValueLib__factory(owner).deploy()).address,
+      'contracts/types/Guarantee.sol:GuaranteeStorageLocalLib': (
+        await new GuaranteeStorageLocalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Guarantee.sol:GuaranteeStorageGlobalLib': (
+        await new GuaranteeStorageGlobalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Order.sol:OrderStorageLocalLib': (
+        await new OrderStorageLocalLib__factory(owner).deploy()
+      ).address,
+      'contracts/types/Order.sol:OrderStorageGlobalLib': (
+        await new OrderStorageGlobalLib__factory(owner).deploy()
+      ).address,
     },
     owner,
   ).deploy(verifier.address)


### PR DESCRIPTION
#### Order
- Makes external
  - `LocalOrderLib.store()`
  - `GlobalOrderLib.store()`
- Logic cleanup
   - `Order.from()`
#### Guarantee
- Makes external
  - `LocalGuaranteeLib.store()`
  - `GlobalGuaranteeLib.store()`
#### MagicValueLib
- Makes internal
  - `MagicValueLib.process()`
- Removes redundant clause [here](https://github.com/equilibria-xyz/perennial-v2/pull/550/files#diff-0a101158e345c3ee4438c191c98ab25025e9421ad80c9a6549fb9af660ea34b2L57).
  - If zero-cross, a zero currentPosition is returned
  - else .min(currentPosition) returns a zero currentPosition

Saves 948 bytes.