### PR TITLE
[Code Size] Clean up .next() methods

### DIFF
--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -868,7 +868,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     ) private {
         (OracleVersion memory oracleVersion, OracleReceipt memory oracleReceipt) = oracle.at(newOrderTimestamp);
         context.global.overrideIfZero(oracleVersion);
-        Guarantee memory newGuarantee;
+        Guarantee memory newGuarantee; // default to fresh guarantee
 
         // if latest timestamp is more recent than order timestamp, sync the order data
         if (newOrderTimestamp > newOrder.timestamp) newOrder = OrderLib.fresh(newOrderTimestamp);
@@ -911,7 +911,7 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     ) private {
         Version memory versionFrom = _versions[context.latestPositionLocal.timestamp].read();
         Version memory versionTo = _versions[newOrderTimestamp].read();
-        Guarantee memory newGuarantee;
+        Guarantee memory newGuarantee; // default to fresh guarantee
 
         // if latest timestamp is more recent than order timestamp, sync the order data
         if (newOrderTimestamp > newOrder.timestamp) newOrder = OrderLib.fresh(newOrderTimestamp);

--- a/packages/core/contracts/test/GuaranteeTester.sol
+++ b/packages/core/contracts/test/GuaranteeTester.sol
@@ -16,10 +16,8 @@ abstract contract GuaranteeTester {
         store(newGuarantee);
     }
 
-    function next() public {
-        Guarantee memory newGuarantee = read();
-        newGuarantee.next();
-        store(newGuarantee);
+    function fresh() public {
+        store(GuaranteeLib.fresh());
     }
 
     function takerPos(Guarantee memory guarantee) public pure returns (UFixed6) {

--- a/packages/core/contracts/test/OrderTester.sol
+++ b/packages/core/contracts/test/OrderTester.sol
@@ -14,10 +14,8 @@ abstract contract OrderTester {
 
     function store(Order memory newOrder) public virtual;
 
-    function next(uint256 timestamp) external {
-        Order memory newOrder = read();
-        newOrder.next(timestamp);
-        store(newOrder);
+    function fresh(uint256 timestamp) external {
+        store(OrderLib.fresh(timestamp));
     }
 
     function invalidate(Guarantee memory guarantee) external {

--- a/packages/core/contracts/types/Guarantee.sol
+++ b/packages/core/contracts/types/Guarantee.sol
@@ -44,15 +44,9 @@ using GuaranteeStorageLocalLib for GuaranteeStorageLocal global;
 /// @dev (external-unsafe): this library must be used internally only
 /// @notice Holds the state for an account's update guarantee
 library GuaranteeLib {
-    /// @notice Prepares the next guarantee from the current guarantee
-    /// @param self The guarantee object to update
-    function next(Guarantee memory self) internal pure  {
-        self.orders = 0;
-        (self.notional, self.takerFee, self.orderReferral, self.solverReferral) =
-            (Fixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
-        (self.longPos, self.longNeg, self.shortPos, self.shortNeg) =
-            (UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
-    }
+    /// @notice Prepares a fresh guarantee
+    /// @return newGuarantee The resulting guarantee
+    function fresh() internal pure returns (Guarantee memory newGuarantee) { }
 
     /// @notice Creates a new guarantee from an order
     /// @param order The order to create the guarantee from

--- a/packages/core/contracts/types/Order.sol
+++ b/packages/core/contracts/types/Order.sol
@@ -69,16 +69,10 @@ library OrderLib {
         return latestVersion.timestamp >= self.timestamp;
     }
 
-    /// @notice Prepares the next order from the current order
-    /// @param self The order object to update
+    /// @notice Prepares a fresh order with the current timestamp
     /// @param timestamp The current timestamp
-    function next(Order memory self, uint256 timestamp) internal pure  {
-        (self.makerReferral, self.takerReferral) =
-            (UFixed6Lib.ZERO, UFixed6Lib.ZERO);
-        (self.makerPos, self.makerNeg, self.longPos, self.longNeg, self.shortPos, self.shortNeg) =
-            (UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO, UFixed6Lib.ZERO);
-        (self.timestamp, self.orders, self.collateral, self.protection, self.invalidation) =
-            (timestamp, 0, Fixed6Lib.ZERO, 0, 0);
+    function fresh(uint256 timestamp) internal pure returns (Order memory newOrder) {
+        newOrder.timestamp = timestamp;
     }
 
     /// @notice Invalidates the non-guarantee portion of the order

--- a/packages/core/test/unit/types/Guarantee.test.ts
+++ b/packages/core/test/unit/types/Guarantee.test.ts
@@ -931,8 +931,8 @@ describe('Guarantee', () => {
       })
     })
 
-    describe('#next', () => {
-      it('calculates taker', async () => {
+    describe('#fresh', () => {
+      it('creates a fresh guarantee', async () => {
         await guarantee.store({
           orders: 1,
           longPos: 2,
@@ -945,7 +945,7 @@ describe('Guarantee', () => {
           solverReferral: 9,
         })
 
-        await guarantee.next()
+        await guarantee.fresh()
         const result = await guarantee.read()
 
         expect(result.orders).to.equal(0)

--- a/packages/core/test/unit/types/Order.test.ts
+++ b/packages/core/test/unit/types/Order.test.ts
@@ -1220,5 +1220,27 @@ describe('Order', () => {
         expect(await order.crossesZero()).to.equal(false)
       })
     })
+
+    describe('#fresh', () => {
+      it('creates a fresh order', async () => {
+        await order.store(validStoredOrder)
+        await order.fresh(123)
+        const result = await order.read()
+
+        expect(result.timestamp).to.equal(123)
+        expect(result.orders).to.equal(0)
+        expect(result.makerPos).to.equal(0)
+        expect(result.makerNeg).to.equal(0)
+        expect(result.longPos).to.equal(0)
+        expect(result.longNeg).to.equal(0)
+        expect(result.shortPos).to.equal(0)
+        expect(result.shortNeg).to.equal(0)
+        expect(result.collateral).to.equal(0)
+        expect(result.protection).to.equal(0)
+        expect(result.invalidation).to.equal(0)
+        expect(result.makerReferral).to.equal(0)
+        expect(result.takerReferral).to.equal(0)
+      })
+    })
   }
 })


### PR DESCRIPTION
Removes `.next()` methods on `Order` and `Guarantee` in favor of `.fresh()` methods which instantiate new copies of these objects instead.

This causes a very slight gas increase w/ a considerable reduction in code siz: `120 bytes`.