### PR TITLE
Vault target array length check

### DIFF
--- a/packages/vault/contracts/Vault.sol
+++ b/packages/vault/contracts/Vault.sol
@@ -436,6 +436,8 @@ abstract contract Vault is IVault, Instance {
 
         Target[] memory targets = _strategy(context, deposit, withdrawal, _ineligible(context, deposit, withdrawal));
 
+        if (targets.length != context.registrations.length) revert VaultTargetLengthMismatchError();
+
         for (uint256 marketId; marketId < context.registrations.length; marketId++)
             if (targets[marketId].collateral.lt(Fixed6Lib.ZERO))
                 _retarget(context.registrations[marketId], targets[marketId], shouldRebalance);

--- a/packages/vault/contracts/interfaces/IVault.sol
+++ b/packages/vault/contracts/interfaces/IVault.sol
@@ -63,6 +63,8 @@ interface IVault is IInstance {
     error VaultAggregateWeightError();
     // sig: 0x50ad85d6
     error VaultCurrentOutOfSyncError();
+    // sig: 0x64bbeb56
+    error VaultTargetLengthMismatchError();
 
     // sig: 0xb8a09499
     error AccountStorageInvalidError();


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-2216/vault-does-not-validate-target-array-length