### PR TITLE
[Audit Fix] Take intent fees into account in invariant

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
       - main
       - v2.4
       - v2.4-mini
+      - britz-intent-consolidate-margin-maintenance
   workflow_dispatch:
 
 env:

--- a/packages/core/contracts/libs/VersionLib.sol
+++ b/packages/core/contracts/libs/VersionLib.sol
@@ -262,18 +262,15 @@ library VersionLib {
         VersionAccumulationContext memory context,
         VersionAccumulationResult memory result
     ) private pure {
-        UFixed6 makerFee = context.order.makerTotal()
-            .mul(context.toOracleVersion.price.abs())
-            .mul(context.marketParameter.makerFee);
-        next.makerFee.decrement(Fixed6Lib.from(makerFee), context.order.makerTotal());
-        UFixed6 makerSubtractiveFee = context.order.makerTotal().isZero() ?
+        UFixed6 makerTotal = context.order.makerTotal();
+        UFixed6 makerFee = context.order.makerFee(context.toOracleVersion, context.marketParameter);
+        next.makerFee.decrement(Fixed6Lib.from(makerFee), makerTotal);
+        UFixed6 makerSubtractiveFee = makerTotal.isZero() ?
             UFixed6Lib.ZERO :
-            makerFee.muldiv(context.order.makerReferral, context.order.makerTotal());
+            makerFee.muldiv(context.order.makerReferral, makerTotal);
 
         UFixed6 takerTotal = context.order.takerTotal().sub(context.guarantee.takerFee);
-        UFixed6 takerFee = takerTotal
-            .mul(context.toOracleVersion.price.abs())
-            .mul(context.marketParameter.takerFee);
+        UFixed6 takerFee = context.order.takerFee(context.guarantee, context.toOracleVersion, context.marketParameter);
         next.takerFee.decrement(Fixed6Lib.from(takerFee), takerTotal);
         UFixed6 takerSubtractiveFee = takerTotal.isZero() ?
             UFixed6Lib.ZERO :

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -247,6 +247,38 @@ library OrderLib {
             ((long(self).isZero() && short(self).isZero()) || increasesTaker(self));
     }
 
+    /// @notice Returns the maker fee for the order
+    /// @param self The order object to check
+    /// @param oracleVersion The settlement oracle version
+    /// @param marketParameter The market parameter
+    /// @return The maker fee
+    function makerFee(
+        Order memory self,
+        OracleVersion memory oracleVersion,
+        MarketParameter memory marketParameter
+    ) internal pure returns (UFixed6) {
+        return self.makerTotal()
+            .mul(oracleVersion.price.abs())
+            .mul(marketParameter.makerFee);
+    }
+
+    /// @notice Returns the taker fee for the order
+    /// @param self The order object to check
+    /// @param guarantee The guarantee
+    /// @param oracleVersion The settlement oracle version
+    /// @param marketParameter The market parameter
+    /// @return The taker fee
+    function takerFee(
+        Order memory self,
+        Guarantee memory guarantee,
+        OracleVersion memory oracleVersion,
+        MarketParameter memory marketParameter
+    ) internal pure returns (UFixed6) {
+        return self.takerTotal().sub(guarantee.takerFee)
+            .mul(oracleVersion.price.abs())
+            .mul(marketParameter.takerFee);
+    }
+
     /// @notice Returns whether the order is protected
     /// @param self The order object to check
     /// @return Whether the order is protected

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -16308,10 +16308,9 @@ describe('Market', () => {
           })
 
           it('can protect w/ pending intent fees losses', async () => {
-            const marketParameter = { ...(await market.parameter()) }
-            marketParameter.takerFee = parse6decimal('0.1') // large fee -> (10% * 615) -> 61.5
-            marketParameter.maxPriceDeviation = parse6decimal('10.00')
-            await market.updateParameter(marketParameter)
+            const riskParameter = { ...(await market.riskParameter()) }
+            riskParameter.staleAfter = BigNumber.from(14400)
+            await market.updateRiskParameter(riskParameter)
 
             const intent = {
               amount: POSITION.div(2),
@@ -16329,12 +16328,28 @@ describe('Market', () => {
                 expiry: 0,
               },
             }
+            const intent2 = {
+              amount: -POSITION.div(2),
+              price: parse6decimal('123'),
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
+              collateralization: parse6decimal('0.01'),
+              common: {
+                account: user.address,
+                signer: user.address,
+                domain: market.address,
+                nonce: 1,
+                group: 0,
+                expiry: 0,
+              },
+            }
 
             dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
             await market
               .connect(userB)
               ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
-            dsu.transferFrom.whenCalledWith(user.address, market.address, utils.parseEther('300')).returns(true)
+            dsu.transferFrom.whenCalledWith(user.address, market.address, utils.parseEther('320')).returns(true)
             await market
               .connect(user)
               ['update(address,uint256,uint256,uint256,int256,bool)'](
@@ -16342,7 +16357,7 @@ describe('Market', () => {
                 0,
                 0,
                 0,
-                parse6decimal('300'),
+                parse6decimal('320'),
                 false,
               )
             dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
@@ -16360,17 +16375,33 @@ describe('Market', () => {
               .returns([false, true, parse6decimal('0.20')])
 
             await market
-              .connect(userC)
-              [
-                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
-              ](userC.address, intent, DEFAULT_SIGNATURE)
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, false)
 
             oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
-            oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+            oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_4.timestamp])
             oracle.request.whenCalledWith(user.address).returns()
 
             await settle(market, user)
             await settle(market, userB)
+
+            const marketParameter = { ...(await market.parameter()) }
+            marketParameter.takerFee = parse6decimal('0.08') // large fee -> (8% * 615) -> 49.2
+            marketParameter.maxPriceDeviation = parse6decimal('10.00')
+            await market.updateParameter(marketParameter)
+
+            // pending price override
+            await market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent2, DEFAULT_SIGNATURE)
+
+            await market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE)
 
             const EXPECTED_LIQUIDATION_FEE = parse6decimal('10')
 
@@ -16392,7 +16423,7 @@ describe('Market', () => {
             await expect(
               market
                 .connect(liquidator)
-                ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
+                ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, POSITION.div(2), 0, 0, true), // no-op liquidation
             ).to.be.not.reverted
           })
 

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -16245,6 +16245,225 @@ describe('Market', () => {
                 ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
             ).to.be.not.reverted
           })
+
+          it('can protect w/ pending intent fees losses', async () => {
+            const marketParameter = { ...(await market.parameter()) }
+            marketParameter.takerFee = parse6decimal('0.1') // large fee -> (10% * 615) -> 61.5
+            marketParameter.maxPriceDeviation = parse6decimal('10.00')
+            await market.updateParameter(marketParameter)
+
+            const intent = {
+              amount: POSITION.div(2),
+              price: parse6decimal('123'),
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: owner.address,
+              collateralization: parse6decimal('0.01'),
+              common: {
+                account: user.address,
+                signer: user.address,
+                domain: market.address,
+                nonce: 0,
+                group: 0,
+                expiry: 0,
+              },
+            }
+
+            dsu.transferFrom.whenCalledWith(userB.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+            await market
+              .connect(userB)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userB.address, POSITION, 0, 0, COLLATERAL, false)
+            dsu.transferFrom.whenCalledWith(user.address, market.address, utils.parseEther('300')).returns(true)
+            await market
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](
+                user.address,
+                0,
+                0,
+                0,
+                parse6decimal('300'),
+                false,
+              )
+            dsu.transferFrom.whenCalledWith(userC.address, market.address, COLLATERAL.mul(1e12)).returns(true)
+            await market
+              .connect(userC)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, COLLATERAL, false)
+
+            // solver
+            factory.authorization
+              .whenCalledWith(userC.address, userC.address, userC.address, constants.AddressZero)
+              .returns([true, true, BigNumber.from(0)])
+            // taker
+            factory.authorization
+              .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
+              .returns([false, true, parse6decimal('0.20')])
+
+            await market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE)
+
+            oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
+            oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+            oracle.request.whenCalledWith(user.address).returns()
+
+            await settle(market, user)
+            await settle(market, userB)
+
+            const EXPECTED_LIQUIDATION_FEE = parse6decimal('10')
+
+            const oracleVersionLowerPrice = {
+              price: parse6decimal('96'),
+              timestamp: TIMESTAMP + 7200,
+              valid: true,
+            }
+            oracle.at
+              .whenCalledWith(oracleVersionLowerPrice.timestamp)
+              .returns([oracleVersionLowerPrice, INITIALIZED_ORACLE_RECEIPT])
+            oracle.status.returns([oracleVersionLowerPrice, ORACLE_VERSION_4.timestamp])
+            oracle.request.whenCalledWith(user.address).returns()
+
+            await settle(market, userB)
+            dsu.transfer.whenCalledWith(liquidator.address, EXPECTED_LIQUIDATION_FEE.mul(1e12)).returns(true)
+            dsu.balanceOf.whenCalledWith(market.address).returns(COLLATERAL.mul(1e12))
+
+            await expect(
+              market
+                .connect(liquidator)
+                ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, 0, true),
+            ).to.be.not.reverted
+          })
+
+          it('cant withdraw w/ pending intent fees', async () => {
+            const riskParameter = { ...(await market.riskParameter()) }
+            riskParameter.margin = parse6decimal('0.012')
+            riskParameter.maintenance = parse6decimal('0.01')
+            riskParameter.minMargin = parse6decimal('5')
+            riskParameter.minMaintenance = parse6decimal('5')
+            await market.updateRiskParameter(riskParameter)
+
+            const marketParameter = { ...(await market.parameter()) }
+            marketParameter.takerFee = parse6decimal('0.003')
+            await market.updateParameter(marketParameter)
+
+            factory.parameter.returns({
+              maxPendingIds: 5,
+              protocolFee: parse6decimal('0.50'),
+              maxFee: parse6decimal('0.01'),
+              maxLiquidationFee: parse6decimal('1000'),
+              maxCut: parse6decimal('0.50'),
+              maxRate: parse6decimal('10.00'),
+              minMaintenance: parse6decimal('0.01'),
+              minEfficiency: parse6decimal('0.1'),
+              referralFee: parse6decimal('0.20'),
+              minScale: parse6decimal('0.001'),
+              maxStaleAfter: 14400,
+            })
+
+            const intent = {
+              amount: parse6decimal('0.3'),
+              price: parse6decimal('123'),
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: liquidator.address,
+              collateralization: parse6decimal('0.01'),
+              common: {
+                account: user.address,
+                signer: user.address,
+                domain: market.address,
+                nonce: 0,
+                group: 0,
+                expiry: 0,
+              },
+            }
+
+            const intent2 = {
+              amount: -parse6decimal('0.3'),
+              price: parse6decimal('123'),
+              fee: parse6decimal('0.5'),
+              originator: liquidator.address,
+              solver: liquidator.address,
+              collateralization: parse6decimal('0.01'),
+              common: {
+                account: user.address,
+                signer: user.address,
+                domain: market.address,
+                nonce: 1,
+                group: 0,
+                expiry: 0,
+              },
+            }
+
+            const LOWER_COLLATERAL = parse6decimal('500')
+
+            dsu.transferFrom.whenCalledWith(user.address, market.address, LOWER_COLLATERAL.mul(1e12)).returns(true)
+            dsu.transferFrom.whenCalledWith(userB.address, market.address, LOWER_COLLATERAL.mul(1e12)).returns(true)
+            dsu.transferFrom.whenCalledWith(userC.address, market.address, LOWER_COLLATERAL.mul(1e12)).returns(true)
+
+            await market
+              .connect(userB)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](
+                userB.address,
+                POSITION,
+                0,
+                0,
+                LOWER_COLLATERAL,
+                false,
+              )
+
+            await market
+              .connect(user)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](user.address, 0, 0, 0, LOWER_COLLATERAL, false)
+            await market
+              .connect(userC)
+              ['update(address,uint256,uint256,uint256,int256,bool)'](userC.address, 0, 0, 0, LOWER_COLLATERAL, false)
+
+            oracle.at.whenCalledWith(ORACLE_VERSION_2.timestamp).returns([ORACLE_VERSION_2, INITIALIZED_ORACLE_RECEIPT])
+            oracle.at.whenCalledWith(ORACLE_VERSION_3.timestamp).returns([ORACLE_VERSION_3, INITIALIZED_ORACLE_RECEIPT])
+            oracle.at.whenCalledWith(ORACLE_VERSION_4.timestamp).returns([ORACLE_VERSION_4, INITIALIZED_ORACLE_RECEIPT])
+            oracle.status.returns([ORACLE_VERSION_2, ORACLE_VERSION_3.timestamp])
+
+            verifier.verifyIntent.returns()
+
+            // solver
+            factory.authorization
+              .whenCalledWith(userC.address, userC.address, userC.address, constants.AddressZero)
+              .returns([true, true, BigNumber.from(0)])
+            // taker
+            factory.authorization
+              .whenCalledWith(user.address, userC.address, user.address, liquidator.address)
+              .returns([false, true, parse6decimal('0.20')])
+
+            await market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent, DEFAULT_SIGNATURE)
+
+            await market
+              .connect(userC)
+              [
+                'update(address,(int256,int256,uint256,address,address,uint256,(address,address,address,uint256,uint256,uint256)),bytes)'
+              ](userC.address, intent2, DEFAULT_SIGNATURE)
+
+            const WITHDRAW_COLLATERAL = parse6decimal('500')
+
+            dsu.transfer.whenCalledWith(user.address, WITHDRAW_COLLATERAL.mul(1e12)).returns(true)
+
+            await expect(
+              market
+                .connect(user)
+                ['update(address,uint256,uint256,uint256,int256,bool)'](
+                  user.address,
+                  0,
+                  0,
+                  0,
+                  -WITHDRAW_COLLATERAL,
+                  false,
+                ),
+            ).to.be.revertedWithCustomError(market, 'MarketInsufficientCollateralError')
+          })
         })
 
         context('in liquidation', async () => {


### PR DESCRIPTION
Approximates the outstanding intent trade fees by measuring all outstanding trade fees.

Applies these to:
- margin check
- maintenance check
- collateral below zero check

Resolves: https://audits.sherlock.xyz/contests/764/voting/31.