### PR TITLE
[Code Size] Remove coordinator / beneficiary getters

### DIFF
--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -48,11 +48,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @dev DEPRECATED SLOT -- previously the payoff provider
     bytes32 private __unused1__;
 
-    /// @dev Beneficiary of the market, receives donations
-    address public beneficiary;
-
     /// @dev Risk coordinator of the market
-    address public coordinator;
+    address private coordinator;
 
     /// @dev Risk parameters of the market
     RiskParameterStorage private _riskParameter;
@@ -312,13 +309,6 @@ contract Market is IMarket, Instance, ReentrancyGuard {
 
         // process update
         _updateAndStore(context, updateContext, newOrder, newGuarantee, referrer, address(0));
-    }
-
-    /// @notice Updates the beneficiary of the market
-    /// @param newBeneficiary The new beneficiary address
-    function updateBeneficiary(address newBeneficiary) external onlyOwner {
-        beneficiary = newBeneficiary;
-        emit BeneficiaryUpdated(newBeneficiary);
     }
 
     /// @notice Updates the coordinator of the market

--- a/packages/core/contracts/interfaces/IMarket.sol
+++ b/packages/core/contracts/interfaces/IMarket.sol
@@ -68,7 +68,6 @@ interface IMarket is IInstance {
     event OrderCreated(address indexed account, Order order, Guarantee guarantee, address liquidator, address orderReferrer, address guaranteeReferrer);
     event PositionProcessed(uint256 orderId, Order order, VersionAccumulationResult accumulationResult);
     event AccountPositionProcessed(address indexed account, uint256 orderId, Order order, CheckpointAccumulationResult accumulationResult);
-    event BeneficiaryUpdated(address newBeneficiary);
     event CoordinatorUpdated(address newCoordinator);
     /// @notice Fee earned by an account was transferred from market to a receiver
     /// @param account User who earned the fee
@@ -103,8 +102,6 @@ interface IMarket is IInstance {
     error MarketExceedsPendingIdLimitError();
     // sig: 0x9bca0625
     error MarketNotCoordinatorError();
-    // sig: 0xb602d086
-    error MarketNotBeneficiaryError();
     // sig: 0x3222db45
     /// @custom:error Sender is not authorized to interact with markets on behalf of the account
     error MarketNotOperatorError();
@@ -143,8 +140,6 @@ interface IMarket is IInstance {
     function initialize(MarketDefinition calldata definition_) external;
     function token() external view returns (Token18);
     function oracle() external view returns (IOracleProvider);
-    function beneficiary() external view returns (address);
-    function coordinator() external view returns (address);
     function positions(address account) external view returns (Position memory);
     function pendingOrders(address account, uint256 id) external view returns (Order memory);
     function guarantees(address account, uint256 id) external view returns (Guarantee memory);
@@ -170,7 +165,6 @@ interface IMarket is IInstance {
     function update(address account, UFixed6 newMaker, UFixed6 newLong, UFixed6 newShort, Fixed6 collateral, bool protect, address referrer) external;
     function parameter() external view returns (MarketParameter memory);
     function riskParameter() external view returns (RiskParameter memory);
-    function updateBeneficiary(address newBeneficiary) external;
     function updateCoordinator(address newCoordinator) external;
     function updateParameter(MarketParameter memory newParameter) external;
     function updateRiskParameter(RiskParameter memory newRiskParameter) external;

--- a/packages/core/test/integration/core/happyPath.test.ts
+++ b/packages/core/test/integration/core/happyPath.test.ts
@@ -1117,11 +1117,6 @@ describe('Happy Path', () => {
 
     const market = await createMarket(instanceVars)
 
-    await expect(market.connect(user).updateBeneficiary(user.address)).to.be.revertedWithCustomError(
-      market,
-      'InstanceNotOwnerError',
-    )
-
     await expect(market.connect(user).updateCoordinator(user.address)).to.be.revertedWithCustomError(
       market,
       'InstanceNotOwnerError',

--- a/packages/core/test/integration/helpers/setupHelpers.ts
+++ b/packages/core/test/integration/helpers/setupHelpers.ts
@@ -296,7 +296,6 @@ export async function createMarket(
 
   const market = Market__factory.connect(marketAddress, owner)
   await market.updateRiskParameter(riskParameter)
-  await market.updateBeneficiary(beneficiaryB.address)
   await market.updateParameter(marketParameter)
   await market.updateCoordinator(coordinator.address)
 

--- a/packages/core/test/unit/market/Market.test.ts
+++ b/packages/core/test/unit/market/Market.test.ts
@@ -648,34 +648,8 @@ describe('Market', () => {
   context('already initialized', async () => {
     beforeEach(async () => {
       await market.connect(factorySigner).initialize(marketDefinition)
-      await market.connect(owner).updateBeneficiary(beneficiary.address)
       await market.connect(owner).updateCoordinator(coordinator.address)
       await market.connect(owner).updateRiskParameter(riskParameter)
-    })
-
-    describe('#updateBeneficiary', async () => {
-      it('updates the beneficiary', async () => {
-        await expect(market.connect(owner).updateBeneficiary(beneficiary.address))
-          .to.emit(market, 'BeneficiaryUpdated')
-          .withArgs(beneficiary.address)
-
-        expect(await market.beneficiary()).to.equal(beneficiary.address)
-      })
-
-      it('reverts if not owner (user)', async () => {
-        await expect(market.connect(user).updateBeneficiary(beneficiary.address)).to.be.revertedWithCustomError(
-          market,
-          'InstanceNotOwnerError',
-        )
-      })
-
-      it('reverts if not owner (coordinator)', async () => {
-        await market.connect(owner).updateBeneficiary(beneficiary.address)
-        await expect(market.connect(coordinator).updateBeneficiary(beneficiary.address)).to.be.revertedWithCustomError(
-          market,
-          'InstanceNotOwnerError',
-        )
-      })
     })
 
     describe('#updateCoordinator', async () => {
@@ -684,7 +658,7 @@ describe('Market', () => {
           .to.emit(market, 'CoordinatorUpdated')
           .withArgs(coordinator.address)
 
-        expect(await market.coordinator()).to.equal(coordinator.address)
+        // expect(await market.coordinator()).to.equal(coordinator.address) - getter has been removed
       })
 
       it('reverts if not owner (user)', async () => {
@@ -1348,7 +1322,6 @@ describe('Market', () => {
     describe('#settle', async () => {
       beforeEach(async () => {
         await market.connect(owner).updateCoordinator(coordinator.address)
-        await market.connect(owner).updateBeneficiary(beneficiary.address)
         await market.connect(owner).updateParameter(marketParameter)
 
         oracle.at.whenCalledWith(ORACLE_VERSION_0.timestamp).returns([ORACLE_VERSION_0, INITIALIZED_ORACLE_RECEIPT])
@@ -1613,7 +1586,6 @@ describe('Market', () => {
     describe('#update', async () => {
       beforeEach(async () => {
         await market.connect(owner).updateCoordinator(coordinator.address)
-        await market.connect(owner).updateBeneficiary(beneficiary.address)
         await market.connect(owner).updateParameter(marketParameter)
 
         oracle.at.whenCalledWith(ORACLE_VERSION_0.timestamp).returns([ORACLE_VERSION_0, INITIALIZED_ORACLE_RECEIPT])
@@ -30095,7 +30067,6 @@ describe('Market', () => {
       }
       await market.connect(factorySigner).initialize(marketDefinition)
 
-      await market.connect(owner).updateBeneficiary(beneficiary.address)
       await market.connect(owner).updateCoordinator(coordinator.address)
       await market.connect(owner).updateRiskParameter(riskParameter)
       await market.connect(owner).updateParameter(marketParameter)


### PR DESCRIPTION
- Removes unused beneficiary code.
- Removes public `coordinator` getter.