### PR TITLE
Collateral Account - handle redeemPrice < 1 when unwrapping

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - v2.4
+      - v2.4-mini
   workflow_dispatch:
 
 env:

--- a/packages/periphery/contracts/CollateralAccounts/Account.sol
+++ b/packages/periphery/contracts/CollateralAccounts/Account.sol
@@ -99,10 +99,8 @@ contract Account is IAccount, Instance {
     }
 
     /// @inheritdoc IAccount
-    function unwrap(UFixed18 amount) public ownerOrController returns (UFixed6 amountUnwrapped) {
-        UFixed6 balanceBefore = USDC.balanceOf(address(this));
+    function unwrap(UFixed18 amount) public ownerOrController {
         reserve.redeem(amount);
-        amountUnwrapped = USDC.balanceOf(address(this)).sub(balanceBefore);
     }
 
     /// @dev Reverts if not called by the owner of the collateral account, or the collateral account controller

--- a/packages/periphery/contracts/CollateralAccounts/Account.sol
+++ b/packages/periphery/contracts/CollateralAccounts/Account.sol
@@ -80,7 +80,7 @@ contract Account is IAccount, Instance {
                 UFixed18Lib.from(amount.sub(usdcBalance)).min(DSU.balanceOf());
             unwrap(unwrapAmount);
         }
-        UFixed6 pushAmount = amount.eq(UFixed6Lib.MAX) ? USDC.balanceOf() : amount;
+        UFixed6 pushAmount = amount.min(USDC.balanceOf());
         USDC.push(owner, pushAmount);
     }
 
@@ -99,8 +99,10 @@ contract Account is IAccount, Instance {
     }
 
     /// @inheritdoc IAccount
