### PR TITLE
fix: correct typo in periphery README

### DIFF
--- a/packages/periphery/README.md
+++ b/packages/periphery/README.md
@@ -7,7 +7,7 @@ Extension systems and periphery contracts for the Perennial V2 Protocol
 
 Collateral accounts help users manage collateral across Perennial markets on a single chain. A user's EOA may deploy only one collateral account, whose address is deterministic. Actions are performed using [EIP-712](https://eips.ethereum.org/EIPS/eip-712) message payloads submitted to keepers through a relayer. Users may self-sign their messages or delegate one or more signers.
 
-Users may also relay requests through this extention to compensate keepers from their collateral account.
+Users may also relay requests through this extension to compensate keepers from their collateral account.
 
 ### Design
 


### PR DESCRIPTION

Fixes a typo in the periphery package README documentation.

## Changes
- **File:** `packages/periphery/README.md`
- **Fix:** Corrected "extention" → "extension" on line 10

