### PR TITLE
Update packages for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perennialmono",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "index.js",
   "license": "MIT",
   "private": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perennial/v2-core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Perennial V2 Core",
   "files": [
     "contracts/interfaces",

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perennial/v2-deploy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Perennial V2 Deployment Tooling",
   "files": [
     "deployments/!(localhost)"
@@ -36,7 +36,7 @@
   "license": "APACHE-2.0",
   "dependencies": {
     "@defi-wonderland/smock": "^2.3.5",
-    "@perennial/v2-core": "1.3.0",
+    "@perennial/v2-core": "1.4.0",
     "@perennial/sdk": "0.0.3-beta.0",
     "@perennial/sdk-0.0.2": "npm:@perennial/sdk@0.0.2-beta27",
     "@pythnetwork/pyth-evm-js": "^1.29.0",

--- a/packages/oracle/package.json
+++ b/packages/oracle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perennial/v2-oracle",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Perennial V2 Oracle",
   "files": [
     "contracts/interfaces",
@@ -36,6 +36,6 @@
   "author": "",
   "license": "APACHE-2.0",
   "dependencies": {
-    "@perennial/v2-core": "1.3.0"
+    "@perennial/v2-core": "1.4.0"
   }
 }

--- a/packages/periphery/contracts/CollateralAccounts/interfaces/IAccount.sol
+++ b/packages/periphery/contracts/CollateralAccounts/interfaces/IAccount.sol
@@ -14,6 +14,18 @@ interface IAccount {
     /// @custom:error Only the owner or the collateral account controller may withdraw
     error AccountNotAuthorizedError();
 
+    /// @notice Address of the owner of the collateral account
+    /// @return owner Address of the owner of the collateral account
+    function owner() external view returns (address);
+
+    /// @notice USDC stablecoin address held by the collateral account
+    /// @return usdc Address of the USDC stablecoin
+    function USDC() external view returns (Token6);
+
+    /// @notice DSU stablecoin address held by the collateral account
+    /// @return dsu Address of the DSU stablecoin
+    function DSU() external view returns (Token18);
+
     /// @notice Sets owner, contract, and token addresses, and runs approvals for a collateral account
     /// @param owner Address of the user for which the account was created
     function initialize(address owner) external;

--- a/packages/periphery/package.json
+++ b/packages/periphery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perennial/v2-periphery",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Perennial V2 Periphery",
   "files": [
     "contracts/interfaces",
@@ -33,8 +33,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@equilibria/emptyset-batcher": "^0.1.0",
-    "@perennial/v2-core": "1.3.0",
-    "@perennial/v2-oracle": "1.3.0"
+    "@perennial/v2-core": "1.4.0",
+    "@perennial/v2-oracle": "1.4.0"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5"

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perennial/v2-vault",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Perennial V2 Vault",
   "files": [
     "contracts/interfaces",
@@ -30,6 +30,6 @@
   "author": "",
   "license": "APACHE-2.0",
   "dependencies": {
-    "@perennial/v2-core": "1.3.0"
+    "@perennial/v2-core": "1.4.0"
   }
 }


### PR DESCRIPTION
Updates the package.json versions to v1.4 to we can publish the packages.

Also adds some missing getters to IAccount - ideally the comments in Account.sol would also be updated to use inheritdoc but I didn't want to touch the impl contracts. Maybe we can update those in the next release