-    function unwrap(UFixed18 amount) public ownerOrController {
+    function unwrap(UFixed18 amount) public ownerOrController returns (UFixed6 amountUnwrapped) {
+        UFixed6 balanceBefore = USDC.balanceOf(address(this));
         reserve.redeem(amount);
+        amountUnwrapped = USDC.balanceOf(address(this)).sub(balanceBefore);
     }
 
     /// @dev Reverts if not called by the owner of the collateral account, or the collateral account controller

--- a/packages/periphery/contracts/CollateralAccounts/interfaces/IAccount.sol
+++ b/packages/periphery/contracts/CollateralAccounts/interfaces/IAccount.sol
@@ -28,7 +28,7 @@ interface IAccount {
     function marketTransfer(IMarket market, Fixed6 amount) external;
 
     /// @notice Transfer USDC collateral from this account to the owner
-    /// @param amount Quantity of tokens to transfer in 6-decimal precision; set to UFixed6.MAX for full withdrawal
+    /// @param amount Maximum quantity of tokens to transfer in 6-decimal precision; set to UFixed6.MAX for full withdrawal
     /// @param shouldUnwrap If amount exceeds USDC balance and this is true, DSU will be unwrapped as necessary to facilitate withdrawal
     function withdraw(UFixed6 amount, bool shouldUnwrap) external;
 
@@ -43,5 +43,6 @@ interface IAccount {
 
     /// @notice Converts a specified amount of DSU to USDC
     /// @param amount Quantity of DSU to burn, in 18-decimal precision
-    function unwrap(UFixed18 amount) external;
+    /// @param amountUnwrapped Quantity of USDC received from DSU burnt
+    function unwrap(UFixed18 amount) external returns (UFixed6 amountUnwrapped);
 }

--- a/packages/periphery/contracts/CollateralAccounts/interfaces/IAccount.sol
+++ b/packages/periphery/contracts/CollateralAccounts/interfaces/IAccount.sol
@@ -43,6 +43,5 @@ interface IAccount {
 
     /// @notice Converts a specified amount of DSU to USDC
     /// @param amount Quantity of DSU to burn, in 18-decimal precision
-    /// @param amountUnwrapped Quantity of USDC received from DSU burnt
-    function unwrap(UFixed18 amount) external returns (UFixed6 amountUnwrapped);
+    function unwrap(UFixed18 amount) external;
 }

--- a/packages/periphery/test/integration/l2/CollateralAccounts/Arbitrum.test.ts
+++ b/packages/periphery/test/integration/l2/CollateralAccounts/Arbitrum.test.ts
@@ -65,7 +65,7 @@ async function deployController(
 
   const keepConfig = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 385_000, // buffer for handling the keeper fee
+    bufferBase: 400_000, // buffer for handling the keeper fee
     multiplierCalldata: ethers.utils.parseEther('1'),
     bufferCalldata: 0,
   }

--- a/packages/periphery/test/unit/CollateralAccounts/Controller.test.ts
+++ b/packages/periphery/test/unit/CollateralAccounts/Controller.test.ts
@@ -751,32 +751,6 @@ describe('Controller', () => {
   })
 
   describe('#withdrawal', () => {
-    it('unwrap returns redeemed amount', async () => {
-      // create a collateral account with 50 DSU
-      const accountA = await createCollateralAccount(userA)
-      const dsuBalance = utils.parseEther('50')
-      usdc.balanceOf.reset()
-
-      // unwrap half at even exchange rate
-      let usdcRedeemed = parse6decimal('25')
-      reserve.redeem.whenCalledWith(dsuBalance.div(2)).returns(usdcRedeemed)
-      usdc.balanceOf.returnsAtCall(0, 0)
-      usdc.balanceOf.returnsAtCall(1, usdcRedeemed)
-      expect(await accountA.connect(userA).callStatic.unwrap(dsuBalance.div(2))).to.equal(usdcRedeemed)
-      await expect(accountA.connect(userA).unwrap(dsuBalance.div(2))).to.not.be.reverted
-      expect(reserve.redeem).to.have.been.calledWith(dsuBalance.div(2))
-
-      // unwrap remaining at lower exchange rate
-      reserve.redeem.reset()
-      usdcRedeemed = parse6decimal('24.5')
-      usdc.balanceOf.reset()
-      usdc.balanceOf.returnsAtCall(0, 0)
-      usdc.balanceOf.returnsAtCall(1, usdcRedeemed)
-      expect(await accountA.connect(userA).callStatic.unwrap(dsuBalance.div(2))).to.equal(usdcRedeemed)
-      await expect(accountA.connect(userA).unwrap(dsuBalance.div(2))).to.not.be.reverted
-      expect(reserve.redeem).to.have.been.calledWith(dsuBalance.div(2))
-    })
-
     it('unwraps when DSU reserve redeemPrice is not 1', async () => {
       // create a collateral account with 100 DSU
       const accountA = await createCollateralAccount(userA)
@@ -790,9 +764,7 @@ describe('Controller', () => {
       const usdcRedeemed = parse6decimal('99.5')
       reserve.redeem.whenCalledWith(dsuBalance).returns(usdcRedeemed)
       usdc.balanceOf.returnsAtCall(0, 0)
-      usdc.balanceOf.returnsAtCall(1, 0)
-      usdc.balanceOf.returnsAtCall(2, usdcRedeemed)
-      usdc.balanceOf.returnsAtCall(3, usdcRedeemed)
+      usdc.balanceOf.returnsAtCall(1, usdcRedeemed)
 
       // user unwraps and withdraws all possible
       await expect(accountA.connect(userA).withdraw(parse6decimal('100'), true)).to.not.be.reverted

--- a/packages/periphery/test/unit/CollateralAccounts/Controller.test.ts
+++ b/packages/periphery/test/unit/CollateralAccounts/Controller.test.ts
@@ -750,6 +750,57 @@ describe('Controller', () => {
     })
   })
 
+  describe('#withdrawal', () => {
+    it('unwrap returns redeemed amount', async () => {
+      // create a collateral account with 50 DSU
+      const accountA = await createCollateralAccount(userA)
+      const dsuBalance = utils.parseEther('50')
+      usdc.balanceOf.reset()
+
+      // unwrap half at even exchange rate
+      let usdcRedeemed = parse6decimal('25')
+      reserve.redeem.whenCalledWith(dsuBalance.div(2)).returns(usdcRedeemed)
+      usdc.balanceOf.returnsAtCall(0, 0)
+      usdc.balanceOf.returnsAtCall(1, usdcRedeemed)
+      expect(await accountA.connect(userA).callStatic.unwrap(dsuBalance.div(2))).to.equal(usdcRedeemed)
+      await expect(accountA.connect(userA).unwrap(dsuBalance.div(2))).to.not.be.reverted
+      expect(reserve.redeem).to.have.been.calledWith(dsuBalance.div(2))
+
+      // unwrap remaining at lower exchange rate
+      reserve.redeem.reset()
+      usdcRedeemed = parse6decimal('24.5')
+      usdc.balanceOf.reset()
+      usdc.balanceOf.returnsAtCall(0, 0)
+      usdc.balanceOf.returnsAtCall(1, usdcRedeemed)
+      expect(await accountA.connect(userA).callStatic.unwrap(dsuBalance.div(2))).to.equal(usdcRedeemed)
+      await expect(accountA.connect(userA).unwrap(dsuBalance.div(2))).to.not.be.reverted
+      expect(reserve.redeem).to.have.been.calledWith(dsuBalance.div(2))
+    })
+
+    it('unwraps when DSU reserve redeemPrice is not 1', async () => {
+      // create a collateral account with 100 DSU
+      const accountA = await createCollateralAccount(userA)
+      const dsuBalance = utils.parseEther('100')
+      usdc.balanceOf.reset()
+      dsu.balanceOf.whenCalledWith(accountA.address).returns(dsuBalance)
+      usdc.transfer.returns(true)
+
+      // exchange rate is not 1:1
+      // (future implementations of reserve.redeem will return amount unwrapped)
+      const usdcRedeemed = parse6decimal('99.5')
+      reserve.redeem.whenCalledWith(dsuBalance).returns(usdcRedeemed)
+      usdc.balanceOf.returnsAtCall(0, 0)
+      usdc.balanceOf.returnsAtCall(1, 0)
+      usdc.balanceOf.returnsAtCall(2, usdcRedeemed)
+      usdc.balanceOf.returnsAtCall(3, usdcRedeemed)
+
+      // user unwraps and withdraws all possible
+      await expect(accountA.connect(userA).withdraw(parse6decimal('100'), true)).to.not.be.reverted
+      expect(reserve.redeem).to.have.been.calledWith(dsuBalance)
+      expect(usdc.transfer).to.have.been.calledWith(userA.address, usdcRedeemed)
+    })
+  })
+
   describe('#messaging', () => {
     it('rejects verification of message signed by unauthorized signer', async () => {
       // specify an unauthorized signer in the message

--- a/packages/periphery/test/unit/TriggerOrders/Verifier.test.ts
+++ b/packages/periphery/test/unit/TriggerOrders/Verifier.test.ts
@@ -66,7 +66,7 @@ describe('Verifier', () => {
   function createPlaceOrderActionMessage(
     userAddress = userA.address,
     signerAddress = userAddress,
-    expiresInSeconds = 6,
+    expiresInSeconds = 12,
   ) {
     return {
       order: {
@@ -89,7 +89,7 @@ describe('Verifier', () => {
   function createCancelOrderActionMessage(
     userAddress = userA.address,
     signerAddress = userAddress,
-    expiresInSeconds = 6,
+    expiresInSeconds = 12,
   ) {
     return {
       ...createActionMessage(userAddress, signerAddress, expiresInSeconds),


### PR DESCRIPTION
`withdraw` now treats `amount` parameter as a maximum rather than absolute - This is cleaner than adding several calculations in the case where `shouldUnwrap == true`.