### PR TITLE
Disable retries in periphery integration test CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
 
   # [CORE]
   core-unit-test:
+    if: false
     name: '[Core] Unit Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +78,7 @@ jobs:
           delete-old-comments: true
         if: ${{ github.event_name == 'pull_request' && env.PARSER_BROKEN != 'true' }}
   core-integration-test:
+    if: false
     name: '[Core] Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -148,6 +150,7 @@ jobs:
 
   # [ORACLE]
   oracle-unit-test:
+    if: false
     name: '[Oracle] Unit Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -177,6 +180,7 @@ jobs:
           name: oracle_unit_test_coverage
           path: ./packages/oracle/coverage/lcov.info
   oracle-integration-test:
+    if: false
     name: '[Oracle] Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -207,6 +211,7 @@ jobs:
           name: oracle_integration_test_coverage
           path: ./packages/oracle/coverage/lcov.info
   oracle-integrationSepolia-test:
+    if: false
     name: '[Oracle] Sepolia Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -239,6 +244,7 @@ jobs:
 
   # [VAULT]
   vault-unit-test:
+    if: false
     name: '[Vault] Unit Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -268,6 +274,7 @@ jobs:
           name: vault_unit_test_coverage
           path: ./packages/vault/coverage/lcov.info
   vault-integration-test:
+    if: false
     name: '[Vault] Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: Automated Tests and Linting
 
 on:
   push:
-    branches: [main, ed/pe-2101]
+    branches: [main]
   pull_request:
     branches:
       - main

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -356,7 +356,6 @@ jobs:
       - name: Run tests
         env:
           MOCHA_REPORTER: dot
-          MOCHA_RETRY_COUNT: 2
           MAINNET_NODE_URL: ${{ secrets.MAINNET_NODE_URL }}
         run: |
           yarn workspace @perennial/v2-periphery run ${{ env.PARSER_BROKEN != 'true' && 'coverage:integration' || 'test:integration' }}
@@ -386,7 +385,6 @@ jobs:
       - name: Run tests with coverage on Arbitrum
         env:
           MOCHA_REPORTER: dot
-          MOCHA_RETRY_COUNT: 2
           ARBITRUM_NODE_URL: ${{ secrets.ARBITRUM_NODE_URL }}
         run: |
           yarn workspace @perennial/v2-periphery run ${{ env.PARSER_BROKEN != 'true' && 'coverage:integrationArbitrum' || 'test:integrationArbitrum' }}
@@ -398,7 +396,6 @@ jobs:
       - name: Run tests on Base
         env:
           MOCHA_REPORTER: dot
-          MOCHA_RETRY_COUNT: 2
           BASE_NODE_URL: ${{ secrets.BASE_NODE_URL }}
         run: |
           yarn workspace @perennial/v2-periphery run test:integrationBase

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,6 @@ jobs:
 
   # [CORE]
   core-unit-test:
-    if: false
     name: '[Core] Unit Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +77,6 @@ jobs:
           delete-old-comments: true
         if: ${{ github.event_name == 'pull_request' && env.PARSER_BROKEN != 'true' }}
   core-integration-test:
-    if: false
     name: '[Core] Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -150,7 +148,6 @@ jobs:
 
   # [ORACLE]
   oracle-unit-test:
-    if: false
     name: '[Oracle] Unit Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -180,7 +177,6 @@ jobs:
           name: oracle_unit_test_coverage
           path: ./packages/oracle/coverage/lcov.info
   oracle-integration-test:
-    if: false
     name: '[Oracle] Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -211,7 +207,6 @@ jobs:
           name: oracle_integration_test_coverage
           path: ./packages/oracle/coverage/lcov.info
   oracle-integrationSepolia-test:
-    if: false
     name: '[Oracle] Sepolia Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -244,7 +239,6 @@ jobs:
 
   # [VAULT]
   vault-unit-test:
-    if: false
     name: '[Vault] Unit Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:
@@ -274,7 +268,6 @@ jobs:
           name: vault_unit_test_coverage
           path: ./packages/vault/coverage/lcov.info
   vault-integration-test:
-    if: false
     name: '[Vault] Integration Tests w/ Coverage'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: Automated Tests and Linting
 
 on:
   push:
-    branches: [main]
+    branches: [main, ed/pe-2101]
   pull_request:
     branches:
       - main

--- a/packages/periphery/test/integration/TriggerOrders/Arbitrum.test.ts
+++ b/packages/periphery/test/integration/TriggerOrders/Arbitrum.test.ts
@@ -47,7 +47,7 @@ const fixture = async (): Promise<FixtureVars> => {
 
   const keepConfig = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 99_300_000, // buffer for withdrawing keeper fee from margin contract
+    bufferBase: 300_000, // buffer for withdrawing keeper fee from margin contract
     multiplierCalldata: 0,
     bufferCalldata: 0,
   }

--- a/packages/periphery/test/integration/TriggerOrders/Arbitrum.test.ts
+++ b/packages/periphery/test/integration/TriggerOrders/Arbitrum.test.ts
@@ -47,7 +47,7 @@ const fixture = async (): Promise<FixtureVars> => {
 
   const keepConfig = {
     multiplierBase: ethers.utils.parseEther('1'),
-    bufferBase: 300_000, // buffer for withdrawing keeper fee from margin contract
+    bufferBase: 99_300_000, // buffer for withdrawing keeper fee from margin contract
     multiplierCalldata: 0,
     bufferCalldata: 0,
   }


### PR DESCRIPTION
When mocha tests are run with retries enabled, errors raised in `afterEach` clauses are suppressed.  This leads to misleading error messages.  In particular, when `periphery` integration tests fail due to gas configuration, CI omits the gas out-of-range error, and shows only subsequent errors for nonce/orderId mismatch.

Since retries are not useful for periphery integration tests, disable them in CI.