### PR TITLE
[Code Size] Remove unused storage slots

### DIFF
--- a/packages/core/contracts/Market.sol
+++ b/packages/core/contracts/Market.sol
@@ -39,14 +39,8 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @dev The underlying token that the market settles in
     Token18 public token;
 
-    /// @dev DEPRECATED SLOT -- previously the reward token
-    bytes32 private __unused0__;
-
     /// @dev The oracle that provides the market price
     IOracleProvider public oracle;
-
-    /// @dev DEPRECATED SLOT -- previously the payoff provider
-    bytes32 private __unused1__;
 
     /// @dev Risk coordinator of the market
     address private coordinator;
@@ -63,17 +57,11 @@ contract Market is IMarket, Instance, ReentrancyGuard {
     /// @dev Current global position of the market
     PositionStorageGlobal private _position;
 
-    /// @dev DEPRECATED SLOT -- previously the global pending positions
-    bytes32 private __unused2__;
-
     /// @dev Current local state of each account
     mapping(address => LocalStorage) private _locals;
 
     /// @dev Current local position of each account
     mapping(address => PositionStorageLocal) private _positions;
-
-    /// @dev DEPRECATED SLOT -- previously the local pending positions
-    bytes32 private __unused3__;
 
     /// @dev The historical version accumulator data for each accessed version
     mapping(uint256 => VersionStorage) private _versions;

--- a/packages/oracle/contracts/OracleFactory.sol
+++ b/packages/oracle/contracts/OracleFactory.sol
@@ -13,15 +13,6 @@ import { IOracle } from "./interfaces/IOracle.sol";
 /// @title OracleFactory
 /// @notice Factory for creating and managing oracles
 contract OracleFactory is IOracleFactory, Factory {
-    /// @notice DEPRECATED SLOT -- previously the incentive token
-    bytes32 private __unused0__;
-
-    /// @notice DEPRECATED SLOT -- previously the max claim
-    bytes32 private __unused1__;
-
-    /// @notice  DEPRECATED SLOT -- previously the authrorized callers
-    bytes32 private __unused2__;
-
     /// @notice Mapping of oracle id to oracle instance
     mapping(bytes32 => IOracleProvider) public oracles;
 

--- a/packages/periphery/contracts/MultiInvoker/types/TriggerOrder.sol
+++ b/packages/periphery/contracts/MultiInvoker/types/TriggerOrder.sol
@@ -29,12 +29,12 @@ struct StoredTriggerOrder {
     /* slot 1 */
     address interfaceFeeReceiver1;
     uint48 interfaceFeeAmount1;      // <= 281m
-    bytes6 __unallocated1__;         // Contains dirty data until updated post v2.3 migration.
+    bytes6 __unallocated1__;
 
     /* slot 2 */
     address interfaceFeeReceiver2;
     uint48 interfaceFeeAmount2;      // <= 281m
-    bytes6 __unallocated2__;         // Contains dirty data until updated post v2.3 migration.
+    bytes6 __unallocated2__;
 }
 struct TriggerOrderStorage { StoredTriggerOrder value; }
 using TriggerOrderStorageLib for TriggerOrderStorage global;

--- a/packages/vault/contracts/Vault.sol
+++ b/packages/vault/contracts/Vault.sol
@@ -50,9 +50,6 @@ abstract contract Vault is IVault, Instance {
     /// @dev Per-id accounting state variables
     mapping(uint256 => CheckpointStorage) private _checkpoints;
 
-    /// @dev DEPRECATED SLOT -- previously the mappings
-    bytes32 private __unused0__;
-
     /// @dev The vault's coordinator address (privileged role that can operate the vault's strategy)
     address public coordinator;
 


### PR DESCRIPTION
`v2.4-mini` no longer needs to be backwards compatible with `v2.3` for this deployment.

As such we can remove these deprecated slots, which would have otherwise changes the storage layout of the already deployed contracts.

related to: https://github.com/equilibria-xyz/perennial-v2/pull/568.